### PR TITLE
require auth when user hits 404 page

### DIFF
--- a/frontend/src/router.js
+++ b/frontend/src/router.js
@@ -93,7 +93,14 @@ const router = createRouter({
         requiresAuth: true,
       },
     },
-    { path: '/:pathMatch(.*)*', name: 'NotFound', component: NotFoundPage },
+    { 
+      path: '/:pathMatch(.*)*', 
+      name: 'NotFound', 
+      component: NotFoundPage, 
+      meta: {
+        requiresAuth: true
+      } 
+    },
   ],
 });
 


### PR DESCRIPTION

# Description

When an unauthenticated user navigate to a 404 page, the user should be redirected to the login page



## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have already been accepted and merged


## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


---
Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://pay-transparency-pr-258-frontend.apps.silver.devops.gov.bc.ca)