### PR TITLE
fix: handle-lock-in-scheduler-as-when-it-unlocks-all-the-pods-are-executing-the-function-geo-456

### DIFF
--- a/backend/src/schedulers/delete-draft-service-scheduler.ts
+++ b/backend/src/schedulers/delete-draft-service-scheduler.ts
@@ -15,11 +15,13 @@ try {
     crontime, // cronTime
     async function () {
       try {
-        await mutex.withLock(async () => {
+        const unlock = await mutex.tryLock();
+        if (unlock) {
           log.info('Starting deleteDraftReports Schedule Job.');
           await schedulerService.deleteDraftReports();
           log.info('deleteDraftReports Schedule Job completed.');
-        });
+          await unlock();
+        }
       } catch (e) {
         log.error('Error in deleteDraftReports.');
         log.error(e);


### PR DESCRIPTION
Changed to use 'trylock' instead of 'withlock'.

https://finrms.atlassian.net/browse/GEO-456

---
Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://pay-transparency-pr-338-frontend.apps.silver.devops.gov.bc.ca)