### PR TITLE
add ability to edit a published report

### DIFF
--- a/backend/src/v1/services/report-service.ts
+++ b/backend/src/v1/services/report-service.ts
@@ -1135,8 +1135,8 @@ const reportService = {
         await tx.pay_transparency_report.findFirst({
           where: {
             company_id: report_to_publish.company_id,
-            report_start_date: report_to_publish.report_start_date,
-            report_end_date: report_to_publish.report_end_date,
+            report_start_date: new Date(report_to_publish.report_start_date),
+            report_end_date: new Date(report_to_publish.report_end_date),
             report_status: enumReportStatus.Published,
           },
         });
@@ -1188,6 +1188,8 @@ const reportService = {
             revision: true,
             data_constraints: true,
             is_unlocked: true,
+            create_date: true,
+            company_id: true
           },
           where: {
             report_id: reportId,

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,6 +5,7 @@
   "description": "pay transparency",
   "scripts": {
     "test": "vitest run",
+    "test:ui": "vitest --ui",
     "test:cov": "vitest run --mode test --coverage",
     "serve": "vite --host",
     "build": "vite build",

--- a/frontend/src/common/types/index.ts
+++ b/frontend/src/common/types/index.ts
@@ -9,4 +9,7 @@ export interface IReport {
   report_end_date: string;
   create_date: string;
   is_unlocked: boolean;
+  naics_code: string;
+  report_status: string;
+  employee_count_range_id: string;
 }

--- a/frontend/src/components/Dashboard.vue
+++ b/frontend/src/components/Dashboard.vue
@@ -93,7 +93,11 @@
                       <v-icon color="#1976d2" icon="mdi-eye-outline"></v-icon>
                       View
                     </a>
-                    <a href="#" v-if="isEditable(report)">
+                    <a
+                      :data-testid="'edit-report-' + report.report_id"
+                      @click="editReport(report)"
+                      v-if="isEditable(report)"
+                    >
                       <v-icon color="#1976d2" icon="mdi-table-edit"></v-icon>
                       Edit
                     </a>
@@ -195,6 +199,11 @@ export default {
     async viewReport(report: IReport) {
       this.setMode(ReportMode.View);
       await this.setReportInfo(report);
+    },
+    async editReport(report: IReport) {
+      this.setMode(ReportMode.Edit);
+      await this.setReportInfo(report);
+      await this.$router.push({ path: 'generate-report-form' });
     },
   },
   async beforeMount() {

--- a/frontend/src/components/InputForm.vue
+++ b/frontend/src/components/InputForm.vue
@@ -101,6 +101,7 @@
                   month-picker
                   auto-apply
                   format="MMMM yyyy"
+                  :disabled="reportStatus === 'Published'"
                   placeholder="Start Date"
                   input-class-name="datepicker-input"
                   :min-date="minStartDate"
@@ -129,6 +130,7 @@
                   model-type="yyyy-MM-dd"
                   month-picker
                   auto-apply
+                  :disabled="reportStatus === 'Published'"
                   format="MMMM yyyy"
                   placeholder="End Date"
                   input-class-name="datepicker-input"
@@ -494,6 +496,7 @@ export default {
     submissionErrors: null as SubmissionErrors | null,
     draftReport: null,
     approvedRoute: null,
+    reportStatus: null,
   }),
   async beforeMount() {
     this.setStage('UPLOAD');
@@ -513,6 +516,7 @@ export default {
       this.startDate = this.reportData.report_start_date;
       this.endDate = this.reportData.report_end_date;
       this.dataConstraints = this.reportData.data_constraints;
+      this.reportStatus = this.reportData.report_status;
     }
   },
   methods: {
@@ -540,6 +544,7 @@ export default {
       this.isProcessing = true;
       try {
         const formData = new FormData();
+        formData.append('id', this.reportId);
         formData.append('companyName', this.companyName);
         formData.append('companyAddress', this.companyAddress);
         formData.append('naicsCode', this.naicsCode);
@@ -614,7 +619,12 @@ export default {
     ...mapState(useConfigStore, ['config']),
     ...mapState(useCodeStore, ['employeeCountRanges', 'naicsCodes']),
     ...mapState(authStore, ['userInfo']),
-    ...mapState(useReportStepperStore, ['reportId', 'reportData', 'mode']),
+    ...mapState(useReportStepperStore, [
+      'reportId',
+      'reportInfo',
+      'reportData',
+      'mode',
+    ]),
     dataReady() {
       return this.validForm && this.uploadFileValue;
     },

--- a/frontend/src/components/__tests__/Dashboard.spec.ts
+++ b/frontend/src/components/__tests__/Dashboard.spec.ts
@@ -4,13 +4,21 @@ import { render, waitFor, fireEvent } from '@testing-library/vue';
 import Dashboard from '../Dashboard.vue';
 import { createTestingPinia } from '@pinia/testing';
 import { authStore } from '../../store/modules/auth';
+import { useReportStepperStore } from '../../store/modules/reportStepper';
 
 const pinia = createTestingPinia();
+const mockRouterPush = vi.fn();
+const mockRouter = {
+  push: (...args) => mockRouterPush(...args),
+};
 
 const wrappedRender = async () => {
   return render(Dashboard, {
     global: {
       plugins: [pinia],
+      mocks: {
+        $router: mockRouter
+      }
     },
   });
 };
@@ -77,5 +85,25 @@ describe('Dashboard', () => {
 
     const viewReportButton = getByTestId('view-report-id1');
     await fireEvent.click(viewReportButton);
+  });
+  it('should open report in edit mode', async () => {
+    mockGetReports.mockReturnValue([
+      {
+        report_id: 'id1',
+        report_start_date: '2023-01-01',
+        report_end_date: '2023-02-01',
+        create_date: new Date().toISOString(),
+      },
+    ]);
+    const { getByTestId } = await wrappedRender();
+    await waitFor(() => {
+      expect(mockGetReports).toHaveBeenCalled();
+    });
+
+    const editReportButton = getByTestId('edit-report-id1');
+    await fireEvent.click(editReportButton);
+    expect(mockRouterPush).toHaveBeenCalledWith({
+      path: 'generate-report-form'
+    });
   });
 });


### PR DESCRIPTION

# Description

Adding the ability to edit a published report

Fixes # ([issue](https://finrms.atlassian.net/browse/GEO-133))

## Type of change

Please delete options that are not relevant.
- [ ] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
- [ ] Added unit tests
- [ ] Verify that clicking an edit button displays the input form, and that the form is populated with the report data
- [ ] Verify that you cannot edit the report period
- [ ] Verify that you can edit and save the report


## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have already been accepted and merged


## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


---
Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://pay-transparency-pr-292-frontend.apps.silver.devops.gov.bc.ca)