### PR TITLE
adding date docs, and validations, returning informative errors

### DIFF
--- a/backend/src/v1/routes/external-consumer-routes.spec.ts
+++ b/backend/src/v1/routes/external-consumer-routes.spec.ts
@@ -132,11 +132,16 @@ describe('external-consumer-routes', () => {
       return request(app)
         .get('')
         .query({ page: 'one', pageSize: '1oooo' })
-        .expect(400);
+        .expect(400)
+        .expect(({ body }) => {
+          expect(body).toEqual({
+            error: 'Invalid offset or limit',
+          });
+        });
     });
     it('should fail if request fails to get reports', () => {
       mockFindMany.mockRejectedValue({});
-      return request(app).get('').expect(500);
+      return request(app).get('').expect(200);
     });
   });
 });

--- a/backend/src/v1/routes/external-consumer-routes.ts
+++ b/backend/src/v1/routes/external-consumer-routes.ts
@@ -23,7 +23,7 @@ router.get(
       );
       res.status(200).json(results);
     } catch (e) {
-      res.status(500).json({ error: e.message });
+      res.json({error: true, message: e.message });
     }
   }),
 );

--- a/backend/src/v1/services/external-consumer-service.spec.ts
+++ b/backend/src/v1/services/external-consumer-service.spec.ts
@@ -115,7 +115,18 @@ describe('external-consumer-service', () => {
     try {
         await externalConsumerService.exportDataWithPagination("20241-01-01", '20241-01-01', -1, -1);
     } catch (error) {
-        expect(error.message).toBe('Failed to parse dates.')
+        expect(error.message).toBe(
+          'Failed to parse dates. Please use date format YYYY-MM-dd',
+        );
+    }
+  });
+  it('should fail when endDate is before the startDate', async () => {
+    mockCount.mockReturnValue(1);
+    mockFindMany.mockReturnValue([testData]);
+    try {
+        await externalConsumerService.exportDataWithPagination("2024-01-01", '2023-01-01', -1, -1);
+    } catch (error) {
+        expect(error.message).toBe('Start date must be before the end date.');
     }
   });
 });

--- a/backend/src/v1/services/scheduler-service.spec.ts
+++ b/backend/src/v1/services/scheduler-service.spec.ts
@@ -67,7 +67,7 @@ describe('deleteDraftReports', () => {
     const call = (prisma.pay_transparency_report.findMany as jest.Mock).mock
       .calls[0][0];
     const callDate = LocalDateTime.from(
-      nativeJs(new Date(call.where.create_date.lte)),
+      nativeJs(new Date(call.where.create_date.lte), ZoneId.UTC),
     )
       .toLocalDate()
       .toString();


### PR DESCRIPTION
# Description

Enhancing the swagger ui by adding params documentations and better error handling
Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [ ] Check if the start date and end date have enough docu
<img width="1428" alt="Screenshot 2024-03-18 at 5 26 54 PM" src="https://github.com/bcgov/fin-pay-transparency/assets/4842061/dce86294-8380-4afd-aec6-db4d3fdd0699">


- [ ] Set the an invalid start date or end date and verify that a 400 error is returned
- [ ] Set the endDate to be before the startDate and verify that a 400 error is returned
- [ ] verify that only Published reports are returned

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have already been accepted and merged


## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


---
Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://pay-transparency-pr-317-frontend.apps.silver.devops.gov.bc.ca)