### PR TITLE
handle generateReport() when chartData and tableData are null.

### DIFF
--- a/doc-gen-service/src/v1/services/doc-gen-service.spec.ts
+++ b/doc-gen-service/src/v1/services/doc-gen-service.spec.ts
@@ -79,17 +79,40 @@ beforeEach(() => {
 });
 
 describe('generateReport', () => {
-  it(
-    'should generate a report',
-    async () => {
-      const report = await generateReport(
-        REPORT_FORMAT.HTML,
-        submittedReportData as any,
-      );
-      expect(report).toBeDefined();
-    },
-    TEST_TIMEOUT_MS,
-  );
+  describe('when at least some calculated data are suppressed', () => {
+    it(
+      'should generate a report',
+      async () => {
+        const report = await generateReport(
+          REPORT_FORMAT.HTML,
+          submittedReportData as any,
+        );
+        expect(report).toBeDefined();
+      },
+      TEST_TIMEOUT_MS,
+    );
+  });
+  describe('when all calculated data are suppressed', () => {
+    it(
+      'should generate a report',
+      async () => {
+        const mockSubmittedReportData = {
+          ...submittedReportData,
+          tableData: null,
+          chartData: null,
+          chartSummaryText: null,
+          explanatoryNotes: null,
+          isAllCalculatedDataSuppressed: true,
+        };
+        const report = await generateReport(
+          REPORT_FORMAT.HTML,
+          mockSubmittedReportData as any,
+        );
+        expect(report).toBeDefined();
+      },
+      TEST_TIMEOUT_MS,
+    );
+  });
 });
 
 describe('buildEjsTemplate', () => {

--- a/doc-gen-service/src/v1/services/doc-gen-service.ts
+++ b/doc-gen-service/src/v1/services/doc-gen-service.ts
@@ -614,6 +614,7 @@ const docGenServicePrivate = {
     const tablesToConsider = ['meanOvertimeHoursGap', 'medianOvertimeHoursGap'];
     const numGenderCategories = submittedReportData.genderCodes.length;
     const hasAtLeastOneIncludedChartWithSuppression =
+      submittedReportData.chartData &&
       chartsToConsider
         .map((chartName) => submittedReportData.chartData[chartName])
         .filter((c) => c.length && c.length < numGenderCategories).length > 0;
@@ -621,10 +622,11 @@ const docGenServicePrivate = {
     // Note: (numGenderCategories - 1) because because the reference gender
     // category isn't displayed in the tables
     const hasAtLeastOneIncludedTableWithSuppression =
+      submittedReportData.tableData &&
       tablesToConsider
         .map((tableName) => submittedReportData.tableData[tableName])
         .filter((c) => c.length && c.length < numGenderCategories - 1).length >
-      0;
+        0;
     return (
       hasAtLeastOneIncludedChartWithSuppression ||
       hasAtLeastOneIncludedTableWithSuppression


### PR DESCRIPTION
# Description

Doc-gen-service: gracefully handle generateReport() when 'chartData' and 'tableData' properties of the submitted reportData are null.

Fixes # [GEO-339](https://finrms.atlassian.net/browse/GEO-339)

## Type of change


- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

New unit test.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have already been accepted and merged


---
Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://pay-transparency-pr-250-frontend.apps.silver.devops.gov.bc.ca)