### PR TITLE
floating footer for buttons "Download PDF" and "Edit this Report"

### DIFF
--- a/frontend/src/components/PublishedReportPage.vue
+++ b/frontend/src/components/PublishedReportPage.vue
@@ -6,7 +6,7 @@
         width=" fit-content"
         border="none"
         bg-color="rgba(255, 255, 255, 0)"
-        style="z-index: 190"
+        class="sticky-top"
       >
         <v-btn to="/">Back</v-btn>
       </v-banner>
@@ -22,21 +22,30 @@
           </v-row>
 
           <HtmlReport @html-report-loaded="htmlReportLoaded = true" />
-
-          <div v-if="htmlReportLoaded" class="d-flex justify-center w-100 mt-4">
-            <v-btn
-              id="downloadDraftPdfButton"
-              color="primary"
-              class="mr-2"
-              :loading="isDownloadingPdf"
-              :disabled="isDownloadingPdf"
-              @click="downloadPdf(reportId)"
-            >
-              Download PDF
-            </v-btn>
-          </div>
         </v-col>
       </v-row>
+      <v-banner
+        sticky
+        width="fit-content"
+        border="none"
+        bg-color="rgba(255, 255, 255, 0.9)"
+        class="d-flex justify-center w-100 sticky-bottom"
+        v-if="htmlReportLoaded"
+      >
+        <v-btn
+          id="downloadPdfButton"
+          color="primary"
+          class="mr-2"
+          :loading="isDownloadingPdf"
+          :disabled="isDownloadingPdf"
+          @click="downloadPdf(reportId)"
+        >
+          Download PDF
+        </v-btn>
+        <v-btn id="editButton" color="primary" to="/generate-report-form">
+          Edit this Report
+        </v-btn>
+      </v-banner>
       <v-overlay
         :persistent="true"
         :model-value="isProcessing"
@@ -84,3 +93,16 @@ const downloadPdf = async (reportId) => {
   isDownloadingPdf.value = false;
 };
 </script>
+
+<style lang="scss">
+.sticky-top {
+  z-index: 190;
+  bottom: none !important;
+  top: 0px !important;
+}
+.sticky-bottom {
+  z-index: 191;
+  bottom: 0px !important;
+  top: none !important;
+}
+</style>


### PR DESCRIPTION
# Description

On the Published Report screen, moved the existing "Download PDF" button into a floating footer ribbon (so it's always visible when scrolling).  Also added an "Edit this Report" button to the footer ribbon.  Currently "Edit this Report" just redirects back to the InputForm screen without any parameters passed.

Fixes # [GEO-214](https://finrms.atlassian.net/browse/GEO-214)

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Visual inspection of the frontend in a browser

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have already been accepted and merged


---
Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://pay-transparency-pr-273-frontend.apps.silver.devops.gov.bc.ca)