### PR TITLE
feat: add endpoint to get config settings and use them in the frontend

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -13,6 +13,7 @@ import codeRouter from './v1/routes/code-routes';
 import { fileUploadRouter } from './v1/routes/file-upload-routes';
 import userRouter from './v1/routes/user-info-routes';
 import { reportRouter } from './v1/routes/report-routes';
+import { router as configRouter } from './v1/routes/config-routes';
 import { auth } from './v1/services/auth-service';
 import { utils } from './v1/services/utils-service';
 import prom from 'prom-client';
@@ -249,6 +250,7 @@ apiRouter.use(
   },
 );
 apiRouter.use('/user', userRouter);
+apiRouter.use('/config', configRouter);
 apiRouter.use('/v1/file-upload', fileUploadRouter);
 apiRouter.use('/v1/codes', codeRouter);
 apiRouter.use('/v1/report', reportRouter);

--- a/backend/src/v1/routes/config-routes.ts
+++ b/backend/src/v1/routes/config-routes.ts
@@ -1,0 +1,14 @@
+import express from 'express';
+import { config } from '../../config';
+
+const router = express.Router();
+
+router.get('', (_, res) => {
+  const settings = {
+    maxUploadFileSize: config.get('server:uploadFileMaxSizeBytes'),
+  };
+
+  return res.status(200).json(settings);
+});
+
+export { router };

--- a/backend/src/v1/routes/config.routes.spec.ts
+++ b/backend/src/v1/routes/config.routes.spec.ts
@@ -1,0 +1,33 @@
+import express, { Application } from 'express';
+import request from 'supertest';
+import { router } from './config-routes';
+
+let app: Application;
+
+const mockConfigGet = jest.fn();
+
+jest.mock('../../config', () => ({
+  config: {
+    get: (key) => mockConfigGet(key),
+  },
+}));
+
+describe('config-routes', () => {
+  beforeEach(() => {
+    app = express();
+    app.use('/config', router);
+  });
+
+  it('should setup the route', () => {
+    return request(app).get('/config').expect(200);
+  });
+  it('should correct config values', () => {
+    mockConfigGet.mockReturnValue(800000);
+
+    return request(app)
+      .get('/config')
+      .expect(({ body }) => {
+        expect(body.maxUploadFileSize).not.toBeNull();
+      });
+  });
+});

--- a/frontend/src/common/__tests__/apiService.spec.ts
+++ b/frontend/src/common/__tests__/apiService.spec.ts
@@ -225,6 +225,74 @@ describe('ApiService', () => {
       });
     });
   });
+  describe('getConfig', () => {
+    describe('when the data are successfully retrieved from the backend', () => {
+      it('returns configuration', async () => {
+        // Internally getReport() makes an API call to the backend.
+        // Mock the call and its response to remove dependency of this test
+        // on a remote service.
+        const mockBackendResponse = { maxUploadFileSize: 8000000 };
+        const mockAxiosResponse = {
+          data: mockBackendResponse,
+        };
+        vi.spyOn(ApiService.apiAxios, 'get').mockResolvedValueOnce(
+          mockAxiosResponse,
+        );
+
+        const resp = await ApiService.getConfig();
+        expect(resp).toEqual(mockBackendResponse);
+      });
+    });
+
+    describe('when the data are not successfully retrieved from the backend', () => {
+      it('returns a rejected promise', async () => {
+        // Simulate an HTTP error response when getReport() tries to
+        // fetch data from the backend
+        const mockAxiosError = new AxiosError();
+        vi.spyOn(ApiService.apiAxios, 'get').mockRejectedValueOnce(
+          mockAxiosError,
+        );
+
+        expect(ApiService.getConfig()).rejects.toEqual(
+          mockAxiosError,
+        );
+      });
+    });
+  });
+  describe('getUserInfo', () => {
+    describe('when the data are successfully retrieved from the backend', () => {
+      it('returns configuration', async () => {
+        // Internally getReport() makes an API call to the backend.
+        // Mock the call and its response to remove dependency of this test
+        // on a remote service.
+        const mockBackendResponse = { name: 'test' };
+        const mockAxiosResponse = {
+          data: mockBackendResponse,
+        };
+        vi.spyOn(ApiService.apiAxios, 'get').mockResolvedValueOnce(
+          mockAxiosResponse,
+        );
+
+        const resp = await ApiService.getUserInfo();
+        expect(resp.data).toEqual(mockBackendResponse);
+      });
+    });
+
+    describe('when the data are not successfully retrieved from the backend', () => {
+      it('returns a rejected promise', async () => {
+        // Simulate an HTTP error response when getReport() tries to
+        // fetch data from the backend
+        const mockAxiosError = new AxiosError();
+        vi.spyOn(ApiService.apiAxios, 'get').mockRejectedValueOnce(
+          mockAxiosError,
+        );
+
+        expect(ApiService.getUserInfo()).rejects.toEqual(
+          mockAxiosError,
+        );
+      });
+    });
+  });
 
   describe('getHtmlReport', () => {
     describe('when the data are successfully retrieved from the backend', () => {

--- a/frontend/src/common/apiService.ts
+++ b/frontend/src/common/apiService.ts
@@ -2,6 +2,7 @@ import axios from 'axios';
 import { saveAs } from 'file-saver';
 import { ApiRoutes } from '../utils/constant';
 import AuthService from './authService';
+import { IConfigValue } from './types';
 
 export enum REPORT_FORMATS {
   HTML = 'html',
@@ -131,8 +132,8 @@ export default {
   },
   async getConfig() {
     try {
-      const response = await apiAxios.get(ApiRoutes.CONFIG);
-      return response;
+      const { data } = await apiAxios.get<IConfigValue>(ApiRoutes.CONFIG);
+      return data;
     } catch (e) {
       console.log(`Failed to do get from Nodejs getConfig API - ${e}`);
       throw e;

--- a/frontend/src/common/apiService.ts
+++ b/frontend/src/common/apiService.ts
@@ -133,6 +133,7 @@ export default {
   async getConfig() {
     try {
       const { data } = await apiAxios.get<IConfigValue>(ApiRoutes.CONFIG);
+      
       return data;
     } catch (e) {
       console.log(`Failed to do get from Nodejs getConfig API - ${e}`);

--- a/frontend/src/common/types/index.ts
+++ b/frontend/src/common/types/index.ts
@@ -1,0 +1,3 @@
+export interface IConfigValue {
+  maxUploadFileSize: number;
+}

--- a/frontend/src/components/InputForm.vue
+++ b/frontend/src/components/InputForm.vue
@@ -418,6 +418,7 @@ import moment from 'moment';
 import { DialogUtils } from '../utils/dialogUtils';
 import { humanFileSize } from '../utils/file';
 import { useConfigStore } from '../store/modules/config';
+import { NotificationService } from '../common/notificationService';
 
 interface LineErrors {
   lineNum: number;
@@ -496,7 +497,13 @@ export default {
   }),
   async beforeMount() {
     this.setStage('UPLOAD');
-    await this.loadConfig();
+
+    try {
+      await this.loadConfig();
+    } catch (error) {
+      NotificationService.pushNotificationError('Failed to load application settings. Please reload the page.')
+    }
+
     if (this.reportId) {
       this.comments = this.reportData.user_comment;
       this.employeeCountRange = this.reportData.employee_count_range_id;

--- a/frontend/src/components/InputForm.vue
+++ b/frontend/src/components/InputForm.vue
@@ -464,7 +464,7 @@ export default {
     employeeCountRange: null,
     isProcessing: false,
     uploadFileValue: null,
-    maxFileUploadSize: '8MB',
+    maxFileUploadSize: '',
     minStartDate: moment().subtract(2, 'years').startOf('month').toDate(),
     maxStartDate: moment().subtract(1, 'years').endOf('month').toDate(),
     minEndDate: moment()

--- a/frontend/src/components/InputForm.vue
+++ b/frontend/src/components/InputForm.vue
@@ -311,7 +311,8 @@
                   </div>
 
                   <p class="d-flex justify-center">
-                    Supported format: CSV. Maximum file size: 8MB.
+                    Supported format: CSV. Maximum file size:
+                    {{ maxFileUploadSize }}.
                   </p>
                 </v-sheet>
               </v-col>
@@ -415,6 +416,8 @@ import {
 } from '../store/modules/reportStepper';
 import moment from 'moment';
 import { DialogUtils } from '../utils/dialogUtils';
+import { humanFileSize } from '../utils/file';
+import { useConfigStore } from '../store/modules/config';
 
 interface LineErrors {
   lineNum: number;
@@ -461,6 +464,7 @@ export default {
     employeeCountRange: null,
     isProcessing: false,
     uploadFileValue: null,
+    maxFileUploadSize: '8MB',
     minStartDate: moment().subtract(2, 'years').startOf('month').toDate(),
     maxStartDate: moment().subtract(1, 'years').endOf('month').toDate(),
     minEndDate: moment()
@@ -492,6 +496,7 @@ export default {
   }),
   async beforeMount() {
     this.setStage('UPLOAD');
+    await this.loadConfig();
     if (this.reportId) {
       this.comments = this.reportData.user_comment;
       this.employeeCountRange = this.reportData.employee_count_range_id;
@@ -503,6 +508,7 @@ export default {
   },
   methods: {
     ...mapActions(useReportStepperStore, ['setStage', 'setReportId', 'reset']),
+    ...mapActions(useConfigStore, ['loadConfig']),
     setSuccessAlert(alertMessage) {
       this.alertMessage = alertMessage;
       this.alertType = 'bootstrap-success';
@@ -579,8 +585,17 @@ export default {
         this.companyAddress = address;
       },
     },
+    config(data) {
+      if (data.maxUploadFileSize) {
+        this.maxFileUploadSize = humanFileSize(
+          data?.maxUploadFileSize || 8000000,
+          0,
+        );
+      }
+    },
   },
   computed: {
+    ...mapState(useConfigStore, ['config']),
     ...mapState(useCodeStore, ['employeeCountRanges', 'naicsCodes']),
     ...mapState(authStore, ['userInfo']),
     ...mapState(useReportStepperStore, ['reportId', 'reportData', 'mode']),

--- a/frontend/src/components/__tests__/InputForm.spec.ts
+++ b/frontend/src/components/__tests__/InputForm.spec.ts
@@ -125,7 +125,7 @@ describe("InputForm", () => {
     const endDateComponent = wrapper.findComponent({ ref: 'endDate' })
 
     const startDate = moment().subtract(1, "years").format("yyyy-MM-DD");
-    const expectedEndDate = moment().subtract(1, "months").format("yyyy-MM-DD");
+    const expectedEndDate = moment().subtract(1, "months").endOf('month').format("yyyy-MM-DD");
     await startDateComponent.setValue(startDate);
 
     expect(wrapper.vm.$data.startDate).toBe(startDate)

--- a/frontend/src/store/modules/__tests__/config.spec.ts
+++ b/frontend/src/store/modules/__tests__/config.spec.ts
@@ -1,0 +1,43 @@
+import { beforeEach, describe, it, expect, vi } from 'vitest';
+import { setActivePinia, createPinia } from 'pinia';
+import { useConfigStore } from '../config';
+import { IConfigValue } from '../../../common/types';
+
+const mockGetConfig = vi.fn();
+
+vi.mock('../../../common/apiService', () => ({
+  default: {
+    getConfig: () => mockGetConfig(),
+  },
+}));
+
+describe('useConfigStore', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    vi.clearAllMocks();
+  });
+  describe('defaults', () => {
+    it('should default to undefined config value', () => {
+      const store = useConfigStore();
+      expect(store.config).toBe<IConfigValue | undefined>(undefined);
+    });
+  });
+
+  describe('methods', () => {
+    describe('loadConfig', () => {
+      it('should load config from api', async () => {
+        mockGetConfig.mockReturnValue({ maxUploadFileSize: 8000000 });
+        const store = useConfigStore();
+        expect(store.config).toBe<IConfigValue | undefined>(undefined);
+        await store.loadConfig();
+        expect(store.config).toEqual({ maxUploadFileSize: 8000000 });
+      });
+      it('should not reload config', async () => {
+        const store = useConfigStore();
+        store.$patch({ config: { maxUploadFileSize: 8000000 } });
+        await store.loadConfig();
+        expect(mockGetConfig).not.toHaveBeenCalled();
+      });
+    });
+  });
+});

--- a/frontend/src/store/modules/config.ts
+++ b/frontend/src/store/modules/config.ts
@@ -1,0 +1,18 @@
+import { ref } from 'vue';
+import { defineStore } from 'pinia';
+import ApiService from '../../common/apiService';
+import { IConfigValue } from '../../common/types';
+
+export const useConfigStore = defineStore('config', () => {
+  const config = ref<IConfigValue>();
+
+  const loadConfig = async () => {
+    if (config.value) return;
+
+    const data = await ApiService.getConfig();
+
+    config.value = data;
+  }
+
+  return { config, loadConfig };
+});

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -14,7 +14,7 @@ export default defineConfig({
     globals: true,
     coverage: {
       reporter: ['lcov', 'text-summary','text', 'json', 'html'],
-      exclude: ['./src/common/types'],
+      exclude: ['src/**/index.ts'],
     },
     setupFiles: ['./src/vitest.setup.ts']
   },

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -14,6 +14,7 @@ export default defineConfig({
     globals: true,
     coverage: {
       reporter: ['lcov', 'text-summary','text', 'json', 'html'],
+      exclude: ['./src/common/types'],
     },
     setupFiles: ['./src/vitest.setup.ts']
   },


### PR DESCRIPTION
# Description
The front end needs to get some config variables from the backend for display. I added a backend endpoint to expose some config variables and consumed them in the front end.

Fixes # (issue)

## Type of change
- I added endpoint `/config` to get the `uploadFileMaxSizeBytes` size
- Added a frontend pinia store to manage config data from the API
- Displayed the `uploadFileMaxSizeBytes` in `MB` in the InputForm

# How Has This Been Tested?
- [ ] Added unit tests
- [ ] Verified that the max csv upload file is 8MB in the input form


## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have already been accepted and merged


## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


---
Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://pay-transparency-pr-262-frontend.apps.silver.devops.gov.bc.ca)