### PR TITLE
feat(database)!: changes for supporting crunchy disaster recovery

### DIFF
--- a/charts/fin-pay-transparency/charts/crunchy-postgres/templates/PostgresCluster.yaml
+++ b/charts/fin-pay-transparency/charts/crunchy-postgres/templates/PostgresCluster.yaml
@@ -16,7 +16,23 @@ spec:
   postGISVersion: {{ .Values.postGISVersion | quote }}
   {{ end }}
   postgresVersion: {{ .Values.postgresVersion }}
-
+  {{- if and .Values.clone .Values.clone.enabled }} # enabled in disaster recovery scenario
+  dataSource:
+    pgbackrest:
+      stanza: {{ .Values.instances.name }}
+      configuration:
+        - secret:
+            name: {{ .Release.Name }}-s3-secret
+      global:
+        repo1-s3-uri-style: path # This is mandatory since the backups are path based.
+        repo1-path: {{ .Values.clone.path }} # path to the backup where cluster will bootstrap from
+      repo:
+        name: repo1 # hardcoded since it is always backed up to object storage.
+        s3:
+          bucket: {{ .Values.pgBackRest.s3.bucket }}
+          endpoint: {{ .Values.pgBackRest.s3.endpoint }}
+          region: "ca-central-1"
+  {{- end}}
   {{ if .Values.pgmonitor.enabled }}
 
   monitoring:
@@ -96,12 +112,12 @@ spec:
         - secret:
             name: {{ .Release.Name }}-s3-secret
       global:
-        repo2-retention-full: {{ .Values.pgBackRest.s3.retention | quote }}
-        repo2-retention-full-type: {{ .Values.pgBackRest.retentionFullType }}
-        repo2-path: '/crunchy-db-backups'
-        repo2-s3-uri-style: path
+        repo1-retention-full: {{ .Values.pgBackRest.s3.retention | quote }}
+        repo1-retention-full-type: {{ .Values.pgBackRest.retentionFullType }}
+        repo1-path: '{{ .Values.pgBackRest.backupPath }}{{ .Values.pgBackRest.clusterCounter}}'
+        repo1-s3-uri-style: path
       repos:
-        - name: repo2
+        - name: repo1
           schedules:
             full: {{ .Values.pgBackRest.s3.fullBackupSchedule }}
             incremental: {{ .Values.pgBackRest.s3.incrementalBackupSchedule }}
@@ -109,6 +125,14 @@ spec:
             bucket: {{ .Values.pgBackRest.s3.bucket }}
             endpoint: {{ .Values.pgBackRest.s3.endpoint }}
             region: "ca-central-1"
+      {{- if and .Values.restore .Values.restore.enabled }}
+      restore:
+        enabled: {{ .Values.restore.enabled }}
+        repoName: repo1
+        options:
+          - --type=time
+          - --target="{{ .Values.restore.target }}"
+      {{- end }}
       # this stuff is for the "pgbackrest" container (the only non-init container) in the "postgres-crunchy-repo-host" pod
       repoHost:
         resources:
@@ -136,6 +160,14 @@ spec:
             limits:
               cpu: {{ .Values.pgBackRest.sidecars.limits.cpu }}
               memory: {{ .Values.pgBackRest.sidecars.limits.memory }}
+      jobs:
+        resources:
+          requests:
+            cpu: {{ .Values.pgBackRest.sidecars.requests.cpu }}
+            memory: {{ .Values.pgBackRest.sidecars.requests.memory }}
+          limits:
+            cpu: {{ .Values.pgBackRest.sidecars.limits.cpu }}
+            memory: {{ .Values.pgBackRest.sidecars.limits.memory }}
 
   patroni:
     dynamicConfiguration:
@@ -148,7 +180,7 @@ spec:
           min_wal_size: {{ .Values.patroni.postgresql.parameters.min_wal_size }}
           max_wal_size: {{ .Values.patroni.postgresql.parameters.max_wal_size }}
           max_slot_wal_keep_size:  {{ .Values.patroni.postgresql.parameters.max_slot_wal_keep_size }}
-  {{- if and .Values.proxy .Values.proxy.enabled }}}
+  {{- if and .Values.proxy .Values.proxy.enabled }}
   proxy:
     pgBouncer:
       config:

--- a/charts/fin-pay-transparency/charts/crunchy-postgres/templates/_helpers.tpl
+++ b/charts/fin-pay-transparency/charts/crunchy-postgres/templates/_helpers.tpl
@@ -62,6 +62,6 @@ Create the name of the service account to use
 {{- end }}
 {{- define "crunchy.s3" }}
 [global]
-repo2-s3-key={{ .Values.pgBackRest.s3.accessKey }}
-repo2-s3-key-secret={{ .Values.pgBackRest.s3.secretKey }}
+repo1-s3-key={{ .Values.pgBackRest.s3.accessKey }}
+repo1-s3-key-secret={{ .Values.pgBackRest.s3.secretKey }}
 {{ end }}

--- a/charts/fin-pay-transparency/values-dev.yaml
+++ b/charts/fin-pay-transparency/values-dev.yaml
@@ -141,15 +141,30 @@ crunchy:
   enabled: true
   postgresVersion: 15
   imagePullPolicy: IfNotPresent
+  # enable below to start a new crunchy cluster after disaster from a backed-up location, crunchy will choose the best place to recover from.
+  # follow https://access.crunchydata.com/documentation/postgres-operator/5.2.0/tutorial/disaster-recovery/
+  # Clone From Backups Stored in S3 / GCS / Azure Blob Storage
+  # TESTED SUCCESSFULLY
+  clone:
+    enabled: false
+    path: ~ # provide the proper path to source the cluster. ex: /backups/cluster/version/1, if current new cluster being created, this should be current cluster version -1, ideally
+  # enable this to go back to a specific timestamp in history in the current cluster.
+  # follow https://access.crunchydata.com/documentation/postgres-operator/5.2.0/tutorial/disaster-recovery/
+  # Perform an In-Place Point-in-time-Recovery (PITR)
+  # need to fire this command `oc annotate postgrescluster pay-transparency-tools-crunchy --overwrite postgres-operator.crunchydata.com/pgbackrest-restore=repo1`
+  # NOT TESTED SUCCESSFULLY
+  restore:
+    enabled: false
+    target: ~ # 2024-03-24 17:16:00-07 this is the target timestamp to go back to in current cluster
   instances:
     name: db
     metadata:
       annotations:
         prometheus.io/scrape: "true"
         prometheus.io/port: "9187"
-    replicas: 2
+    replicas: 3
     dataVolumeClaimSpec:
-      storage: 960Mi
+      storage: 500Mi
       storageClassName: netapp-block-standard
     requests:
       cpu: 50m
@@ -166,6 +181,8 @@ crunchy:
         memory: 32Mi
 
   pgBackRest:
+    backupPath: /backups/cluster/version
+    clusterCounter: 1 # this is the number to identify what is the current counter for the cluster, each time it is cloned it should be incremented.
     image: # it's not necessary to specify an image as the images specified in the Crunchy Postgres Operator will be pulled by default
     retention: "2" # Ideally a larger number such as 30 backups/days
     # If retention-full-type set to 'count' then the oldest backups will expire when the number of backups reach the number defined in retention

--- a/charts/fin-pay-transparency/values-prod.yaml
+++ b/charts/fin-pay-transparency/values-prod.yaml
@@ -51,17 +51,17 @@ backend:
     targetPort: 3000
   resources:
     limits:
-      cpu: 150m
+      cpu: 200m
       memory: 250Mi
     requests:
-      cpu: 50m
+      cpu: 30m
       memory: 100Mi
   initResources:
     limits:
-      cpu: 150m
+      cpu: 200m
       memory: 250Mi
     requests:
-      cpu: 50m
+      cpu: 30m
       memory: 100Mi
 
   autoscaling:
@@ -141,6 +141,21 @@ crunchy:
   enabled: true
   postgresVersion: 15
   imagePullPolicy: IfNotPresent
+  # enable below to start a new crunchy cluster after disaster from a backed-up location, crunchy will choose the best place to recover from.
+  # follow https://access.crunchydata.com/documentation/postgres-operator/5.2.0/tutorial/disaster-recovery/
+  # Clone From Backups Stored in S3 / GCS / Azure Blob Storage
+  # TESTED SUCCESSFULLY
+  clone:
+    enabled: false
+    path: ~ # provide the proper path to source the cluster. ex: /backups/cluster/version/1, if current new cluster being created, this should be current cluster version -1, ideally
+  # enable this to go back to a specific timestamp in history in the current cluster.
+  # follow https://access.crunchydata.com/documentation/postgres-operator/5.2.0/tutorial/disaster-recovery/
+  # Perform an In-Place Point-in-time-Recovery (PITR)
+  # need to fire this command `oc annotate postgrescluster pay-transparency-tools-crunchy --overwrite postgres-operator.crunchydata.com/pgbackrest-restore=repo1`
+  # NOT TESTED SUCCESSFULLY
+  restore:
+    enabled: false
+    target: ~ # 2024-03-24 17:16:00-07 this is the target timestamp to go back to in current cluster
   instances:
     name: db
     metadata:
@@ -166,6 +181,8 @@ crunchy:
         memory: 32Mi
 
   pgBackRest:
+    backupPath: /backups/cluster/version
+    clusterCounter: 1 # this is the number to identify what is the current counter for the cluster, each time it is cloned it should be incremented.
     image: # it's not necessary to specify an image as the images specified in the Crunchy Postgres Operator will be pulled by default
     # If retention-full-type set to 'count' then the oldest backups will expire when the number of backups reach the number defined in retention
     # If retention-full-type set to 'time' then the number defined in retention will take that many days worth of full backups before expiration
@@ -252,7 +269,7 @@ doc-gen-service:
     targetPort: 3000
   resources:
     limits:
-      cpu: 600m
+      cpu: 650m
       memory: 350Mi
     requests:
       cpu: 100m
@@ -271,7 +288,7 @@ doc-gen-service:
 backend-external:
   enabled: true
   deploymentStrategy: Recreate
-  replicaCount: 1
+  replicaCount: 2
   nameOverride: ""
   fullnameOverride: ""
   image:

--- a/charts/fin-pay-transparency/values-test.yaml
+++ b/charts/fin-pay-transparency/values-test.yaml
@@ -141,6 +141,21 @@ crunchy:
   enabled: true
   postgresVersion: 15
   imagePullPolicy: IfNotPresent
+  # enable below to start a new crunchy cluster after disaster from a backed-up location, crunchy will choose the best place to recover from.
+  # follow https://access.crunchydata.com/documentation/postgres-operator/5.2.0/tutorial/disaster-recovery/
+  # Clone From Backups Stored in S3 / GCS / Azure Blob Storage
+  # TESTED SUCCESSFULLY
+  clone:
+    enabled: false
+    path: ~ # provide the proper path to source the cluster. ex: /backups/cluster/version/1, if current new cluster being created, this should be current cluster version -1, ideally
+  # enable this to go back to a specific timestamp in history in the current cluster.
+  # follow https://access.crunchydata.com/documentation/postgres-operator/5.2.0/tutorial/disaster-recovery/
+  # Perform an In-Place Point-in-time-Recovery (PITR)
+  # need to fire this command `oc annotate postgrescluster pay-transparency-tools-crunchy --overwrite postgres-operator.crunchydata.com/pgbackrest-restore=repo1`
+  # NOT TESTED SUCCESSFULLY
+  restore:
+    enabled: false
+    target: ~ # 2024-03-24 17:16:00-07 this is the target timestamp to go back to in current cluster
   instances:
     name: db
     metadata:
@@ -166,6 +181,8 @@ crunchy:
         memory: 32Mi
 
   pgBackRest:
+    backupPath: /backups/cluster/version
+    clusterCounter: 1 # this is the number to identify what is the current counter for the cluster, each time it is cloned it should be incremented.
     image: # it's not necessary to specify an image as the images specified in the Crunchy Postgres Operator will be pulled by default
     # If retention-full-type set to 'count' then the oldest backups will expire when the number of backups reach the number defined in retention
     # If retention-full-type set to 'time' then the number defined in retention will take that many days worth of full backups before expiration
@@ -235,7 +252,7 @@ crunchy:
         memory: 32Mi
 doc-gen-service:
   enabled: true
-  deploymentStrategy: RollingUpdate
+  deploymentStrategy: Recreate
   replicaCount: 2
   nameOverride: ""
   fullnameOverride: ""

--- a/charts/fin-pay-transparency/values.yaml
+++ b/charts/fin-pay-transparency/values.yaml
@@ -141,15 +141,30 @@ crunchy:
   enabled: true
   postgresVersion: 15
   imagePullPolicy: IfNotPresent
+  # enable below to start a new crunchy cluster after disaster from a backed-up location, crunchy will choose the best place to recover from.
+  # follow https://access.crunchydata.com/documentation/postgres-operator/5.2.0/tutorial/disaster-recovery/
+  # Clone From Backups Stored in S3 / GCS / Azure Blob Storage
+  # TESTED SUCCESSFULLY
+  clone:
+    enabled: false
+    path: ~ # provide the proper path to source the cluster. ex: /backups/cluster/version/1, if current new cluster being created, this should be current cluster version -1, ideally
+  # enable this to go back to a specific timestamp in history in the current cluster.
+  # follow https://access.crunchydata.com/documentation/postgres-operator/5.2.0/tutorial/disaster-recovery/
+  # Perform an In-Place Point-in-time-Recovery (PITR)
+  # need to fire this command `oc annotate postgrescluster pay-transparency-tools-crunchy --overwrite postgres-operator.crunchydata.com/pgbackrest-restore=repo1`
+  # NOT TESTED SUCCESSFULLY
+  restore:
+    enabled: false
+    target: ~ # 2024-03-24 17:16:00-07 this is the target timestamp to go back to in current cluster
   instances:
     name: db
     metadata:
       annotations:
         prometheus.io/scrape: "true"
         prometheus.io/port: "9187"
-    replicas: 2
+    replicas: 3
     dataVolumeClaimSpec:
-      storage: 750Mi
+      storage: 500Mi
       storageClassName: netapp-block-standard
     requests:
       cpu: 50m
@@ -166,8 +181,9 @@ crunchy:
         memory: 32Mi
 
   pgBackRest:
+    backupPath: /backups/cluster/version
+    clusterCounter: 1 # this is the number to identify what is the current counter for the cluster, each time it is cloned it should be incremented.
     image: # it's not necessary to specify an image as the images specified in the Crunchy Postgres Operator will be pulled by default
-    retention: "2" # Ideally a larger number such as 30 backups/days
     # If retention-full-type set to 'count' then the oldest backups will expire when the number of backups reach the number defined in retention
     # If retention-full-type set to 'time' then the number defined in retention will take that many days worth of full backups before expiration
     retentionFullType: count
@@ -178,17 +194,7 @@ crunchy:
       accessKey: ~
       secretKey: ~
       fullBackupSchedule: 0 9 * * *
-      incrementalBackupSchedule: "0 0,1,3,5,7,11,13,15,17,19,21,23 * * *" # every 2 hours, but 9 is not put intentionally to avoid conflict with full backup
-    repos:
-      schedules:
-        #-- full backup occurs every midnight PST which is 8am UTC
-        full: 0 8 * * *
-        #-- every 4 hours, but 8 is not put intentionally to avoid conflict with full backup
-        incremental: 0 0,4,12,16,20 * * *
-      volume:
-        accessModes: "ReadWriteOnce"
-        storage: 128Mi
-        storageClassName: netapp-file-backup
+      incrementalBackupSchedule: "0 0,4,8,12,16 * * *" # every 4 hours, but 9 is not put intentionally to avoid conflict with full backup
     config:
       requests:
         cpu: 5m
@@ -263,7 +269,7 @@ doc-gen-service:
     targetPort: 3000
   resources:
     limits:
-      cpu: 600m
+      cpu: 650m
       memory: 350Mi
     requests:
       cpu: 100m


### PR DESCRIPTION
BREAKING CHANGE: changes to backup path in object storage, and making object storage as primary repo for pgbackrest, `repo1`