### PR TITLE
terminate session when failed to get company details

### DIFF
--- a/backend/src/v1/routes/auth-routes.ts
+++ b/backend/src/v1/routes/auth-routes.ts
@@ -151,6 +151,9 @@ router.get(
   utils.asyncHandler(auth.refreshJWT),
   (req: Request, res: Response) => {
     const user: any = req.user;
+    if (!user.companyDetails) {
+      return res.status(401).json({ error: 'Missing company details' });
+    }
     const session: any = req.session;
     if (user?.jwtFrontend && user?.refreshToken) {
       if (session?.passport?.user?._json) {

--- a/backend/src/v1/routes/auth-routes.ts
+++ b/backend/src/v1/routes/auth-routes.ts
@@ -118,7 +118,7 @@ router.post(
     const session: any = req.session;
     const errors = validationResult(req);
 
-    if (!user?.companyDetails) {
+    if (!session?.companyDetails) {
       return res.status(401).json({error: 'Missing company details'});
     }
 
@@ -151,10 +151,10 @@ router.get(
   utils.asyncHandler(auth.refreshJWT),
   (req: Request, res: Response) => {
     const user: any = req.user;
-    if (!user?.companyDetails) {
+    const session: any = req.session;
+    if (!session?.companyDetails) {
       return res.status(401).json({ error: 'Missing company details' });
     }
-    const session: any = req.session;
     if (user?.jwtFrontend && user?.refreshToken) {
       if (session?.passport?.user?._json) {
         req.session['correlationID'] = uuidv4();

--- a/backend/src/v1/routes/auth-routes.ts
+++ b/backend/src/v1/routes/auth-routes.ts
@@ -118,7 +118,7 @@ router.post(
     const session: any = req.session;
     const errors = validationResult(req);
 
-    if (!user.companyDetails) {
+    if (!user?.companyDetails) {
       return res.status(401).json({error: 'Missing company details'});
     }
 
@@ -151,7 +151,7 @@ router.get(
   utils.asyncHandler(auth.refreshJWT),
   (req: Request, res: Response) => {
     const user: any = req.user;
-    if (!user.companyDetails) {
+    if (!user?.companyDetails) {
       return res.status(401).json({ error: 'Missing company details' });
     }
     const session: any = req.session;

--- a/backend/src/v1/routes/auth-routes.ts
+++ b/backend/src/v1/routes/auth-routes.ts
@@ -118,6 +118,10 @@ router.post(
     const session: any = req.session;
     const errors = validationResult(req);
 
+    if (!user.companyDetails) {
+      return res.status(401).json({error: 'Missing company details'});
+    }
+
     if (!errors.isEmpty()) {
       return res.status(400).json({
         errors: errors.array(),

--- a/backend/src/v1/services/auth-service.spec.ts
+++ b/backend/src/v1/services/auth-service.spec.ts
@@ -633,17 +633,4 @@ describe('handleCallBackBusinessBceid', () => {
     expect(prisma.pay_transparency_company.findFirst).toHaveBeenCalled();
     expect(prisma.pay_transparency_company.update).toHaveBeenCalled();
   });
-  it('should terminate current session and redirect when it fails to get Company details', async () => {
-    jest.spyOn(bceidService, 'getCompanyDetails').mockImplementation(() => {
-      return Promise.reject(mockCompanyInSession);
-    });
-    
-    const modifiedReq = {
-      ...req,
-    };
-    modifiedReq.session.companyDetails = undefined;
-    await auth.handleCallBackBusinessBceid(modifiedReq, res);
-    expect(mock_reqLogout).toHaveBeenCalled();
-    expect(res.redirect).toHaveBeenCalled();
-  });
 });

--- a/backend/src/v1/services/auth-service.spec.ts
+++ b/backend/src/v1/services/auth-service.spec.ts
@@ -479,7 +479,7 @@ const req: any = {
       user: {
         ...userInfo,
       },
-    },
+    }
   }
 };
 
@@ -565,7 +565,6 @@ describe('handleCallBackBusinessBceid', () => {
       aud: 'clientId',
       identity_provider: 'bceidbusiness',
     });
-    jest.clearAllMocks();
   });
   it('should handle the callback successfully', async () => {
     // Mock any dependencies and set up the expected behavior

--- a/backend/src/v1/services/auth-service.spec.ts
+++ b/backend/src/v1/services/auth-service.spec.ts
@@ -470,7 +470,6 @@ const userInfo = {
     display_name: 'Test User',
   },
 };
-const mock_reqLogout = jest.fn();
 const req: any = {
   session: {
     companyDetails: {
@@ -481,11 +480,7 @@ const req: any = {
         ...userInfo,
       },
     },
-  },
-  logOut: (callback) => {
-    callback();
-    mock_reqLogout();
-  },
+  }
 };
 
 describe('storeUserInfo', () => {

--- a/backend/src/v1/services/auth-service.spec.ts
+++ b/backend/src/v1/services/auth-service.spec.ts
@@ -479,8 +479,8 @@ const req: any = {
       user: {
         ...userInfo,
       },
-    }
-  }
+    },
+  },
 };
 
 describe('storeUserInfo', () => {

--- a/backend/src/v1/services/auth-service.ts
+++ b/backend/src/v1/services/auth-service.ts
@@ -296,13 +296,7 @@ const auth = {
             `Error happened while getting company details from BCEID for user ${userGuid}`,
             e,
           );
-          return req.logOut((error) => {
-            log.error(
-              `Error happened while terminating session created before getting company details for user ${userGuid}`,
-              error,
-            );
-            return res.redirect(config.get('server:frontend') + '/login-error');
-          });
+          return res.redirect(config.get('server:frontend') + '/login-error');
         }
       }
       res.redirect(config.get('server:frontend'));

--- a/backend/src/v1/services/auth-service.ts
+++ b/backend/src/v1/services/auth-service.ts
@@ -296,7 +296,13 @@ const auth = {
             `Error happened while getting company details from BCEID for user ${userGuid}`,
             e,
           );
-          res.redirect(config.get('server:frontend') + '/login-error');
+          return req.logOut((error) => {
+            log.error(
+              `Error happened while terminating session created before getting company details for user ${userGuid}`,
+              error,
+            );
+            return res.redirect(config.get('server:frontend') + '/login-error');
+          });
         }
       }
       res.redirect(config.get('server:frontend'));


### PR DESCRIPTION

# Description

If the IDIM SOAP call fails then the login error page is shown to the user but if the user refreshes the page they are shown the home page. This needs to be solved by redirecting the user to the login page.
Fixes # (issue)

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

**Repro steps:**

- Disconnect the VPN connection to mimic a login fail

- Attempt to log in and verify that you are redirected to the /login-error page

- Open another tab and attempt to visit http://localhost:8081/ and verify that you land on the home page

**Expected behavior:**

When the VPN connection fails, the user should not be allowed to visit the homepage



## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have already been accepted and merged


## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


---
Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://pay-transparency-pr-213-frontend.apps.silver.devops.gov.bc.ca)