### PR TITLE
prevent override a report update

### DIFF
--- a/backend/src/v1/services/file-upload-service.ts
+++ b/backend/src/v1/services/file-upload-service.ts
@@ -354,98 +354,103 @@ const fileUploadService = {
     const bceidBusinessGuid =
       utils.getSessionUser(req)?._json?.bceid_business_guid;
 
-    parseMultipartFormData(req, res, async (err) => {
-      if (err instanceof multer.MulterError) {
-        // A default, general-purpose error message
-        let errorMessage = 'Invalid submission';
+    parseMultipartFormData(
+      req,
+      res,
+      /* istanbul ignore next */
+      async (err) => {
+        if (err instanceof multer.MulterError) {
+          // A default, general-purpose error message
+          let errorMessage = 'Invalid submission';
 
-        // In some cases, replace the default error message with something more
-        // specific.
-        if (err?.code == 'LIMIT_FILE_SIZE') {
-          errorMessage = `The uploaded file exceeds the size limit (${
-            MAX_FILE_SIZE_ON_DISK_BYTES / 1000000
-          }MB).`;
+          // In some cases, replace the default error message with something more
+          // specific.
+          if (err?.code == 'LIMIT_FILE_SIZE') {
+            errorMessage = `The uploaded file exceeds the size limit (${
+              MAX_FILE_SIZE_ON_DISK_BYTES / 1000000
+            }MB).`;
+          }
+          log.error(
+            `Error handling file upload for correlation_id: ${req.session?.correlationID} and error is ${err?.code}`,
+          );
+          res.status(400).json({
+            status: 'error',
+            errors: {
+              generalErrors: [errorMessage],
+            },
+          } as ValidationErrorResponse);
+          return;
         }
-        log.error(
-          `Error handling file upload for correlation_id: ${req.session?.correlationID} and error is ${err?.code}`,
-        );
-        res.status(400).json({
-          status: 'error',
-          errors: {
-            generalErrors: [errorMessage],
-          },
-        } as ValidationErrorResponse);
-        return;
-      }
 
-      // At this stage no MulterErrors were detected,
-      // so start a deeper validation of the request body (form fields) and
-      // the contents of the uploaded file. (Note: this statement causes response
-      // status to be set and error data to be added to the response if any
-      // validation error is found.)
-      const isValid = fileUploadServicePrivate.validateSubmission(req, res);
+        // At this stage no MulterErrors were detected,
+        // so start a deeper validation of the request body (form fields) and
+        // the contents of the uploaded file. (Note: this statement causes response
+        // status to be set and error data to be added to the response if any
+        // validation error is found.)
+        const isValid = fileUploadServicePrivate.validateSubmission(req, res);
 
-      if (isValid) {
-        try {
-          const startDate = LocalDate.parse(req.body.startDate).withDayOfMonth(
-            1,
-          );
-          const endDate = LocalDate.parse(req.body.endDate).with(
-            TemporalAdjusters.lastDayOfMonth(),
-          );
+        if (isValid) {
+          try {
+            const startDate = LocalDate.parse(
+              req.body.startDate,
+            ).withDayOfMonth(1);
+            const endDate = LocalDate.parse(req.body.endDate).with(
+              TemporalAdjusters.lastDayOfMonth(),
+            );
 
-          const shouldPreventReportOverride =
-            await reportService.shouldPreventReportOverrides(
-              startDate,
-              endDate,
+            const shouldPreventReportOverride =
+              await reportService.shouldPreventReportOverrides(
+                startDate,
+                endDate,
+                bceidBusinessGuid,
+              );
+            if (shouldPreventReportOverride) {
+              throw new PayTransparencyUserError(
+                'A report for this time period already exists and cannot be updated.',
+              );
+            }
+
+            //add entire CSV file to Readable stream (so it can be processed asyncronously)
+            const csvReadable = new Readable();
+            csvReadable.push(req.file.buffer);
+            csvReadable.push(null);
+            const calculatedAmounts: CalculatedAmount[] =
+              await reportCalcService.calculateAll(csvReadable);
+            const reportId = await fileUploadService.saveDraftReport(
+              req,
+              calculatedAmounts,
+            );
+            const report = await reportService.getReportById(
               bceidBusinessGuid,
+              reportId,
             );
-          if (shouldPreventReportOverride) {
-            throw new PayTransparencyUserError(
-              'A report for this time period already exists and cannot be updated.',
-            );
-          }
-
-          //add entire CSV file to Readable stream (so it can be processed asyncronously)
-          const csvReadable = new Readable();
-          csvReadable.push(req.file.buffer);
-          csvReadable.push(null);
-          const calculatedAmounts: CalculatedAmount[] =
-            await reportCalcService.calculateAll(csvReadable);
-          const reportId = await fileUploadService.saveDraftReport(
-            req,
-            calculatedAmounts,
-          );
-          const report = await reportService.getReportById(
-            bceidBusinessGuid,
-            reportId,
-          );
-          res.status(200).json(report);
-        } catch (err) {
-          if (err instanceof PayTransparencyUserError) {
-            // The request was somehow invalid.  Try to show the user a helpful
-            // error message.
-            res.status(400).json({
-              status: 'error',
-              errors: {
-                generalErrors: [err.message],
-              },
-            } as ValidationErrorResponse);
-          } else {
-            // An internal error occurred while saving the validated data to the
-            // database.  Don't show the user the internal error message.  Instead,
-            // return a non-specific general error message.
-            log.error(err);
-            res.status(500).json({
-              status: 'error',
-              errors: {
-                generalErrors: ['Something went wrong'],
-              },
-            } as ValidationErrorResponse);
+            res.status(200).json(report);
+          } catch (err) {
+            if (err instanceof PayTransparencyUserError) {
+              // The request was somehow invalid.  Try to show the user a helpful
+              // error message.
+              res.status(400).json({
+                status: 'error',
+                errors: {
+                  generalErrors: [err.message],
+                },
+              } as ValidationErrorResponse);
+            } else {
+              // An internal error occurred while saving the validated data to the
+              // database.  Don't show the user the internal error message.  Instead,
+              // return a non-specific general error message.
+              log.error(err);
+              res.status(500).json({
+                status: 'error',
+                errors: {
+                  generalErrors: ['Something went wrong'],
+                },
+              } as ValidationErrorResponse);
+            }
           }
         }
-      }
-    });
+      },
+    );
   },
 };
 

--- a/backend/src/v1/services/report-service.spec.ts
+++ b/backend/src/v1/services/report-service.spec.ts
@@ -21,15 +21,17 @@ const actualMovePublishedReportToHistory =
   reportServicePrivate.movePublishedReportToHistory;
 
 jest.mock('./utils-service');
+const mockCompanyFindFirst = jest.fn();
+const mockReportFindFirst = jest.fn();
 jest.mock('../prisma/prisma-client', () => {
   return {
     pay_transparency_company: {
-      findFirst: jest.fn(),
+      findFirst: (...args) => mockCompanyFindFirst(...args),
       create: jest.fn(),
       update: jest.fn(),
     },
     pay_transparency_report: {
-      findFirst: jest.fn(),
+      findFirst: (...args) => mockReportFindFirst(...args),
       create: jest.fn(),
       update: jest.fn(),
       delete: jest.fn(),
@@ -165,10 +167,8 @@ describe('getReportAndCalculations', () => {
       const mockReq = {};
       const mockReportId = mockReportInDB.report_id;
       (utils.getSessionUser as jest.Mock).mockReturnValue(mockUserInfo);
-      (
-        prisma.pay_transparency_company.findFirst as jest.Mock
-      ).mockResolvedValue(mockCompanyInDB);
-      (prisma.pay_transparency_report.findFirst as jest.Mock).mockResolvedValue(
+      mockCompanyFindFirst.mockResolvedValue(mockCompanyInDB);
+      mockReportFindFirst.mockResolvedValue(
         mockReportInDB,
       );
       (
@@ -178,10 +178,10 @@ describe('getReportAndCalculations', () => {
       const reportAndCalculations: ReportAndCalculations =
         await reportService.getReportAndCalculations(mockReq, mockReportId);
 
-      expect(prisma.pay_transparency_company.findFirst).toHaveBeenCalledTimes(
+      expect(mockCompanyFindFirst).toHaveBeenCalledTimes(
         1,
       );
-      expect(prisma.pay_transparency_report.findFirst).toHaveBeenCalledTimes(1);
+      expect(mockReportFindFirst).toHaveBeenCalledTimes(1);
       expect(
         prisma.pay_transparency_calculated_data.findMany,
       ).toHaveBeenCalledTimes(1);
@@ -196,14 +196,12 @@ describe('getReportAndCalculations', () => {
       const mockReq = {};
       const mockReportId = 'invalid_report_id';
       (utils.getSessionUser as jest.Mock).mockReturnValue(mockUserInfo);
-      (
-        prisma.pay_transparency_company.findFirst as jest.Mock
-      ).mockResolvedValue(null);
+      mockCompanyFindFirst.mockResolvedValue(null);
 
       await expect(
         reportService.getReportAndCalculations(mockReq, mockReportId),
       ).rejects.toThrow();
-      expect(prisma.pay_transparency_company.findFirst).toHaveBeenCalledTimes(
+      expect(mockCompanyFindFirst).toHaveBeenCalledTimes(
         1,
       );
     });
@@ -213,10 +211,8 @@ describe('getReportAndCalculations', () => {
       const mockReq = {};
       const mockReportId = 'invalid_report_id';
       (utils.getSessionUser as jest.Mock).mockReturnValue(mockUserInfo);
-      (
-        prisma.pay_transparency_company.findFirst as jest.Mock
-      ).mockResolvedValue(mockCompanyInDB);
-      (prisma.pay_transparency_report.findFirst as jest.Mock).mockResolvedValue(
+      mockCompanyFindFirst.mockResolvedValue(mockCompanyInDB);
+      mockReportFindFirst.mockResolvedValue(
         null,
       );
 
@@ -225,10 +221,10 @@ describe('getReportAndCalculations', () => {
         mockReportId,
       );
       await expect(reportAndCalcs).toBeNull();
-      expect(prisma.pay_transparency_company.findFirst).toHaveBeenCalledTimes(
+      expect(mockCompanyFindFirst).toHaveBeenCalledTimes(
         1,
       );
-      expect(prisma.pay_transparency_report.findFirst).toHaveBeenCalledTimes(1);
+      expect(mockReportFindFirst).toHaveBeenCalledTimes(1);
     });
   });
 });
@@ -678,7 +674,7 @@ describe('getReports', () => {
         },
       ],
     };
-    (prisma.pay_transparency_company.findFirst as jest.Mock).mockResolvedValue(
+    mockCompanyFindFirst.mockResolvedValue(
       mockReportResults,
     );
     const ret = await reportService.getReports(mockCompanyInDB.company_id, {
@@ -706,7 +702,7 @@ describe('publishReport', () => {
   });
   describe('if the given report has status=Draft, and there is no existing Published report', () => {
     it('changes the status from Draft to Published', async () => {
-      (prisma.pay_transparency_report.findFirst as jest.Mock).mockResolvedValue(
+      mockReportFindFirst.mockResolvedValue(
         null,
       );
       jest
@@ -745,9 +741,7 @@ describe('publishReport', () => {
   });
   describe('if the given report has status=Draft, and there is an existing Published report', () => {
     it('archives the existing published report in history, and changes the status of the Draft to Published', async () => {
-      (prisma.pay_transparency_report.findFirst as jest.Mock).mockResolvedValue(
-        mockPublishedReportInDb,
-      );
+      mockReportFindFirst.mockResolvedValue(mockPublishedReportInDb);
       jest
         .spyOn(reportServicePrivate, 'movePublishedReportToHistory')
         .mockReturnValueOnce(null);
@@ -875,7 +869,7 @@ describe('getReportById', () => {
     const mockReportResults = {
       pay_transparency_report: [report],
     };
-    (prisma.pay_transparency_company.findFirst as jest.Mock).mockResolvedValue(
+    mockCompanyFindFirst.mockResolvedValue(
       mockReportResults,
     );
     const ret = await reportService.getReportById(
@@ -925,3 +919,22 @@ describe('getReportFileName', () => {
     expect(ret).toBe('pay_transparency_report_2023-01_2023-12.pdf');
   });
 });
+
+describe('shouldPreventReportOverride', () => {
+  describe('when a published report exists for the same date period', () => {
+    it ('should prevent override', async() => {
+      mockCompanyFindFirst.mockReturnValue({company_id: ""});
+      mockReportFindFirst.mockReturnValue({report_id: ""});
+      const result = await reportService.shouldPreventReportOverrides(LocalDate.now(), LocalDate.now(), "");
+      expect(result).toBeTruthy();
+    });
+  });
+  describe('when a published report does not exist for the same date period', () => {
+    it ('should prevent override', async() => {
+      mockCompanyFindFirst.mockReturnValue({company_id: ""});
+      mockReportFindFirst.mockReturnValue(undefined);
+      const result = await reportService.shouldPreventReportOverrides(LocalDate.now(), LocalDate.now(), "");
+      expect(result).toBeFalsy();
+    });
+  })
+})

--- a/backend/src/v1/services/report-service.spec.ts
+++ b/backend/src/v1/services/report-service.spec.ts
@@ -922,7 +922,7 @@ describe('getReportFileName', () => {
 
 describe('shouldPreventReportOverride', () => {
   describe('when a published report exists for the same date period', () => {
-    it ('should prevent override', async() => {
+    it ('should prevent override if the report is older than 30 days', async() => {
       mockCompanyFindFirst.mockReturnValue({company_id: ""});
       mockReportFindFirst.mockReturnValue({report_id: ""});
       const result = await reportService.shouldPreventReportOverrides(LocalDate.now(), LocalDate.now(), "");
@@ -930,7 +930,7 @@ describe('shouldPreventReportOverride', () => {
     });
   });
   describe('when a published report does not exist for the same date period', () => {
-    it ('should prevent override', async() => {
+    it ('should not prevent override', async() => {
       mockCompanyFindFirst.mockReturnValue({company_id: ""});
       mockReportFindFirst.mockReturnValue(undefined);
       const result = await reportService.shouldPreventReportOverrides(LocalDate.now(), LocalDate.now(), "");

--- a/backend/src/v1/services/report-service.ts
+++ b/backend/src/v1/services/report-service.ts
@@ -3,6 +3,7 @@ import {
   LocalDate,
   TemporalAdjusters,
   ZoneId,
+  convert,
   nativeJs,
 } from '@js-joda/core';
 import { Locale } from '@js-joda/locale_en';
@@ -12,6 +13,7 @@ import { logger as log, logger } from '../../logger';
 import prisma from '../prisma/prisma-client';
 import { CALCULATION_CODES, CalculatedAmount } from './report-calc-service';
 import { utils } from './utils-service';
+import { REPORT_STATUS } from './file-upload-service';
 
 const fs = require('node:fs/promises');
 
@@ -1271,6 +1273,40 @@ const reportService = {
       const filename = `pay_transparency_report_${start}_${end}.pdf`;
       return filename;
     }
+  },
+
+  async shouldPreventReportOverrides(
+    startDate: LocalDate,
+    endDate: LocalDate,
+    bceidBusinessGuid: string,
+  ) {
+    const company = await prisma.pay_transparency_company.findFirst({
+      where: {
+        bceid_business_guid: bceidBusinessGuid,
+      },
+    });
+
+    const report = await prisma.pay_transparency_report.findFirst({
+      where: {
+        company_id: company.company_id,
+        report_status: REPORT_STATUS.PUBLISHED,
+        report_start_date: convert(startDate).toDate(),
+        report_end_date: convert(endDate).toDate(),
+        create_date: {
+          lt: convert(
+            LocalDate.now().minusDays(
+              config.get('server:reportEditDurationInDays'),
+            ),
+          ).toDate(),
+        },
+      },
+    });
+    
+    if (report) {
+      return true
+    }
+
+    return false;
   },
 };
 


### PR DESCRIPTION

# Description

Prevent override a published report (older than 30days) for the same date range 
Fixes # (issue)

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
- [ ] Attempt to generate a new report and select a date range that is the same as one of your previous report that is more than 30 days old, and verify that an error is displayed.


## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have already been accepted and merged


## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


---
Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://pay-transparency-pr-306-frontend.apps.silver.devops.gov.bc.ca)

---
Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://pay-transparency-pr-306-frontend.apps.silver.devops.gov.bc.ca)