### PR TITLE
bugfix/Make footer apply to app instead of container.

### DIFF
--- a/frontend/src/components/Footer.vue
+++ b/frontend/src/components/Footer.vue
@@ -1,16 +1,5 @@
 <template>
-  <v-footer color="#003366" dark absolute>
-    <v-row no-gutters>
-      <v-col class="justify-center" style="text-align: center">
-        For questions or assistance with creating a report please contact the
-        Pay Transparency Unit -
-        <a class="contact-email" href="mailto:paytransparency@gov.bc.ca">
-          PayTransparency@gov.bc.ca
-        </a>
-      </v-col>
-    </v-row>
-  </v-footer>
-  <v-footer color="#003366" dark absolute class="bordered">
+  <v-footer color="#003366" dark absolute class="bordered" app>
     <v-row no-gutters>
       <v-col class="justify-center">
         <v-btn
@@ -82,6 +71,17 @@
         >
           Contact Us
         </v-btn>
+      </v-col>
+    </v-row>
+  </v-footer>
+  <v-footer color="#003366" dark absolute app>
+    <v-row no-gutters>
+      <v-col class="justify-center" style="text-align: center">
+        For questions or assistance with creating a report please contact the
+        Pay Transparency Unit -
+        <a class="contact-email" href="mailto:paytransparency@gov.bc.ca">
+          PayTransparency@gov.bc.ca
+        </a>
       </v-col>
     </v-row>
   </v-footer>


### PR DESCRIPTION
I made a bug in the footer on this page https://dev.paytransparency.fin.gov.bc.ca/token-expired
Footer is too large.
This fixes the issue as seen here https://pay-transparency-pr-263-frontend.apps.silver.devops.gov.bc.ca/token-expired

---
Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://pay-transparency-pr-263-frontend.apps.silver.devops.gov.bc.ca)