### PR TITLE
feat: pdb and affinity

### DIFF
--- a/charts/fin-pay-transparency/charts/backend/templates/deployment.yaml
+++ b/charts/fin-pay-transparency/charts/backend/templates/deployment.yaml
@@ -178,5 +178,5 @@ spec:
                     values:
                       - {{ .Release.Name }}
               topologyKey: "kubernetes.io/hostname"
-      {{- with .Values.tolerations }}
+
 {{- end }}

--- a/charts/fin-pay-transparency/charts/backend/templates/deployment.yaml
+++ b/charts/fin-pay-transparency/charts/backend/templates/deployment.yaml
@@ -160,12 +160,23 @@ spec:
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.affinity }}
-      affinity:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
       {{- with .Values.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                  - key: app.kubernetes.io/name
+                    operator: In
+                    values:
+                      - {{ include "backend.fullname" . }}
+                  - key: app.kubernetes.io/instance
+                    operator: In
+                    values:
+                      - {{ .Release.Name }}
+              topologyKey: "kubernetes.io/hostname"
+      {{- with .Values.tolerations }}
 {{- end }}

--- a/charts/fin-pay-transparency/charts/backend/templates/pdb.yaml
+++ b/charts/fin-pay-transparency/charts/backend/templates/pdb.yaml
@@ -1,4 +1,4 @@
-{{- if and (.Values.enabled and (.Values.pdb .Values.pdb.enabled )) }}
+{{- if .Values.pdb }}
 ---
 apiVersion: policy/v1
 kind: PodDisruptionBudget

--- a/charts/fin-pay-transparency/charts/backend/templates/pdb.yaml
+++ b/charts/fin-pay-transparency/charts/backend/templates/pdb.yaml
@@ -1,0 +1,16 @@
+{{- if and (.Values.enabled and (.Values.pdb .Values.pdb.enabled )) }}
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "backend.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "backend.name" . }}
+    helm.sh/chart: {{ include "backend.chart" . }}
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "backend.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  minAvailable: 1
+{{- end }}

--- a/charts/fin-pay-transparency/charts/doc-gen-service/templates/deployment.yaml
+++ b/charts/fin-pay-transparency/charts/doc-gen-service/templates/deployment.yaml
@@ -81,12 +81,22 @@ spec:
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.affinity }}
-      affinity:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
       {{- with .Values.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                  - key: app.kubernetes.io/name
+                    operator: In
+                    values:
+                      - {{ include "doc-gen-service.fullname" . }}
+                  - key: app.kubernetes.io/instance
+                    operator: In
+                    values:
+                      - {{ .Release.Name }}
+              topologyKey: "kubernetes.io/hostname"
 {{- end }}

--- a/charts/fin-pay-transparency/charts/doc-gen-service/templates/pdb.yaml
+++ b/charts/fin-pay-transparency/charts/doc-gen-service/templates/pdb.yaml
@@ -1,4 +1,4 @@
-{{- if and (.Values.enabled and (.Values.pdb .Values.pdb.enabled )) }}
+{{- if .Values.pdb }}
 ---
 apiVersion: policy/v1
 kind: PodDisruptionBudget

--- a/charts/fin-pay-transparency/charts/doc-gen-service/templates/pdb.yaml
+++ b/charts/fin-pay-transparency/charts/doc-gen-service/templates/pdb.yaml
@@ -1,0 +1,16 @@
+{{- if and (.Values.enabled and (.Values.pdb .Values.pdb.enabled )) }}
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "doc-gen-service.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "doc-gen-service.name" . }}
+    helm.sh/chart: {{ include "doc-gen-service.chart" . }}
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "doc-gen-service.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  minAvailable: 1
+{{- end }}

--- a/charts/fin-pay-transparency/charts/frontend/templates/deployment.yaml
+++ b/charts/fin-pay-transparency/charts/frontend/templates/deployment.yaml
@@ -63,12 +63,22 @@ spec:
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.affinity }}
-      affinity:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
       {{- with .Values.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                  - key: app.kubernetes.io/name
+                    operator: In
+                    values:
+                      - {{ include "frontend.fullname" . }}
+                  - key: app.kubernetes.io/instance
+                    operator: In
+                    values:
+                      - {{ .Release.Name }}
+              topologyKey: "kubernetes.io/hostname"
 {{- end }}

--- a/charts/fin-pay-transparency/charts/frontend/templates/pdb.yaml
+++ b/charts/fin-pay-transparency/charts/frontend/templates/pdb.yaml
@@ -1,4 +1,4 @@
-{{- if and (.Values.enabled and (.Values.pdb .Values.pdb.enabled )) }}
+{{- if .Values.pdb }}
 ---
 apiVersion: policy/v1
 kind: PodDisruptionBudget

--- a/charts/fin-pay-transparency/charts/frontend/templates/pdb.yaml
+++ b/charts/fin-pay-transparency/charts/frontend/templates/pdb.yaml
@@ -1,0 +1,16 @@
+{{- if and (.Values.enabled and (.Values.pdb .Values.pdb.enabled )) }}
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "frontend.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "frontend.name" . }}
+    helm.sh/chart: {{ include "frontend.chart" . }}
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "frontend.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  minAvailable: 1
+{{- end }}

--- a/charts/fin-pay-transparency/values-pr.yaml
+++ b/charts/fin-pay-transparency/values-pr.yaml
@@ -41,8 +41,8 @@ backend:
     enabled: true
     size: 50Mi
     accessMode: ReadWriteMany
-  pdb:
-    enabled: false
+  pdb: false
+
 frontend:
   deploymentStrategy: Recreate
   resources:
@@ -54,8 +54,8 @@ frontend:
       memory: 50Mi
   env:
     logLevel: info
-  pdb:
-    enabled: false
+  pdb: false
+    
 database:
   enabled: true
   deploymentStrategy: Recreate
@@ -126,5 +126,4 @@ doc-gen-service:
   imagePullSecrets: [ ]
   nodeSelector: { }
   tolerations: [ ]
-  pdb:
-    enabled: false
+  pdb: false

--- a/charts/fin-pay-transparency/values-pr.yaml
+++ b/charts/fin-pay-transparency/values-pr.yaml
@@ -41,7 +41,8 @@ backend:
     enabled: true
     size: 50Mi
     accessMode: ReadWriteMany
-
+  pdb:
+    enabled: false
 frontend:
   deploymentStrategy: Recreate
   resources:
@@ -53,7 +54,8 @@ frontend:
       memory: 50Mi
   env:
     logLevel: info
-
+  pdb:
+    enabled: false
 database:
   enabled: true
   deploymentStrategy: Recreate
@@ -119,10 +121,10 @@ doc-gen-service:
       cpu: 30m
       memory: 50Mi
 
-  podAnnotations: { }
   podSecurityContext: { }
   securityContext: { }
   imagePullSecrets: [ ]
   nodeSelector: { }
   tolerations: [ ]
-  affinity: { }
+  pdb:
+    enabled: false

--- a/charts/fin-pay-transparency/values.yaml
+++ b/charts/fin-pay-transparency/values.yaml
@@ -83,8 +83,7 @@ backend:
   imagePullSecrets: [ ]
   nodeSelector: { }
   tolerations: [ ]
-  pdb:
-    enabled: true
+  pdb: true
 frontend:
   enabled: true
   deploymentStrategy: RollingUpdate
@@ -131,8 +130,7 @@ frontend:
   imagePullSecrets: [ ]
   nodeSelector: { }
   tolerations: [ ]
-  pdb:
-    enabled: true
+  pdb: true
 database:
   enabled: false
 crunchy:
@@ -268,6 +266,4 @@ doc-gen-service:
   imagePullSecrets: [ ]
   nodeSelector: { }
   tolerations: [ ]
-  pdb:
-    enabled: true
-
+  pdb: true

--- a/charts/fin-pay-transparency/values.yaml
+++ b/charts/fin-pay-transparency/values.yaml
@@ -83,7 +83,8 @@ backend:
   imagePullSecrets: [ ]
   nodeSelector: { }
   tolerations: [ ]
-  affinity: { }
+  pdb:
+    enabled: true
 frontend:
   enabled: true
   deploymentStrategy: RollingUpdate
@@ -130,7 +131,8 @@ frontend:
   imagePullSecrets: [ ]
   nodeSelector: { }
   tolerations: [ ]
-  affinity: { }
+  pdb:
+    enabled: true
 database:
   enabled: false
 crunchy:
@@ -266,5 +268,6 @@ doc-gen-service:
   imagePullSecrets: [ ]
   nodeSelector: { }
   tolerations: [ ]
-  affinity: { }
+  pdb:
+    enabled: true
 


### PR DESCRIPTION
The PR helps in 
1. Distributing pods across multiple worker nodes in HA environment with affinity rules.
2. Making sure there is always minimum available 1 pod during upgrades with PDB.

affinity docs:
https://docs.openshift.com/container-platform/4.14/nodes/scheduling/nodes-scheduler-node-affinity.html#nodes-scheduler-node-affinity-about_nodes-scheduler-node-affinity

pdb docs:
https://docs.openshift.com/container-platform/4.14/nodes/pods/nodes-pods-configuring.html#nodes-pods-pod-disruption-configuring_nodes-pods-configuring



---
Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://pay-transparency-pr-165-frontend.apps.silver.devops.gov.bc.ca)