### PR TITLE
fixed a problem with the database service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,8 +3,7 @@ version: "3.9"
 
 services:
   database:
-    build:
-      context: database
+    image: postgres:15
     container_name: database
     environment:
       POSTGRES_USER: postgres


### PR DESCRIPTION
# Description

Fixed an issue preventing the database service from being built.

The issue was caused by a recent commit that removed the Dockerfile for the database service.  Sukanya says instead of the Dockerfile for that service, we can use the postgres:15 image.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Running `podman-compose up --build -d database` now works again!

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have already been accepted and merged
