### PR TITLE
Make sure that max file upload size is always displayed in the input form

### DIFF
--- a/frontend/src/components/InputForm.vue
+++ b/frontend/src/components/InputForm.vue
@@ -404,6 +404,7 @@ import {
   DateTimeFormatter,
 } from '@js-joda/core';
 import { Locale } from '@js-joda/locale_en';
+import { IConfigValue } from '../common/types';
 
 interface LineErrors {
   lineNum: number;
@@ -502,7 +503,8 @@ export default {
     this.setStage('UPLOAD');
 
     try {
-      await this.loadConfig();
+      const data = await this.loadConfig();
+      this.setMaxFileUploadSize(data!);
     } catch (error) {
       NotificationService.pushNotificationError(
         'Failed to load application settings. Please reload the page.',
@@ -570,6 +572,14 @@ export default {
         this.setErrorAlert(error.response.data?.errors);
       }
     },
+    setMaxFileUploadSize(data: IConfigValue) {
+      if (data.maxUploadFileSize) {
+        this.maxFileUploadSize = humanFileSize(
+          data?.maxUploadFileSize || 8000000,
+          0,
+        );
+      }
+    },
   },
   watch: {
     naicsCodes(val) {
@@ -607,12 +617,7 @@ export default {
       },
     },
     config(data) {
-      if (data.maxUploadFileSize) {
-        this.maxFileUploadSize = humanFileSize(
-          data?.maxUploadFileSize || 8000000,
-          0,
-        );
-      }
+      this.setMaxFileUploadSize(data);
     },
   },
   computed: {

--- a/frontend/src/components/InputForm.vue
+++ b/frontend/src/components/InputForm.vue
@@ -504,7 +504,7 @@ export default {
 
     try {
       const data = await this.loadConfig();
-      this.setMaxFileUploadSize(data!);
+      this.setMaxFileUploadSize(data as IConfigValue);
     } catch (error) {
       NotificationService.pushNotificationError(
         'Failed to load application settings. Please reload the page.',

--- a/frontend/src/components/__tests__/Dashboard.spec.ts
+++ b/frontend/src/components/__tests__/Dashboard.spec.ts
@@ -101,6 +101,9 @@ describe('Dashboard', () => {
     });
 
     const editReportButton = getByTestId('edit-report-id1');
+    await waitFor(() => {
+      expect(editReportButton).toBeInTheDocument();
+    })
     await fireEvent.click(editReportButton);
     expect(mockRouterPush).toHaveBeenCalledWith({
       path: 'generate-report-form'

--- a/frontend/src/router.js
+++ b/frontend/src/router.js
@@ -116,6 +116,7 @@ router.beforeEach((to, _from, next) => {
 
   // requires authentication
   const aStore = authStore();
+
   aStore
     .getJwtToken()
     .then(() => {

--- a/frontend/src/store/modules/config.ts
+++ b/frontend/src/store/modules/config.ts
@@ -12,6 +12,8 @@ export const useConfigStore = defineStore('config', () => {
     const data = await ApiService.getConfig();
 
     config.value = data;
+
+    return data;
   }
 
   return { config, loadConfig };


### PR DESCRIPTION

# Description

Make sure that the max file upload size is always displayed in the input form
Fixes # (issue)

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
- [ ] Load the generate report form and verify the maximum upload file size is displayed


## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have already been accepted and merged


## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


---
Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://pay-transparency-pr-293-frontend.apps.silver.devops.gov.bc.ca)