### PR TITLE
move-data-constraits

### DIFF
--- a/backend/src/v1/services/report-service.ts
+++ b/backend/src/v1/services/report-service.ts
@@ -454,14 +454,8 @@ const reportService = {
   createExplanatoryNotes(report: any) {
     const explanatoryNotes = {};
     let nextNum = 1;
-    if (report.data_constraints) {
-      explanatoryNotes['dataConstraints'] = {
-        num: nextNum++,
-        text: report.data_constraints,
-      } as ExplanatoryNote;
-    }
 
-    //assign numbers to all the other notes
+    //assign numbers to all the notes, in the following order
     const noteCodes = [
       'meanHourlyPayDiff',
       'medianHourlyPayDiff',
@@ -476,7 +470,7 @@ const reportService = {
     noteCodes.forEach((noteCode) => {
       explanatoryNotes[noteCode] = {
         num: nextNum++,
-        //don't include the text.  the template file has the text of the note
+        //don't include the text.  The doc-gen-service template file has the text of the note
       } as ExplanatoryNote;
     });
 
@@ -951,6 +945,7 @@ const reportService = {
           .naics_label,
       employeeCountRange: report.employee_count_range.employee_count_range,
       comments: report.user_comment,
+      dataConstraints: report.data_constraints,
       referenceGenderCategory: !isAllCalculatedDataSuppressed
         ? referenceGenderChartInfo.label
         : null,

--- a/doc-gen-service/src/templates/report-template-emp-data-summary.html
+++ b/doc-gen-service/src/templates/report-template-emp-data-summary.html
@@ -64,37 +64,26 @@
   </table>
 
   <div class="block-explanatory-notes">
-    <% if (explanatoryNotes.dataConstraints) { %>
-      <div class="note">
-        <div class="note-number">
-          <%= explanatoryNotes.dataConstraints.num %>.
-        </div>
-        <div>
-          <%= explanatoryNotes.dataConstraints.text %>
-        </div>
+    <div class="note">
+      <div class="note-number">
+        <%= explanatoryNotes.meanHourlyPayDiff.num %>.
       </div>
-      <% } %>
-
-        <div class="note">
-          <div class="note-number">
-            <%= explanatoryNotes.meanHourlyPayDiff.num %>.
-          </div>
-          <div>
-            &quot;Mean hourly pay gap&quot; refers to the differences in pay between
-            gender groups calculated by average pay. Hourly pay does not include
-            bonuses and overtime.
-          </div>
-        </div>
-        <div class="note">
-          <div class="note-number">
-            <%= explanatoryNotes.medianHourlyPayDiff.num %>.
-          </div>
-          <div>
-            &quot;Median hourly pay gap&quot; refers to the differences in pay
-            between gender groups calculated by the mid range of pay for each group.
-            Hourly pay does not include bonuses and overtime.
-          </div>
-        </div>
+      <div>
+        &quot;Mean hourly pay gap&quot; refers to the differences in pay between
+        gender groups calculated by average pay. Hourly pay does not include
+        bonuses and overtime.
+      </div>
+    </div>
+    <div class="note">
+      <div class="note-number">
+        <%= explanatoryNotes.medianHourlyPayDiff.num %>.
+      </div>
+      <div>
+        &quot;Median hourly pay gap&quot; refers to the differences in pay
+        between gender groups calculated by the mid range of pay for each group.
+        Hourly pay does not include bonuses and overtime.
+      </div>
+    </div>
   </div>
 
 </div>
@@ -545,23 +534,34 @@
 
 </div>
 
-</div>
-<%# end of class='block-group' %>
-
-  <div class="footnote-group">
-    <% if (isGeneralSuppressedDataFootnoteVisible) { %>
-      <div class="note mt-4">
-        <div class="note-number">
-          <%= footnoteSymbols.genderCategorySuppressed %>
-        </div>
-        <div>
-          In accordance with the Pay Transparency Act and reporting rules designed to protect the anonymity and
-          privacy
-          of
-          respondents, one or more gender categories has been excluded due to insufficient numbers to meet
-          disclosure
-          requirements.
-        </div>
-      </div>
-      <% } %>
+<% if (dataConstraints) { %>
+  <div id="block-data-constraits" class="block">
+    <h4 class="mb-0">
+      Data constraints
+    </h4>
+    <div class="data-constraints text-normal">
+      <%= dataConstraints %>
+    </div>
   </div>
+  <% } %>
+
+    </div>
+    <%# end of class='block-group' %>
+
+      <div class="footnote-group">
+        <% if (isGeneralSuppressedDataFootnoteVisible) { %>
+          <div class="note mt-4">
+            <div class="note-number">
+              <%= footnoteSymbols.genderCategorySuppressed %>
+            </div>
+            <div>
+              In accordance with the Pay Transparency Act and reporting rules designed to protect the anonymity and
+              privacy
+              of
+              respondents, one or more gender categories has been excluded due to insufficient numbers to meet
+              disclosure
+              requirements.
+            </div>
+          </div>
+          <% } %>
+      </div>

--- a/doc-gen-service/src/templates/report-template-header.html
+++ b/doc-gen-service/src/templates/report-template-header.html
@@ -276,7 +276,8 @@
     margin-right: 10px;
   }
 
-  .pay-transparency-report .user-comments {
+  .pay-transparency-report .user-comments,
+  .pay-transparency-report .data-constraints {
     color: #888888;
   }
 

--- a/doc-gen-service/src/v1/services/doc-gen-service.spec.ts
+++ b/doc-gen-service/src/v1/services/doc-gen-service.spec.ts
@@ -19,6 +19,7 @@ const submittedReportData: SubmittedReportData = {
   naicsLabel: 'Agriculture, forestry, fishing and hunting',
   employeeCountRange: '50-299',
   comments: '',
+  dataConstraints: '',
   referenceGenderCategory: 'Men',
   chartSuppressedError: '',
   tableData: {

--- a/doc-gen-service/src/v1/services/doc-gen-service.ts
+++ b/doc-gen-service/src/v1/services/doc-gen-service.ts
@@ -45,6 +45,7 @@ export type SubmittedReportData = {
   naicsLabel: string;
   employeeCountRange: string;
   comments: string;
+  dataConstraints: string;
   referenceGenderCategory: string;
   explanatoryNotes: unknown;
   chartData: {


### PR DESCRIPTION
# Description

move the data constraints to the end of the report (and out of 'explanatory notes')

Fixes # [GEO-275](https://finrms.atlassian.net/browse/GEO-275)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Visual inspection of the report + existing unit tests

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have already been accepted and merged


---
Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://pay-transparency-pr-248-frontend.apps.silver.devops.gov.bc.ca)