### PR TITLE
adding is_unlocked column to report_history table

### DIFF
--- a/backend/db/migrations/V1.0.16__report_history_locking.sql
+++ b/backend/db/migrations/V1.0.16__report_history_locking.sql
@@ -1,0 +1,4 @@
+SET search_path TO pay_transparency;
+
+alter table report_history add column is_unlocked boolean not null default false;
+


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description
Added `is_unlocked` column to the `report_history` table to allow reports to be copied


## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have already been accepted and merged


## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


---
Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://pay-transparency-pr-286-frontend.apps.silver.devops.gov.bc.ca)