### PR TITLE
New CSV validation rules

### DIFF
--- a/backend/src/v1/services/validate-service.spec.ts
+++ b/backend/src/v1/services/validate-service.spec.ts
@@ -130,10 +130,41 @@ describe("validateRow", () => {
 
       //expect one line error that mentions both COL_HOURS_WORKED and COL_SPECIAL_SALARY
       expect(lineErrors).not.toBeNull();
-      expect(lineErrors?.errors?.length).toBe(1);
-      expect(doesAnyLineErrorContain(lineErrors, COL_HOURS_WORKED)).toBeTruthy();
-      expect(doesAnyLineErrorContain(lineErrors, COL_SPECIAL_SALARY)).toBeTruthy();
+      expect(doesAnyLineErrorContainAll(lineErrors, [COL_HOURS_WORKED, COL_SPECIAL_SALARY])).toBeTruthy();
+    })
+  })
 
+  describe(`given an row that specifies ${COL_HOURS_WORKED} but not ${COL_ORDINARY_PAY}`, () => {
+    it("returns a line error", () => {
+
+      const overrides = {};
+      overrides[COL_HOURS_WORKED] = 20;
+      overrides[COL_ORDINARY_PAY] = NO_DATA_VALUES[0];
+      overrides[COL_SPECIAL_SALARY] = NO_DATA_VALUES[0];
+      const invalidRow: Row = createSampleRow(overrides);
+
+      const lineNum = 1;
+      const lineErrors: LineErrors = validateService.validateRow(lineNum, invalidRow);
+
+      //expect one line error that mentions both COL_HOURS_WORKED and COL_ORDINARY_PAY
+      expect(doesAnyLineErrorContainAll(lineErrors, [COL_HOURS_WORKED, COL_ORDINARY_PAY])).toBeTruthy();
+    })
+  })
+
+  describe(`given an row that specifies ${COL_ORDINARY_PAY} but not ${COL_HOURS_WORKED}`, () => {
+    it("returns a line error", () => {
+
+      const overrides = {};
+      overrides[COL_HOURS_WORKED] = NO_DATA_VALUES[0];
+      overrides[COL_ORDINARY_PAY] = 35;
+      overrides[COL_SPECIAL_SALARY] = NO_DATA_VALUES[0];
+      const invalidRow: Row = createSampleRow(overrides);
+
+      const lineNum = 1;
+      const lineErrors: LineErrors = validateService.validateRow(lineNum, invalidRow);
+
+      //expect one line error that mentions both COL_HOURS_WORKED and COL_ORDINARY_PAY
+      expect(doesAnyLineErrorContainAll(lineErrors, [COL_HOURS_WORKED, COL_ORDINARY_PAY])).toBeTruthy();
     })
   })
 

--- a/backend/src/v1/services/validate-service.ts
+++ b/backend/src/v1/services/validate-service.ts
@@ -252,6 +252,14 @@ const validateService = {
       this.isZeroSynonym(record[COL_SPECIAL_SALARY])) {
       errorMessages.push(`${COL_SPECIAL_SALARY} must contain data when ${COL_HOURS_WORKED} and ${COL_ORDINARY_PAY} do not contain data.`)
     }
+    if (this.isZeroSynonym(record[COL_HOURS_WORKED]) &&
+      !this.isZeroSynonym(record[COL_ORDINARY_PAY])) {
+      errorMessages.push(`${COL_HOURS_WORKED} must not be blank or 0 when ${COL_ORDINARY_PAY} contains data.`)
+    }
+    if (this.isZeroSynonym(record[COL_ORDINARY_PAY]) &&
+      !this.isZeroSynonym(record[COL_HOURS_WORKED])) {
+      errorMessages.push(`${COL_ORDINARY_PAY} must not be blank or 0 when ${COL_HOURS_WORKED} contains data.`)
+    }
 
     if (errorMessages.length) {
       const lineErrors = {


### PR DESCRIPTION
# Description

Added two new CSV validation rules:
- Hours Worked can not be blank or 0 if Ordinary Pay contains data.
- Ordinary Pay can not be blank or 0 if Hours Worked contains data.

Fixes # [(issue)](https://finrms.atlassian.net/browse/GEO-141)

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [x] One new unit tests for each of the new validation rules

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have already been accepted and merged