### PR TITLE
fix: security issue: force axios 1.6.7 in a subdependency

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -2363,7 +2363,7 @@
     "node_modules/cldr-data-downloader/node_modules/axios": {
       "version": "1.6.7",
       "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.7.tgz",
-      "integrity": "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==",
+      "integrity": "sha512-/hDJGff6/c7u0hDkvkGxR/oy6CbCs8ziCsC7SqmhjfozqiJGc8Z11wrv9z9lYfY4K8l+H9TpjcMDX0xOZmx+RA==",
       "peer": true,
       "dependencies": {
         "follow-redirects": "^1.14.8"

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -2350,7 +2350,7 @@
       "integrity": "sha512-jskJncLkJlkBCdqdgzLSV9sOOLyEdeVOtwJOwVwRyliVJ+4822KZWvfaD620c9Lk7el3auwFDg92FXYjGA5BhQ==",
       "peer": true,
       "dependencies": {
-        "axios": "^0.26.0",
+        "axios": "^1.6.7",
         "mkdirp": "0.5.5",
         "nopt": "3.0.x",
         "q": "1.0.1",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -2168,7 +2168,7 @@
         "is-buffer": "^2.0.5"
       },
       "peerDependencies": {
-        "axios": ">= 0.17.0"
+        "axios": ">= 1.6.7"
       }
     },
     "node_modules/balanced-match": {
@@ -2361,8 +2361,8 @@
       }
     },
     "node_modules/cldr-data-downloader/node_modules/axios": {
-      "version": "0.26.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.26.1.tgz",
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.7.tgz",
       "integrity": "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==",
       "peer": true,
       "dependencies": {


### PR DESCRIPTION

# Description

Fixing security issue raised by dependabot caused by an old version of axios in some of our sub dependencies

Fixes # ([issue](https://finrms.atlassian.net/browse/GEO-397))

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Make sure the build passes

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have already been accepted and merged


## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


---
Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://pay-transparency-pr-301-frontend.apps.silver.devops.gov.bc.ca)