### PR TITLE
fix: geo 387 input form calendar change allow up to two previous years from current date

### DIFF
--- a/backend/src/constants/index.ts
+++ b/backend/src/constants/index.ts
@@ -1,6 +1,21 @@
+import { DateTimeFormatter } from "@js-joda/core";
+import { Locale } from "@js-joda/locale_en";
+
 export const MISSING_COMPANY_DETAILS_ERROR = 'Missing company details';
 export const MISSING_TOKENS_ERROR = 'Token or refresh token cannot be found';
 export const MISSING_BUSINESS_GUID_ERROR = 'Business GUID not found';
 export const REPORT_NOT_FOUND_ERROR = 'Report not found';
 export const REPORT_STATUS_NOT_VALID_ERROR = 'Report status not valid';
 export const BAD_REQUEST = 'Bad request, the information provided is not i=enough or invalid';
+
+export const JSON_REPORT_DATE_FORMAT = DateTimeFormatter.ofPattern(
+  'YYYY-MM-dd',
+).withLocale(Locale.ENGLISH);
+
+// Define how report dates should be formatted for different
+export const DISPLAY_REPORT_DATE_FORMAT = DateTimeFormatter.ofPattern(
+  'MMMM d, YYYY',
+).withLocale(Locale.ENGLISH);
+export const FILENAME_REPORT_DATE_FORMAT = DateTimeFormatter.ofPattern(
+  'YYYY-MM',
+).withLocale(Locale.ENGLISH);

--- a/backend/src/v1/services/report-calc-service.ts
+++ b/backend/src/v1/services/report-calc-service.ts
@@ -110,7 +110,11 @@ accessed as follows:
   const medianBonusPayFemale = bonusPayStats.getMedian("female");
 */
 class GroupedColumnStats {
-  static readonly REF_CATEGORY_PREFERENCE = [['M'], ['U'], ['X']];
+  static readonly REF_CATEGORY_PREFERENCE = [
+    GENDER_CODES.MALE,
+    GENDER_CODES.UNKNOWN,
+    GENDER_CODES.NON_BINARY,
+  ];
 
   dataByCategoryKey: any;
   sumByCategoryKey: any;

--- a/backend/src/v1/services/report-calc-service.ts
+++ b/backend/src/v1/services/report-calc-service.ts
@@ -110,11 +110,7 @@ accessed as follows:
   const medianBonusPayFemale = bonusPayStats.getMedian("female");
 */
 class GroupedColumnStats {
-  static readonly REF_CATEGORY_PREFERENCE = [
-    GENDER_CODES.MALE,
-    GENDER_CODES.UNKNOWN,
-    GENDER_CODES.NON_BINARY,
-  ];
+  static readonly REF_CATEGORY_PREFERENCE = [['M'], ['U'], ['X']];
 
   dataByCategoryKey: any;
   sumByCategoryKey: any;

--- a/backend/src/v1/services/report-service.spec.ts
+++ b/backend/src/v1/services/report-service.spec.ts
@@ -12,10 +12,8 @@ import prisma from '../prisma/prisma-client';
 import { CALCULATION_CODES } from './report-calc-service';
 import {
   CalcCodeGenderCode,
-  DISPLAY_REPORT_DATE_FORMAT,
   GENDERS,
   GenderChartInfo,
-  JSON_REPORT_DATE_FORMAT,
   Report,
   ReportAndCalculations,
   enumReportStatus,
@@ -23,6 +21,7 @@ import {
   reportServicePrivate,
 } from './report-service';
 import { utils } from './utils-service';
+import { DISPLAY_REPORT_DATE_FORMAT, JSON_REPORT_DATE_FORMAT } from '../../constants';
 
 const actualMovePublishedReportToHistory =
   reportServicePrivate.movePublishedReportToHistory;

--- a/backend/src/v1/services/report-service.ts
+++ b/backend/src/v1/services/report-service.ts
@@ -5,7 +5,6 @@ import {
   convert,
   nativeJs,
 } from '@js-joda/core';
-import { Locale } from '@js-joda/locale_en';
 import type { pay_transparency_report } from '@prisma/client';
 import { config } from '../../config';
 import { logger as log, logger } from '../../logger';

--- a/backend/src/v1/services/report-service.ts
+++ b/backend/src/v1/services/report-service.ts
@@ -1,5 +1,4 @@
 import {
-  DateTimeFormatter,
   LocalDate,
   TemporalAdjusters,
   ZoneId,
@@ -14,8 +13,7 @@ import prisma from '../prisma/prisma-client';
 import { REPORT_STATUS } from './file-upload-service';
 import { CALCULATION_CODES, CalculatedAmount } from './report-calc-service';
 import { utils } from './utils-service';
-
-const fs = require('node:fs/promises');
+import { JSON_REPORT_DATE_FORMAT, DISPLAY_REPORT_DATE_FORMAT, FILENAME_REPORT_DATE_FORMAT } from '../../constants';
 
 const GENERIC_CHART_SUPPRESSED_MSG =
   'This measure cannot be displayed because there is insufficient data to meet disclosure requirements.';
@@ -87,16 +85,7 @@ const GENDERS = {
   } as GenderChartInfo,
 };
 
-// Define how report dates should be formatted for different
-const JSON_REPORT_DATE_FORMAT = DateTimeFormatter.ofPattern(
-  'YYYY-MM-dd',
-).withLocale(Locale.ENGLISH);
-const DISPLAY_REPORT_DATE_FORMAT = DateTimeFormatter.ofPattern(
-  'MMMM d, YYYY',
-).withLocale(Locale.ENGLISH);
-const FILENAME_REPORT_DATE_FORMAT = DateTimeFormatter.ofPattern(
-  'YYYY-MM',
-).withLocale(Locale.ENGLISH);
+
 
 const reportServicePrivate = {
   /*
@@ -1313,10 +1302,8 @@ const reportService = {
 
 export {
   CalcCodeGenderCode,
-  DISPLAY_REPORT_DATE_FORMAT,
   GENDERS,
   GenderChartInfo,
-  JSON_REPORT_DATE_FORMAT,
   Report,
   ReportAndCalculations,
   enumReportStatus,

--- a/backend/src/v1/services/validate-service.spec.ts
+++ b/backend/src/v1/services/validate-service.spec.ts
@@ -1,4 +1,4 @@
-import { LocalDate, TemporalAdjusters } from '@js-joda/core';
+import { DateTimeFormatter, LocalDate, TemporalAdjusters } from '@js-joda/core';
 import {
   FIELD_DATA_CONSTRAINTS,
   GENDER_CODES,
@@ -8,7 +8,8 @@ import {
   validateService,
   ValidationError,
 } from './validate-service';
-import { JSON_REPORT_DATE_FORMAT } from './report-service';
+import { Locale } from '@js-joda/locale_en';
+import { JSON_REPORT_DATE_FORMAT } from '../../constants';
 
 // ----------------------------------------------------------------------------
 // Helper functions
@@ -184,740 +185,771 @@ const mockValidSubmission = {
 // ----------------------------------------------------------------------------
 // Tests
 // ----------------------------------------------------------------------------
-
-describe('cleanRow', () => {
-  describe('given an array of strings', () => {
-    it('removes leading and trailing whitespace for each element', () => {
-      const row = [' A ', 'B ', ' C', 'D'];
-      const result = validateService.cleanRow(row);
-      expect(result).toStrictEqual(row.map((d) => (d ? d.trim() : '')));
-    });
-  });
-});
-
-describe('standardizeGenderCode', () => {
-  it('converts the given gender code into its standardized form', () => {
-    const standardized1 = validateService.standardizeGenderCode(
-      GENDER_CODES.FEMALE[0],
-    );
-    const standardized2 = validateService.standardizeGenderCode(
-      GENDER_CODES.FEMALE[GENDER_CODES.FEMALE.length - 1],
-    );
-    expect(standardized1).not.toBeNull();
-    expect(standardized1).toBe(standardized2);
-  });
-});
-
-describe('isZeroSynonym', () => {
-  NO_DATA_VALUES.forEach((value) => {
-    describe(`given a value ('${value}') that should be treated as zero`, () => {
-      it('returns true', () => {
-        expect(validateService.isZeroSynonym(value)).toBeTruthy();
+describe('validate-service', () => {
+  describe('cleanRow', () => {
+    describe('given an array of strings', () => {
+      it('removes leading and trailing whitespace for each element', () => {
+        const row = [' A ', 'B ', ' C', 'D'];
+        const result = validateService.cleanRow(row);
+        expect(result).toStrictEqual(row.map((d) => (d ? d.trim() : '')));
       });
     });
   });
 
-  const nonZeroValues = ['999999999', '1919', '2029.20', '150.4', 'F', 'N/A'];
-  nonZeroValues.forEach((value) => {
-    describe(`given a value ('${value}') that should not be treated as zero`, () => {
-      it('returns false', () => {
-        expect(validateService.isZeroSynonym(value)).toBeFalsy();
-      });
-    });
-  });
-});
-
-describe('validateSubmissionBody', () => {
-  const validSubmission = {
-    companyName: 'Fake Company Name',
-    companyAddress: '1200 Fake St.',
-    naicsCode: '11',
-    employeeCountRangeId: 'enmployeeRangeCountId',
-    startDate: '2022-12-01',
-    endDate: '2023-11-01',
-    dataConstraints: 'data constraints',
-    comments: 'other comments',
-    rows: [] as any[],
-  };
-
-  describe(`given data constraints that exceed the maximum length`, () => {
-    it('returns an error message', () => {
-      const dataConstraintsTooLong = 'a'.repeat(MAX_LEN_DATA_CONSTRAINTS + 1);
-      const invalidSubmission = Object.assign({}, validSubmission, {
-        dataConstraints: dataConstraintsTooLong,
-      });
-      const result: ValidationError | null =
-        validateService.validateSubmissionBody(invalidSubmission);
-      expect(
-        doesAnyStringContainAll(result.bodyErrors, [
-          FIELD_DATA_CONSTRAINTS,
-          MAX_LEN_DATA_CONSTRAINTS + '',
-        ]),
-      ).toBeTruthy();
-    });
-  });
-
-  describe(`given valid data constraints`, () => {
-    it('returns no error messages related to data constraints', () => {
-      const dataConstraintsTooLong = 'a'.repeat(MAX_LEN_DATA_CONSTRAINTS);
-      const invalidSubmission = Object.assign({}, validSubmission, {
-        dataConstraints: dataConstraintsTooLong,
-      });
-      const result: ValidationError | null =
-        validateService.validateSubmissionBody(invalidSubmission);
-      expect(
-        doesAnyStringContainAll(result?.bodyErrors, [
-          FIELD_DATA_CONSTRAINTS,
-          MAX_LEN_DATA_CONSTRAINTS + '',
-        ]),
-      ).toBeFalsy();
-    });
-  });
-
-  describe('given a startDate before minimum start date', () => {
-    it('should return error', () => {
-      const startDate = LocalDate.now()
-        .minusYears(3)
-        .format(JSON_REPORT_DATE_FORMAT);
-      const errors = validateService.validateSubmissionBody({
-        ...(validSubmission as any),
-        startDate,
-      });
-
-      const minStartTime = LocalDate.now()
-        .with(TemporalAdjusters.firstDayOfYear())
-        .minusYears(2)
-        .with(TemporalAdjusters.firstDayOfMonth())
-        .format(JSON_REPORT_DATE_FORMAT);
-
-      expect(errors.bodyErrors).toContain(
-        `Minimum allowed start date is ${minStartTime}`,
+  describe('standardizeGenderCode', () => {
+    it('converts the given gender code into its standardized form', () => {
+      const standardized1 = validateService.standardizeGenderCode(
+        GENDER_CODES.FEMALE[0],
       );
-    });
-  });
-  describe('given an endDate is after maximum end date', () => {
-    it('should return error', () => {
-      const startDate = LocalDate.now()
-        .minusYears(1)
-        .format(JSON_REPORT_DATE_FORMAT);
-      const endDate = LocalDate.now()
-        .plusYears(1)
-        .format(JSON_REPORT_DATE_FORMAT);
-      const errors = validateService.validateSubmissionBody({
-        ...(validSubmission as any),
-        startDate,
-        endDate,
-      });
-
-      const maxEndTime = LocalDate.now()
-        .minusMonths(1)
-        .with(TemporalAdjusters.lastDayOfMonth())
-        .format(JSON_REPORT_DATE_FORMAT);
-
-      expect(errors.bodyErrors).toContain(
-        `Maximum allowed end date is ${maxEndTime}`,
+      const standardized2 = validateService.standardizeGenderCode(
+        GENDER_CODES.FEMALE[GENDER_CODES.FEMALE.length - 1],
       );
+      expect(standardized1).not.toBeNull();
+      expect(standardized1).toBe(standardized2);
     });
   });
-});
 
-describe('validateSubmissionRowsHeader', () => {
-  describe(`given a valid header row`, () => {
-    it('returns null', () => {
-      const result: string | null =
-        validateService.validateSubmissionRowsHeader(
-          mockValidSubmission.rows[0],
+  describe('isZeroSynonym', () => {
+    NO_DATA_VALUES.forEach((value) => {
+      describe(`given a value ('${value}') that should be treated as zero`, () => {
+        it('returns true', () => {
+          expect(validateService.isZeroSynonym(value)).toBeTruthy();
+        });
+      });
+    });
+
+    const nonZeroValues = ['999999999', '1919', '2029.20', '150.4', 'F', 'N/A'];
+    nonZeroValues.forEach((value) => {
+      describe(`given a value ('${value}') that should not be treated as zero`, () => {
+        it('returns false', () => {
+          expect(validateService.isZeroSynonym(value)).toBeFalsy();
+        });
+      });
+    });
+  });
+
+  describe('validateSubmissionBody', () => {
+    const validSubmission = {
+      companyName: 'Fake Company Name',
+      companyAddress: '1200 Fake St.',
+      naicsCode: '11',
+      employeeCountRangeId: 'enmployeeRangeCountId',
+      startDate: '2022-12-01',
+      endDate: '2023-11-01',
+      dataConstraints: 'data constraints',
+      comments: 'other comments',
+      rows: [] as any[],
+    };
+
+    describe(`given data constraints that exceed the maximum length`, () => {
+      it('returns an error message', () => {
+        const dataConstraintsTooLong = 'a'.repeat(MAX_LEN_DATA_CONSTRAINTS + 1);
+        const invalidSubmission = Object.assign({}, validSubmission, {
+          dataConstraints: dataConstraintsTooLong,
+        });
+        const result: ValidationError | null =
+          validateService.validateSubmissionBody(invalidSubmission);
+        expect(
+          doesAnyStringContainAll(result.bodyErrors, [
+            FIELD_DATA_CONSTRAINTS,
+            MAX_LEN_DATA_CONSTRAINTS + '',
+          ]),
+        ).toBeTruthy();
+      });
+    });
+
+    describe(`given valid data constraints`, () => {
+      it('returns no error messages related to data constraints', () => {
+        const dataConstraintsTooLong = 'a'.repeat(MAX_LEN_DATA_CONSTRAINTS);
+        const invalidSubmission = Object.assign({}, validSubmission, {
+          dataConstraints: dataConstraintsTooLong,
+        });
+        const result: ValidationError | null =
+          validateService.validateSubmissionBody(invalidSubmission);
+        expect(
+          doesAnyStringContainAll(result?.bodyErrors, [
+            FIELD_DATA_CONSTRAINTS,
+            MAX_LEN_DATA_CONSTRAINTS + '',
+          ]),
+        ).toBeFalsy();
+      });
+    });
+
+    describe('given a startDate before minimum start date', () => {
+      it('should return error', () => {
+        const startDate = LocalDate.now()
+          .minusYears(3)
+          .format(JSON_REPORT_DATE_FORMAT);
+        const errors = validateService.validateSubmissionBody({
+          ...(validSubmission as any),
+          startDate,
+        });
+
+        const minStartTime = LocalDate.now()
+          .with(TemporalAdjusters.firstDayOfYear())
+          .minusYears(2)
+          .with(TemporalAdjusters.firstDayOfMonth())
+          .format(JSON_REPORT_DATE_FORMAT);
+
+        expect(errors.bodyErrors).toContain(
+          `Minimum allowed start date is ${minStartTime}`,
         );
-      expect(result).toBeNull();
+      });
     });
-  });
-  describe(`given a header row that has extra whitespace before and after column names, but is otherwise valid`, () => {
-    it('returns null', () => {
-      const headerWithExtraWhitespace = mockValidSubmission.rows[0].map(
-        (d) => ` ${d} `,
-      );
-      headerWithExtraWhitespace;
-      const result: string | null =
-        validateService.validateSubmissionRowsHeader(headerWithExtraWhitespace);
-      expect(result).toBeNull();
-    });
-  });
-  describe(`given a null header row`, () => {
-    it('returns an error object', () => {
-      const result: string | null =
-        validateService.validateSubmissionRowsHeader(null);
-      expect(result).not.toBeNull();
-    });
-  });
-  describe(`given an invalid header row`, () => {
-    it('returns an error object', () => {
-      const result: string | null =
-        validateService.validateSubmissionRowsHeader(['col1', 'col2']);
-      expect(result).not.toBeNull();
-    });
-  });
-});
-
-describe('validateRecord', () => {
-  describe(`given an record that is fully valid`, () => {
-    it('returns null', () => {
-      const overrides = {};
-      //Valid records must either have values for both (Hours Worked and )
-      //or a value for Special Salary.
-      overrides[SUBMISSION_ROW_COLUMNS.HOURS_WORKED] = 10;
-      overrides[SUBMISSION_ROW_COLUMNS.ORDINARY_PAY] = 20;
-      const validRecord = createSampleRecord(overrides);
-
-      const recordNum = 1;
-      const result: RowError | null = validateService.validateRecord(
-        recordNum,
-        validRecord,
-      );
-      expect(result).toBeNull();
-    });
-  });
-
-  describe(`given a valid record with 0.00 in one of the columns`, () => {
-    it('the 0.00 is interpreted the same as 0', () => {
-      const overrides = {};
-      //Valid records must either have values for both (Hours Worked and Ordinary Pay)
-      //or a value for Special Salary.
-      overrides[SUBMISSION_ROW_COLUMNS.HOURS_WORKED] = 10;
-      overrides[SUBMISSION_ROW_COLUMNS.ORDINARY_PAY] = 20;
-      overrides[SUBMISSION_ROW_COLUMNS.SPECIAL_SALARY] = '0.00';
-      const validRecord = createSampleRecord(overrides);
-
-      const recordNum = 1;
-      const result: RowError | null = validateService.validateRecord(
-        recordNum,
-        validRecord,
-      );
-      expect(result).toBeNull();
-    });
-  });
-
-  describe(`given an record that specifies both ${SUBMISSION_ROW_COLUMNS.HOURS_WORKED} and ${SUBMISSION_ROW_COLUMNS.SPECIAL_SALARY}`, () => {
-    it('returns a RowError', () => {
-      const overrides = {};
-      overrides[SUBMISSION_ROW_COLUMNS.HOURS_WORKED] = VALID_HOUR_AMOUNTS[0];
-      overrides[SUBMISSION_ROW_COLUMNS.SPECIAL_SALARY] =
-        VALID_DOLLAR_AMOUNTS[0];
-      const invalidRecord = createSampleRecord(overrides);
-
-      const recordNum = 1;
-      const result: RowError | null = validateService.validateRecord(
-        recordNum,
-        invalidRecord,
-      );
-
-      //expect one line error that mentions both SUBMISSION_ROW_COLUMNS.HOURS_WORKED and SUBMISSION_ROW_COLUMNS.SPECIAL_SALARY
-      expect(result).not.toBeNull();
-      expect(
-        doesAnyRowErrorContainAll(result, [
-          SUBMISSION_ROW_COLUMNS.HOURS_WORKED,
-          SUBMISSION_ROW_COLUMNS.SPECIAL_SALARY,
-        ]),
-      ).toBeTruthy();
-    });
-  });
-
-  describe(`given an record that specifies ${SUBMISSION_ROW_COLUMNS.HOURS_WORKED} but not ${SUBMISSION_ROW_COLUMNS.ORDINARY_PAY}`, () => {
-    it('returns a RowError', () => {
-      const overrides = {};
-      overrides[SUBMISSION_ROW_COLUMNS.HOURS_WORKED] = 20;
-      overrides[SUBMISSION_ROW_COLUMNS.ORDINARY_PAY] = NO_DATA_VALUES[0];
-      overrides[SUBMISSION_ROW_COLUMNS.SPECIAL_SALARY] = NO_DATA_VALUES[0];
-      const invalidRecord = createSampleRecord(overrides);
-
-      const recordNum = 1;
-      const result: RowError | null = validateService.validateRecord(
-        recordNum,
-        invalidRecord,
-      );
-
-      //expect one line error that mentions both SUBMISSION_ROW_COLUMNS.HOURS_WORKED and SUBMISSION_ROW_COLUMNS.ORDINARY_PAY
-      expect(
-        doesAnyRowErrorContainAll(result, [
-          SUBMISSION_ROW_COLUMNS.HOURS_WORKED,
-          SUBMISSION_ROW_COLUMNS.ORDINARY_PAY,
-        ]),
-      ).toBeTruthy();
-    });
-  });
-
-  describe(`given an record that specifies ${SUBMISSION_ROW_COLUMNS.ORDINARY_PAY} but not ${SUBMISSION_ROW_COLUMNS.HOURS_WORKED}`, () => {
-    it('returns a RowError', () => {
-      const overrides = {};
-      overrides[SUBMISSION_ROW_COLUMNS.HOURS_WORKED] = NO_DATA_VALUES[0];
-      overrides[SUBMISSION_ROW_COLUMNS.ORDINARY_PAY] = 35;
-      overrides[SUBMISSION_ROW_COLUMNS.SPECIAL_SALARY] = NO_DATA_VALUES[0];
-      const invalidRecord = createSampleRecord(overrides);
-
-      const recordNum = 1;
-      const result: RowError | null = validateService.validateRecord(
-        recordNum,
-        invalidRecord,
-      );
-
-      //expect one line error that mentions both SUBMISSION_ROW_COLUMNS.HOURS_WORKED and SUBMISSION_ROW_COLUMNS.ORDINARY_PAY
-      expect(
-        doesAnyRowErrorContainAll(result, [
-          SUBMISSION_ROW_COLUMNS.HOURS_WORKED,
-          SUBMISSION_ROW_COLUMNS.ORDINARY_PAY,
-        ]),
-      ).toBeTruthy();
-    });
-  });
-
-  describe(`given a record that specifies no data in any of the following columns: ${SUBMISSION_ROW_COLUMNS.HOURS_WORKED}, ${SUBMISSION_ROW_COLUMNS.ORDINARY_PAY} and ${SUBMISSION_ROW_COLUMNS.SPECIAL_SALARY}`, () => {
-    it('returns a RowError', () => {
-      const overrides = {};
-      overrides[SUBMISSION_ROW_COLUMNS.HOURS_WORKED] = NO_DATA_VALUES[0];
-      overrides[SUBMISSION_ROW_COLUMNS.ORDINARY_PAY] = NO_DATA_VALUES[0];
-      overrides[SUBMISSION_ROW_COLUMNS.SPECIAL_SALARY] = NO_DATA_VALUES[0];
-      const invalidRecord = createSampleRecord(overrides);
-
-      const recordNum = 1;
-      const result: RowError | null = validateService.validateRecord(
-        recordNum,
-        invalidRecord,
-      );
-
-      //expect one line error that mentions SUBMISSION_ROW_COLUMNS.HOURS_WORKED, SUBMISSION_ROW_COLUMNS.ORDINARY_PAY and SUBMISSION_ROW_COLUMNS.SPECIAL_SALARY
-      expect(result).not.toBeNull();
-      expect(result?.errorMsgs?.length).toBe(1);
-      expect(
-        doesAnyRowErrorContainAll(result, [
-          SUBMISSION_ROW_COLUMNS.HOURS_WORKED,
-          SUBMISSION_ROW_COLUMNS.ORDINARY_PAY,
-          SUBMISSION_ROW_COLUMNS.SPECIAL_SALARY,
-        ]),
-      ).toBeTruthy();
-    });
-  });
-
-  describe(`given a record with invalid '${SUBMISSION_ROW_COLUMNS.GENDER_CODE}'`, () => {
-    //Check that validation fails for each of several different
-    //invalid gender codes
-    INVALID_GENDER_CODES.forEach((genderCode) => {
-      describe(`${SUBMISSION_ROW_COLUMNS.GENDER_CODE} = ${genderCode}`, () => {
-        it('returns a RowError', () => {
-          // Create a sample row that is valid except for the value of the
-          // Gender Code
-          const overrides = {};
-          overrides[SUBMISSION_ROW_COLUMNS.GENDER_CODE] = genderCode;
-          const record = createSampleRecord(overrides);
-
-          const recordNum = 1;
-          const result: RowError | null = validateService.validateRecord(
-            recordNum,
-            record,
-          );
-          expect(result).not.toBeNull();
-          expect(result.rowNum).toBe(recordNum);
-          expect(
-            doesAnyRowErrorContain(result, SUBMISSION_ROW_COLUMNS.GENDER_CODE),
-          ).toBeTruthy();
+    describe('given an endDate is after maximum end date', () => {
+      it('should return error', () => {
+        const startDate = LocalDate.now()
+          .minusYears(1)
+          .format(JSON_REPORT_DATE_FORMAT);
+        const endDate = LocalDate.now()
+          .plusYears(1)
+          .format(JSON_REPORT_DATE_FORMAT);
+        const errors = validateService.validateSubmissionBody({
+          ...(validSubmission as any),
+          startDate,
+          endDate,
         });
+
+        const maxEndTime = LocalDate.now()
+          .minusMonths(1)
+          .with(TemporalAdjusters.lastDayOfMonth())
+          .format(JSON_REPORT_DATE_FORMAT);
+
+        expect(errors.bodyErrors).toContain(
+          `Maximum allowed end date is ${maxEndTime}`,
+        );
       });
     });
   });
 
-  describe(`given a record with valid '${SUBMISSION_ROW_COLUMNS.GENDER_CODE}'`, () => {
-    // Check that validation passes for each given gender code
-    VALID_GENDER_CODES.forEach((genderCode) => {
-      describe(`${SUBMISSION_ROW_COLUMNS.GENDER_CODE} = ${genderCode}`, () => {
-        it('returns no errors for this column', () => {
-          // Create a sample row and uses a specific Gender Code value
-          const overrides = {};
-          overrides[SUBMISSION_ROW_COLUMNS.GENDER_CODE] = genderCode;
-          const record = createSampleRecord(overrides);
-
-          const recordNum = 1;
-          const result: RowError | null = validateService.validateRecord(
-            recordNum,
-            record,
+  describe('validateSubmissionRowsHeader', () => {
+    describe(`given a valid header row`, () => {
+      it('returns null', () => {
+        const result: string | null =
+          validateService.validateSubmissionRowsHeader(
+            mockValidSubmission.rows[0],
           );
-          expect(
-            doesAnyRowErrorContain(result, SUBMISSION_ROW_COLUMNS.GENDER_CODE),
-          ).toBeFalsy();
-        });
+        expect(result).toBeNull();
+      });
+    });
+    describe(`given a header row that has extra whitespace before and after column names, but is otherwise valid`, () => {
+      it('returns null', () => {
+        const headerWithExtraWhitespace = mockValidSubmission.rows[0].map(
+          (d) => ` ${d} `,
+        );
+        headerWithExtraWhitespace;
+        const result: string | null =
+          validateService.validateSubmissionRowsHeader(
+            headerWithExtraWhitespace,
+          );
+        expect(result).toBeNull();
+      });
+    });
+    describe(`given a null header row`, () => {
+      it('returns an error object', () => {
+        const result: string | null =
+          validateService.validateSubmissionRowsHeader(null);
+        expect(result).not.toBeNull();
+      });
+    });
+    describe(`given an invalid header row`, () => {
+      it('returns an error object', () => {
+        const result: string | null =
+          validateService.validateSubmissionRowsHeader(['col1', 'col2']);
+        expect(result).not.toBeNull();
       });
     });
   });
 
-  describe("given a record with invalid '${SUBMISSION_ROW_COLUMNS.HOURS_WORKED}'", () => {
-    const invalidHoursWorked = INVALID_HOUR_AMOUNTS;
+  describe('validateRecord', () => {
+    describe(`given an record that is fully valid`, () => {
+      it('returns null', () => {
+        const overrides = {};
+        //Valid records must either have values for both (Hours Worked and )
+        //or a value for Special Salary.
+        overrides[SUBMISSION_ROW_COLUMNS.HOURS_WORKED] = 10;
+        overrides[SUBMISSION_ROW_COLUMNS.ORDINARY_PAY] = 20;
+        const validRecord = createSampleRecord(overrides);
 
-    //Check that validation fails for each of several different
-    //invalid values for SUBMISSION_ROW_COLUMNS.HOURS_WORKED
-    invalidHoursWorked.forEach((hoursWorked) => {
-      describe(`${SUBMISSION_ROW_COLUMNS.HOURS_WORKED} = ${hoursWorked}`, () => {
-        it('returns a RowError', () => {
-          // Create a sample row that is valid except for the value of the
-          // Hours worked
-          const overrides = {};
-          overrides[SUBMISSION_ROW_COLUMNS.HOURS_WORKED] = hoursWorked;
-          const record = createSampleRecord(overrides);
+        const recordNum = 1;
+        const result: RowError | null = validateService.validateRecord(
+          recordNum,
+          validRecord,
+        );
+        expect(result).toBeNull();
+      });
+    });
 
-          const recordNum = 1;
-          const result: RowError | null = validateService.validateRecord(
-            recordNum,
-            record,
-          );
-          expect(result).not.toBeNull();
-          expect(result.rowNum).toBe(recordNum);
-          expect(
-            doesAnyRowErrorContain(result, SUBMISSION_ROW_COLUMNS.HOURS_WORKED),
-          ).toBeTruthy();
+    describe(`given a valid record with 0.00 in one of the columns`, () => {
+      it('the 0.00 is interpreted the same as 0', () => {
+        const overrides = {};
+        //Valid records must either have values for both (Hours Worked and Ordinary Pay)
+        //or a value for Special Salary.
+        overrides[SUBMISSION_ROW_COLUMNS.HOURS_WORKED] = 10;
+        overrides[SUBMISSION_ROW_COLUMNS.ORDINARY_PAY] = 20;
+        overrides[SUBMISSION_ROW_COLUMNS.SPECIAL_SALARY] = '0.00';
+        const validRecord = createSampleRecord(overrides);
+
+        const recordNum = 1;
+        const result: RowError | null = validateService.validateRecord(
+          recordNum,
+          validRecord,
+        );
+        expect(result).toBeNull();
+      });
+    });
+
+    describe(`given an record that specifies both ${SUBMISSION_ROW_COLUMNS.HOURS_WORKED} and ${SUBMISSION_ROW_COLUMNS.SPECIAL_SALARY}`, () => {
+      it('returns a RowError', () => {
+        const overrides = {};
+        overrides[SUBMISSION_ROW_COLUMNS.HOURS_WORKED] = VALID_HOUR_AMOUNTS[0];
+        overrides[SUBMISSION_ROW_COLUMNS.SPECIAL_SALARY] =
+          VALID_DOLLAR_AMOUNTS[0];
+        const invalidRecord = createSampleRecord(overrides);
+
+        const recordNum = 1;
+        const result: RowError | null = validateService.validateRecord(
+          recordNum,
+          invalidRecord,
+        );
+
+        //expect one line error that mentions both SUBMISSION_ROW_COLUMNS.HOURS_WORKED and SUBMISSION_ROW_COLUMNS.SPECIAL_SALARY
+        expect(result).not.toBeNull();
+        expect(
+          doesAnyRowErrorContainAll(result, [
+            SUBMISSION_ROW_COLUMNS.HOURS_WORKED,
+            SUBMISSION_ROW_COLUMNS.SPECIAL_SALARY,
+          ]),
+        ).toBeTruthy();
+      });
+    });
+
+    describe(`given an record that specifies ${SUBMISSION_ROW_COLUMNS.HOURS_WORKED} but not ${SUBMISSION_ROW_COLUMNS.ORDINARY_PAY}`, () => {
+      it('returns a RowError', () => {
+        const overrides = {};
+        overrides[SUBMISSION_ROW_COLUMNS.HOURS_WORKED] = 20;
+        overrides[SUBMISSION_ROW_COLUMNS.ORDINARY_PAY] = NO_DATA_VALUES[0];
+        overrides[SUBMISSION_ROW_COLUMNS.SPECIAL_SALARY] = NO_DATA_VALUES[0];
+        const invalidRecord = createSampleRecord(overrides);
+
+        const recordNum = 1;
+        const result: RowError | null = validateService.validateRecord(
+          recordNum,
+          invalidRecord,
+        );
+
+        //expect one line error that mentions both SUBMISSION_ROW_COLUMNS.HOURS_WORKED and SUBMISSION_ROW_COLUMNS.ORDINARY_PAY
+        expect(
+          doesAnyRowErrorContainAll(result, [
+            SUBMISSION_ROW_COLUMNS.HOURS_WORKED,
+            SUBMISSION_ROW_COLUMNS.ORDINARY_PAY,
+          ]),
+        ).toBeTruthy();
+      });
+    });
+
+    describe(`given an record that specifies ${SUBMISSION_ROW_COLUMNS.ORDINARY_PAY} but not ${SUBMISSION_ROW_COLUMNS.HOURS_WORKED}`, () => {
+      it('returns a RowError', () => {
+        const overrides = {};
+        overrides[SUBMISSION_ROW_COLUMNS.HOURS_WORKED] = NO_DATA_VALUES[0];
+        overrides[SUBMISSION_ROW_COLUMNS.ORDINARY_PAY] = 35;
+        overrides[SUBMISSION_ROW_COLUMNS.SPECIAL_SALARY] = NO_DATA_VALUES[0];
+        const invalidRecord = createSampleRecord(overrides);
+
+        const recordNum = 1;
+        const result: RowError | null = validateService.validateRecord(
+          recordNum,
+          invalidRecord,
+        );
+
+        //expect one line error that mentions both SUBMISSION_ROW_COLUMNS.HOURS_WORKED and SUBMISSION_ROW_COLUMNS.ORDINARY_PAY
+        expect(
+          doesAnyRowErrorContainAll(result, [
+            SUBMISSION_ROW_COLUMNS.HOURS_WORKED,
+            SUBMISSION_ROW_COLUMNS.ORDINARY_PAY,
+          ]),
+        ).toBeTruthy();
+      });
+    });
+
+    describe(`given a record that specifies no data in any of the following columns: ${SUBMISSION_ROW_COLUMNS.HOURS_WORKED}, ${SUBMISSION_ROW_COLUMNS.ORDINARY_PAY} and ${SUBMISSION_ROW_COLUMNS.SPECIAL_SALARY}`, () => {
+      it('returns a RowError', () => {
+        const overrides = {};
+        overrides[SUBMISSION_ROW_COLUMNS.HOURS_WORKED] = NO_DATA_VALUES[0];
+        overrides[SUBMISSION_ROW_COLUMNS.ORDINARY_PAY] = NO_DATA_VALUES[0];
+        overrides[SUBMISSION_ROW_COLUMNS.SPECIAL_SALARY] = NO_DATA_VALUES[0];
+        const invalidRecord = createSampleRecord(overrides);
+
+        const recordNum = 1;
+        const result: RowError | null = validateService.validateRecord(
+          recordNum,
+          invalidRecord,
+        );
+
+        //expect one line error that mentions SUBMISSION_ROW_COLUMNS.HOURS_WORKED, SUBMISSION_ROW_COLUMNS.ORDINARY_PAY and SUBMISSION_ROW_COLUMNS.SPECIAL_SALARY
+        expect(result).not.toBeNull();
+        expect(result?.errorMsgs?.length).toBe(1);
+        expect(
+          doesAnyRowErrorContainAll(result, [
+            SUBMISSION_ROW_COLUMNS.HOURS_WORKED,
+            SUBMISSION_ROW_COLUMNS.ORDINARY_PAY,
+            SUBMISSION_ROW_COLUMNS.SPECIAL_SALARY,
+          ]),
+        ).toBeTruthy();
+      });
+    });
+
+    describe(`given a record with invalid '${SUBMISSION_ROW_COLUMNS.GENDER_CODE}'`, () => {
+      //Check that validation fails for each of several different
+      //invalid gender codes
+      INVALID_GENDER_CODES.forEach((genderCode) => {
+        describe(`${SUBMISSION_ROW_COLUMNS.GENDER_CODE} = ${genderCode}`, () => {
+          it('returns a RowError', () => {
+            // Create a sample row that is valid except for the value of the
+            // Gender Code
+            const overrides = {};
+            overrides[SUBMISSION_ROW_COLUMNS.GENDER_CODE] = genderCode;
+            const record = createSampleRecord(overrides);
+
+            const recordNum = 1;
+            const result: RowError | null = validateService.validateRecord(
+              recordNum,
+              record,
+            );
+            expect(result).not.toBeNull();
+            expect(result.rowNum).toBe(recordNum);
+            expect(
+              doesAnyRowErrorContain(
+                result,
+                SUBMISSION_ROW_COLUMNS.GENDER_CODE,
+              ),
+            ).toBeTruthy();
+          });
         });
       });
     });
-  });
 
-  describe(`given a record with valid '${SUBMISSION_ROW_COLUMNS.HOURS_WORKED}'`, () => {
-    const validHoursWorked = VALID_HOUR_AMOUNTS;
+    describe(`given a record with valid '${SUBMISSION_ROW_COLUMNS.GENDER_CODE}'`, () => {
+      // Check that validation passes for each given gender code
+      VALID_GENDER_CODES.forEach((genderCode) => {
+        describe(`${SUBMISSION_ROW_COLUMNS.GENDER_CODE} = ${genderCode}`, () => {
+          it('returns no errors for this column', () => {
+            // Create a sample row and uses a specific Gender Code value
+            const overrides = {};
+            overrides[SUBMISSION_ROW_COLUMNS.GENDER_CODE] = genderCode;
+            const record = createSampleRecord(overrides);
 
-    // Check that validation passes for each given value of Hours Worked
-    validHoursWorked.forEach((hoursWorked) => {
-      describe(`${SUBMISSION_ROW_COLUMNS.HOURS_WORKED} = ${hoursWorked}`, () => {
-        it('returns no errors for this column', () => {
-          // Create a sample row and uses a specific Hours Worked value
-          const overrides = {};
-          overrides[SUBMISSION_ROW_COLUMNS.HOURS_WORKED] = hoursWorked;
-
-          //Hours Worked is semi-optional (it, along with Ordinary Pay, are mutually
-          //exclusive with Special Salary).  Make sure the related columns have
-          //appropriate values for the record to be fully valid.
-          if (!validateService.isZeroSynonym(hoursWorked)) {
-            overrides[SUBMISSION_ROW_COLUMNS.ORDINARY_PAY] = 10;
-            overrides[SUBMISSION_ROW_COLUMNS.SPECIAL_SALARY] =
-              NO_DATA_VALUES[0];
-          } else {
-            overrides[SUBMISSION_ROW_COLUMNS.ORDINARY_PAY] = NO_DATA_VALUES[0];
-            overrides[SUBMISSION_ROW_COLUMNS.SPECIAL_SALARY] = 100;
-          }
-          const record = createSampleRecord(overrides);
-
-          const recordNum = 1;
-          const result: RowError | null = validateService.validateRecord(
-            recordNum,
-            record,
-          );
-
-          expect(
-            doesAnyRowErrorContain(result, SUBMISSION_ROW_COLUMNS.HOURS_WORKED),
-          ).toBeFalsy();
+            const recordNum = 1;
+            const result: RowError | null = validateService.validateRecord(
+              recordNum,
+              record,
+            );
+            expect(
+              doesAnyRowErrorContain(
+                result,
+                SUBMISSION_ROW_COLUMNS.GENDER_CODE,
+              ),
+            ).toBeFalsy();
+          });
         });
       });
     });
-  });
 
-  describe(`given a record with invalid '${SUBMISSION_ROW_COLUMNS.ORDINARY_PAY}'`, () => {
-    const invalidOrdinaryPay = INVALID_DOLLAR_AMOUNTS;
+    describe("given a record with invalid '${SUBMISSION_ROW_COLUMNS.HOURS_WORKED}'", () => {
+      const invalidHoursWorked = INVALID_HOUR_AMOUNTS;
 
-    //Check that validation fails for each of several different
-    //invalid values for 'Ordinary Pay'
-    invalidOrdinaryPay.forEach((ordinaryPay) => {
-      describe(`${SUBMISSION_ROW_COLUMNS.ORDINARY_PAY} = ${ordinaryPay}`, () => {
-        it('returns a RowError', () => {
-          // Create a sample row that is valid except for the value of the
-          // Ordinary Pay
-          const overrides = {};
-          overrides[SUBMISSION_ROW_COLUMNS.ORDINARY_PAY] = ordinaryPay;
-          const record = createSampleRecord(overrides);
+      //Check that validation fails for each of several different
+      //invalid values for SUBMISSION_ROW_COLUMNS.HOURS_WORKED
+      invalidHoursWorked.forEach((hoursWorked) => {
+        describe(`${SUBMISSION_ROW_COLUMNS.HOURS_WORKED} = ${hoursWorked}`, () => {
+          it('returns a RowError', () => {
+            // Create a sample row that is valid except for the value of the
+            // Hours worked
+            const overrides = {};
+            overrides[SUBMISSION_ROW_COLUMNS.HOURS_WORKED] = hoursWorked;
+            const record = createSampleRecord(overrides);
 
-          const recordNum = 1;
-          const result: RowError | null = validateService.validateRecord(
-            recordNum,
-            record,
-          );
-          expect(result).not.toBeNull();
-          expect(result.rowNum).toBe(recordNum);
-          expect(
-            doesAnyRowErrorContain(result, SUBMISSION_ROW_COLUMNS.ORDINARY_PAY),
-          ).toBeTruthy();
+            const recordNum = 1;
+            const result: RowError | null = validateService.validateRecord(
+              recordNum,
+              record,
+            );
+            expect(result).not.toBeNull();
+            expect(result.rowNum).toBe(recordNum);
+            expect(
+              doesAnyRowErrorContain(
+                result,
+                SUBMISSION_ROW_COLUMNS.HOURS_WORKED,
+              ),
+            ).toBeTruthy();
+          });
         });
       });
     });
-  });
 
-  describe(`given a record with valid '${SUBMISSION_ROW_COLUMNS.ORDINARY_PAY}'`, () => {
-    const validOrdinaryPay = VALID_DOLLAR_AMOUNTS;
+    describe(`given a record with valid '${SUBMISSION_ROW_COLUMNS.HOURS_WORKED}'`, () => {
+      const validHoursWorked = VALID_HOUR_AMOUNTS;
 
-    // Check that validation passes for each given value of Ordinary Pay
-    validOrdinaryPay.forEach((ordinaryPay) => {
-      describe(`${SUBMISSION_ROW_COLUMNS.ORDINARY_PAY} = '${ordinaryPay}'`, () => {
-        it('returns no errors for this column', () => {
-          // Create a sample row and uses a specific Ordinary Pay value
-          const overrides = {};
-          overrides[SUBMISSION_ROW_COLUMNS.ORDINARY_PAY] = ordinaryPay;
+      // Check that validation passes for each given value of Hours Worked
+      validHoursWorked.forEach((hoursWorked) => {
+        describe(`${SUBMISSION_ROW_COLUMNS.HOURS_WORKED} = ${hoursWorked}`, () => {
+          it('returns no errors for this column', () => {
+            // Create a sample row and uses a specific Hours Worked value
+            const overrides = {};
+            overrides[SUBMISSION_ROW_COLUMNS.HOURS_WORKED] = hoursWorked;
 
-          //Ordinary Pay is semi-optional (it, along with Hours Worked, are mutually
-          //exclusive with Special Salary).  Make sure the related columns have
-          //appropriate values for the record to be fully valid.
-          if (!validateService.isZeroSynonym(ordinaryPay)) {
-            overrides[SUBMISSION_ROW_COLUMNS.HOURS_WORKED] = 10;
-            overrides[SUBMISSION_ROW_COLUMNS.SPECIAL_SALARY] =
-              NO_DATA_VALUES[0];
-          } else {
-            overrides[SUBMISSION_ROW_COLUMNS.HOURS_WORKED] = NO_DATA_VALUES[0];
-            overrides[SUBMISSION_ROW_COLUMNS.SPECIAL_SALARY] = 100;
-          }
-          const record = createSampleRecord(overrides);
+            //Hours Worked is semi-optional (it, along with Ordinary Pay, are mutually
+            //exclusive with Special Salary).  Make sure the related columns have
+            //appropriate values for the record to be fully valid.
+            if (!validateService.isZeroSynonym(hoursWorked)) {
+              overrides[SUBMISSION_ROW_COLUMNS.ORDINARY_PAY] = 10;
+              overrides[SUBMISSION_ROW_COLUMNS.SPECIAL_SALARY] =
+                NO_DATA_VALUES[0];
+            } else {
+              overrides[SUBMISSION_ROW_COLUMNS.ORDINARY_PAY] =
+                NO_DATA_VALUES[0];
+              overrides[SUBMISSION_ROW_COLUMNS.SPECIAL_SALARY] = 100;
+            }
+            const record = createSampleRecord(overrides);
 
-          const recordNum = 1;
-          const result: RowError | null = validateService.validateRecord(
-            recordNum,
-            record,
-          );
+            const recordNum = 1;
+            const result: RowError | null = validateService.validateRecord(
+              recordNum,
+              record,
+            );
 
-          expect(
-            doesAnyRowErrorContain(result, SUBMISSION_ROW_COLUMNS.ORDINARY_PAY),
-          ).toBeFalsy();
+            expect(
+              doesAnyRowErrorContain(
+                result,
+                SUBMISSION_ROW_COLUMNS.HOURS_WORKED,
+              ),
+            ).toBeFalsy();
+          });
         });
       });
     });
-  });
 
-  describe(`given a record with invalid '${SUBMISSION_ROW_COLUMNS.SPECIAL_SALARY}'`, () => {
-    const invalidSpecialSalary = INVALID_DOLLAR_AMOUNTS;
+    describe(`given a record with invalid '${SUBMISSION_ROW_COLUMNS.ORDINARY_PAY}'`, () => {
+      const invalidOrdinaryPay = INVALID_DOLLAR_AMOUNTS;
 
-    //Check that validation fails for each of several different
-    //invalid values for SUBMISSION_ROW_COLUMNS.SPECIAL_SALARY
-    invalidSpecialSalary.forEach((specialSalary) => {
-      describe(`${SUBMISSION_ROW_COLUMNS.SPECIAL_SALARY} = ${specialSalary}`, () => {
-        it('returns a RowError', () => {
-          // Create a sample row that is valid except for the value of the
-          // Special Salary
-          const overrides = {};
-          overrides[SUBMISSION_ROW_COLUMNS.SPECIAL_SALARY] = specialSalary;
-          const record = createSampleRecord(overrides);
+      //Check that validation fails for each of several different
+      //invalid values for 'Ordinary Pay'
+      invalidOrdinaryPay.forEach((ordinaryPay) => {
+        describe(`${SUBMISSION_ROW_COLUMNS.ORDINARY_PAY} = ${ordinaryPay}`, () => {
+          it('returns a RowError', () => {
+            // Create a sample row that is valid except for the value of the
+            // Ordinary Pay
+            const overrides = {};
+            overrides[SUBMISSION_ROW_COLUMNS.ORDINARY_PAY] = ordinaryPay;
+            const record = createSampleRecord(overrides);
 
-          const recordNum = 1;
-          const result: RowError | null = validateService.validateRecord(
-            recordNum,
-            record,
-          );
-          expect(result).not.toBeNull();
-          expect(result.rowNum).toBe(recordNum);
-          expect(
-            doesAnyRowErrorContain(
-              result,
-              SUBMISSION_ROW_COLUMNS.SPECIAL_SALARY,
-            ),
-          ).toBeTruthy();
+            const recordNum = 1;
+            const result: RowError | null = validateService.validateRecord(
+              recordNum,
+              record,
+            );
+            expect(result).not.toBeNull();
+            expect(result.rowNum).toBe(recordNum);
+            expect(
+              doesAnyRowErrorContain(
+                result,
+                SUBMISSION_ROW_COLUMNS.ORDINARY_PAY,
+              ),
+            ).toBeTruthy();
+          });
         });
       });
     });
-  });
 
-  describe(`given a record with valid '${SUBMISSION_ROW_COLUMNS.SPECIAL_SALARY}'`, () => {
-    const validSpecialSalary = VALID_DOLLAR_AMOUNTS;
+    describe(`given a record with valid '${SUBMISSION_ROW_COLUMNS.ORDINARY_PAY}'`, () => {
+      const validOrdinaryPay = VALID_DOLLAR_AMOUNTS;
 
-    // Check that validation passes for each given value of Special Salary
-    validSpecialSalary.forEach((specialSalary) => {
-      describe(`${SUBMISSION_ROW_COLUMNS.SPECIAL_SALARY} = '${specialSalary}'`, () => {
-        it('returns no errors for this column', () => {
-          // Create a sample row and uses a specific Special Salary value
-          const overrides = {};
-          overrides[SUBMISSION_ROW_COLUMNS.SPECIAL_SALARY] = specialSalary;
+      // Check that validation passes for each given value of Ordinary Pay
+      validOrdinaryPay.forEach((ordinaryPay) => {
+        describe(`${SUBMISSION_ROW_COLUMNS.ORDINARY_PAY} = '${ordinaryPay}'`, () => {
+          it('returns no errors for this column', () => {
+            // Create a sample row and uses a specific Ordinary Pay value
+            const overrides = {};
+            overrides[SUBMISSION_ROW_COLUMNS.ORDINARY_PAY] = ordinaryPay;
 
-          //Special Salary is semi-optional (mutually exclusive with Hours Worked and
-          //Ordinary Pay).  If a blank value for Special Salary is given, be sure
-          //to include non-blank values for the mutually exclusive cols.
-          if (validateService.isZeroSynonym(specialSalary)) {
-            overrides[SUBMISSION_ROW_COLUMNS.HOURS_WORKED] = 10;
-            overrides[SUBMISSION_ROW_COLUMNS.ORDINARY_PAY] = 20;
-          } else {
-            overrides[SUBMISSION_ROW_COLUMNS.HOURS_WORKED] = NO_DATA_VALUES[0];
-            overrides[SUBMISSION_ROW_COLUMNS.ORDINARY_PAY] = NO_DATA_VALUES[0];
-          }
-          const record = createSampleRecord(overrides);
+            //Ordinary Pay is semi-optional (it, along with Hours Worked, are mutually
+            //exclusive with Special Salary).  Make sure the related columns have
+            //appropriate values for the record to be fully valid.
+            if (!validateService.isZeroSynonym(ordinaryPay)) {
+              overrides[SUBMISSION_ROW_COLUMNS.HOURS_WORKED] = 10;
+              overrides[SUBMISSION_ROW_COLUMNS.SPECIAL_SALARY] =
+                NO_DATA_VALUES[0];
+            } else {
+              overrides[SUBMISSION_ROW_COLUMNS.HOURS_WORKED] =
+                NO_DATA_VALUES[0];
+              overrides[SUBMISSION_ROW_COLUMNS.SPECIAL_SALARY] = 100;
+            }
+            const record = createSampleRecord(overrides);
 
-          const recordNum = 1;
-          const result: RowError | null = validateService.validateRecord(
-            recordNum,
-            record,
-          );
-          expect(
-            doesAnyRowErrorContain(
-              result,
-              SUBMISSION_ROW_COLUMNS.SPECIAL_SALARY,
-            ),
-          ).toBeFalsy();
+            const recordNum = 1;
+            const result: RowError | null = validateService.validateRecord(
+              recordNum,
+              record,
+            );
+
+            expect(
+              doesAnyRowErrorContain(
+                result,
+                SUBMISSION_ROW_COLUMNS.ORDINARY_PAY,
+              ),
+            ).toBeFalsy();
+          });
         });
       });
     });
-  });
 
-  describe(`given a record with invalid '${SUBMISSION_ROW_COLUMNS.OVERTIME_HOURS}'`, () => {
-    const invalidOvertimeHours = INVALID_HOUR_AMOUNTS;
+    describe(`given a record with invalid '${SUBMISSION_ROW_COLUMNS.SPECIAL_SALARY}'`, () => {
+      const invalidSpecialSalary = INVALID_DOLLAR_AMOUNTS;
 
-    //Check that validation fails for each of several different
-    //invalid values for SUBMISSION_ROW_COLUMNS.OVERTIME_HOURS
-    invalidOvertimeHours.forEach((overtimeHours) => {
-      describe(`${SUBMISSION_ROW_COLUMNS.OVERTIME_HOURS} = ${overtimeHours}`, () => {
-        it('returns a RowEerror', () => {
-          // Create a sample row that is valid except for the value of the
-          // Overtime Hours
-          const overrides = {};
-          overrides[SUBMISSION_ROW_COLUMNS.OVERTIME_HOURS] = overtimeHours;
-          const record = createSampleRecord(overrides);
+      //Check that validation fails for each of several different
+      //invalid values for SUBMISSION_ROW_COLUMNS.SPECIAL_SALARY
+      invalidSpecialSalary.forEach((specialSalary) => {
+        describe(`${SUBMISSION_ROW_COLUMNS.SPECIAL_SALARY} = ${specialSalary}`, () => {
+          it('returns a RowError', () => {
+            // Create a sample row that is valid except for the value of the
+            // Special Salary
+            const overrides = {};
+            overrides[SUBMISSION_ROW_COLUMNS.SPECIAL_SALARY] = specialSalary;
+            const record = createSampleRecord(overrides);
 
-          const recordNum = 1;
-          const result: RowError | null = validateService.validateRecord(
-            recordNum,
-            record,
-          );
-          expect(result).not.toBeNull();
-          expect(result.rowNum).toBe(recordNum);
-          expect(
-            doesAnyRowErrorContain(
-              result,
-              SUBMISSION_ROW_COLUMNS.OVERTIME_HOURS,
-            ),
-          ).toBeTruthy();
+            const recordNum = 1;
+            const result: RowError | null = validateService.validateRecord(
+              recordNum,
+              record,
+            );
+            expect(result).not.toBeNull();
+            expect(result.rowNum).toBe(recordNum);
+            expect(
+              doesAnyRowErrorContain(
+                result,
+                SUBMISSION_ROW_COLUMNS.SPECIAL_SALARY,
+              ),
+            ).toBeTruthy();
+          });
         });
       });
     });
-  });
 
-  describe(`given a record with valid '${SUBMISSION_ROW_COLUMNS.OVERTIME_HOURS}'`, () => {
-    const validOvertimeHours = VALID_HOUR_AMOUNTS;
+    describe(`given a record with valid '${SUBMISSION_ROW_COLUMNS.SPECIAL_SALARY}'`, () => {
+      const validSpecialSalary = VALID_DOLLAR_AMOUNTS;
 
-    // Check that validation passes for each given value of Overtime Hours
-    validOvertimeHours.forEach((overtimeHours) => {
-      describe(`${SUBMISSION_ROW_COLUMNS.OVERTIME_HOURS} = ${overtimeHours}`, () => {
-        it('returns no errors for this column', () => {
-          // Create a sample row and uses a specific Overtime Hours value
-          const overrides = {};
-          overrides[SUBMISSION_ROW_COLUMNS.OVERTIME_HOURS] = overtimeHours;
-          const record = createSampleRecord(overrides);
+      // Check that validation passes for each given value of Special Salary
+      validSpecialSalary.forEach((specialSalary) => {
+        describe(`${SUBMISSION_ROW_COLUMNS.SPECIAL_SALARY} = '${specialSalary}'`, () => {
+          it('returns no errors for this column', () => {
+            // Create a sample row and uses a specific Special Salary value
+            const overrides = {};
+            overrides[SUBMISSION_ROW_COLUMNS.SPECIAL_SALARY] = specialSalary;
 
-          const recordNum = 1;
-          const result: RowError | null = validateService.validateRecord(
-            recordNum,
-            record,
-          );
-          expect(
-            doesAnyRowErrorContain(
-              result,
-              SUBMISSION_ROW_COLUMNS.OVERTIME_HOURS,
-            ),
-          ).toBeFalsy();
+            //Special Salary is semi-optional (mutually exclusive with Hours Worked and
+            //Ordinary Pay).  If a blank value for Special Salary is given, be sure
+            //to include non-blank values for the mutually exclusive cols.
+            if (validateService.isZeroSynonym(specialSalary)) {
+              overrides[SUBMISSION_ROW_COLUMNS.HOURS_WORKED] = 10;
+              overrides[SUBMISSION_ROW_COLUMNS.ORDINARY_PAY] = 20;
+            } else {
+              overrides[SUBMISSION_ROW_COLUMNS.HOURS_WORKED] =
+                NO_DATA_VALUES[0];
+              overrides[SUBMISSION_ROW_COLUMNS.ORDINARY_PAY] =
+                NO_DATA_VALUES[0];
+            }
+            const record = createSampleRecord(overrides);
+
+            const recordNum = 1;
+            const result: RowError | null = validateService.validateRecord(
+              recordNum,
+              record,
+            );
+            expect(
+              doesAnyRowErrorContain(
+                result,
+                SUBMISSION_ROW_COLUMNS.SPECIAL_SALARY,
+              ),
+            ).toBeFalsy();
+          });
         });
       });
     });
-  });
 
-  describe(`given a record with invalid '${SUBMISSION_ROW_COLUMNS.OVERTIME_PAY}'`, () => {
-    const invalidOvertimePay = INVALID_DOLLAR_AMOUNTS;
+    describe(`given a record with invalid '${SUBMISSION_ROW_COLUMNS.OVERTIME_HOURS}'`, () => {
+      const invalidOvertimeHours = INVALID_HOUR_AMOUNTS;
 
-    //Check that validation fails for each of several different
-    //invalid values for SUBMISSION_ROW_COLUMNS.OVERTIME_PAY
-    invalidOvertimePay.forEach((overtimePay) => {
-      describe(`${SUBMISSION_ROW_COLUMNS.OVERTIME_PAY} = ${overtimePay}`, () => {
-        it('returns a RowError', () => {
-          // Create a sample row that is valid except for the value of the
-          // Overtime Pay
-          const overrides = {};
-          overrides[SUBMISSION_ROW_COLUMNS.OVERTIME_PAY] = overtimePay;
-          const record = createSampleRecord(overrides);
+      //Check that validation fails for each of several different
+      //invalid values for SUBMISSION_ROW_COLUMNS.OVERTIME_HOURS
+      invalidOvertimeHours.forEach((overtimeHours) => {
+        describe(`${SUBMISSION_ROW_COLUMNS.OVERTIME_HOURS} = ${overtimeHours}`, () => {
+          it('returns a RowEerror', () => {
+            // Create a sample row that is valid except for the value of the
+            // Overtime Hours
+            const overrides = {};
+            overrides[SUBMISSION_ROW_COLUMNS.OVERTIME_HOURS] = overtimeHours;
+            const record = createSampleRecord(overrides);
 
-          const recordNum = 1;
-          const result: RowError | null = validateService.validateRecord(
-            recordNum,
-            record,
-          );
-          expect(result).not.toBeNull();
-          expect(result.rowNum).toBe(recordNum);
-          expect(
-            doesAnyRowErrorContain(result, SUBMISSION_ROW_COLUMNS.OVERTIME_PAY),
-          ).toBeTruthy();
+            const recordNum = 1;
+            const result: RowError | null = validateService.validateRecord(
+              recordNum,
+              record,
+            );
+            expect(result).not.toBeNull();
+            expect(result.rowNum).toBe(recordNum);
+            expect(
+              doesAnyRowErrorContain(
+                result,
+                SUBMISSION_ROW_COLUMNS.OVERTIME_HOURS,
+              ),
+            ).toBeTruthy();
+          });
         });
       });
     });
-  });
 
-  describe(`given a record with valid '${SUBMISSION_ROW_COLUMNS.OVERTIME_PAY}'`, () => {
-    const validOvertimePay = VALID_DOLLAR_AMOUNTS;
+    describe(`given a record with valid '${SUBMISSION_ROW_COLUMNS.OVERTIME_HOURS}'`, () => {
+      const validOvertimeHours = VALID_HOUR_AMOUNTS;
 
-    // Check that validation passes for each given value of Overtime Pay
-    validOvertimePay.forEach((overtimePay) => {
-      describe(`${SUBMISSION_ROW_COLUMNS.OVERTIME_PAY} = ${overtimePay}`, () => {
-        it('returns no errors for this column', () => {
-          // Create a sample row and uses a specific Overtime Pay value
-          const overrides = {};
-          overrides[SUBMISSION_ROW_COLUMNS.OVERTIME_PAY] = overtimePay;
-          const record = createSampleRecord(overrides);
+      // Check that validation passes for each given value of Overtime Hours
+      validOvertimeHours.forEach((overtimeHours) => {
+        describe(`${SUBMISSION_ROW_COLUMNS.OVERTIME_HOURS} = ${overtimeHours}`, () => {
+          it('returns no errors for this column', () => {
+            // Create a sample row and uses a specific Overtime Hours value
+            const overrides = {};
+            overrides[SUBMISSION_ROW_COLUMNS.OVERTIME_HOURS] = overtimeHours;
+            const record = createSampleRecord(overrides);
 
-          const recordNum = 1;
-          const result: RowError | null = validateService.validateRecord(
-            recordNum,
-            record,
-          );
-          expect(
-            doesAnyRowErrorContain(result, SUBMISSION_ROW_COLUMNS.OVERTIME_PAY),
-          ).toBeFalsy();
+            const recordNum = 1;
+            const result: RowError | null = validateService.validateRecord(
+              recordNum,
+              record,
+            );
+            expect(
+              doesAnyRowErrorContain(
+                result,
+                SUBMISSION_ROW_COLUMNS.OVERTIME_HOURS,
+              ),
+            ).toBeFalsy();
+          });
         });
       });
     });
-  });
 
-  describe(`given an row with invalid '${SUBMISSION_ROW_COLUMNS.BONUS_PAY}'`, () => {
-    const invalidBonusPay = [
-      'NA',
-      '3,000',
-      '$7,000',
-      '$7000',
-      '-1',
-      '1000000000',
-    ];
-    invalidBonusPay.forEach((bonusPay) => {
-      describe(`${SUBMISSION_ROW_COLUMNS.BONUS_PAY} = ${bonusPay}`, () => {
-        it('returns a RowError', () => {
-          // Create a sample row that is valid except for the value of the
-          // Bonus Pay
-          const overrides = {};
-          overrides[SUBMISSION_ROW_COLUMNS.BONUS_PAY] = bonusPay;
-          const record = createSampleRecord(overrides);
+    describe(`given a record with invalid '${SUBMISSION_ROW_COLUMNS.OVERTIME_PAY}'`, () => {
+      const invalidOvertimePay = INVALID_DOLLAR_AMOUNTS;
 
-          const recordNum = 1;
-          const result: RowError | null = validateService.validateRecord(
-            recordNum,
-            record,
-          );
-          expect(result).not.toBeNull();
-          expect(result.rowNum).toBe(recordNum);
-          expect(
-            doesAnyRowErrorContain(result, SUBMISSION_ROW_COLUMNS.BONUS_PAY),
-          ).toBeTruthy();
+      //Check that validation fails for each of several different
+      //invalid values for SUBMISSION_ROW_COLUMNS.OVERTIME_PAY
+      invalidOvertimePay.forEach((overtimePay) => {
+        describe(`${SUBMISSION_ROW_COLUMNS.OVERTIME_PAY} = ${overtimePay}`, () => {
+          it('returns a RowError', () => {
+            // Create a sample row that is valid except for the value of the
+            // Overtime Pay
+            const overrides = {};
+            overrides[SUBMISSION_ROW_COLUMNS.OVERTIME_PAY] = overtimePay;
+            const record = createSampleRecord(overrides);
+
+            const recordNum = 1;
+            const result: RowError | null = validateService.validateRecord(
+              recordNum,
+              record,
+            );
+            expect(result).not.toBeNull();
+            expect(result.rowNum).toBe(recordNum);
+            expect(
+              doesAnyRowErrorContain(
+                result,
+                SUBMISSION_ROW_COLUMNS.OVERTIME_PAY,
+              ),
+            ).toBeTruthy();
+          });
         });
       });
     });
-  });
 
-  describe(`given a row with valid '${SUBMISSION_ROW_COLUMNS.BONUS_PAY}'`, () => {
-    const validBonusPay = VALID_DOLLAR_AMOUNTS;
+    describe(`given a record with valid '${SUBMISSION_ROW_COLUMNS.OVERTIME_PAY}'`, () => {
+      const validOvertimePay = VALID_DOLLAR_AMOUNTS;
 
-    // Check that validation passes for each given value of Overtime Pay
-    validBonusPay.forEach((bonusPay) => {
-      describe(`${SUBMISSION_ROW_COLUMNS.BONUS_PAY} = ${bonusPay}`, () => {
-        it('returns no errors for this column', () => {
-          // Create a sample row and uses a specific Overtime Pay value
-          const overrides = {};
-          overrides[SUBMISSION_ROW_COLUMNS.BONUS_PAY] = bonusPay;
-          const record = createSampleRecord(overrides);
+      // Check that validation passes for each given value of Overtime Pay
+      validOvertimePay.forEach((overtimePay) => {
+        describe(`${SUBMISSION_ROW_COLUMNS.OVERTIME_PAY} = ${overtimePay}`, () => {
+          it('returns no errors for this column', () => {
+            // Create a sample row and uses a specific Overtime Pay value
+            const overrides = {};
+            overrides[SUBMISSION_ROW_COLUMNS.OVERTIME_PAY] = overtimePay;
+            const record = createSampleRecord(overrides);
 
-          const recordNum = 1;
-          const result: RowError | null = validateService.validateRecord(
-            recordNum,
-            record,
-          );
-          expect(
-            doesAnyRowErrorContain(result, SUBMISSION_ROW_COLUMNS.BONUS_PAY),
-          ).toBeFalsy();
+            const recordNum = 1;
+            const result: RowError | null = validateService.validateRecord(
+              recordNum,
+              record,
+            );
+            expect(
+              doesAnyRowErrorContain(
+                result,
+                SUBMISSION_ROW_COLUMNS.OVERTIME_PAY,
+              ),
+            ).toBeFalsy();
+          });
+        });
+      });
+    });
+
+    describe(`given an row with invalid '${SUBMISSION_ROW_COLUMNS.BONUS_PAY}'`, () => {
+      const invalidBonusPay = [
+        'NA',
+        '3,000',
+        '$7,000',
+        '$7000',
+        '-1',
+        '1000000000',
+      ];
+      invalidBonusPay.forEach((bonusPay) => {
+        describe(`${SUBMISSION_ROW_COLUMNS.BONUS_PAY} = ${bonusPay}`, () => {
+          it('returns a RowError', () => {
+            // Create a sample row that is valid except for the value of the
+            // Bonus Pay
+            const overrides = {};
+            overrides[SUBMISSION_ROW_COLUMNS.BONUS_PAY] = bonusPay;
+            const record = createSampleRecord(overrides);
+
+            const recordNum = 1;
+            const result: RowError | null = validateService.validateRecord(
+              recordNum,
+              record,
+            );
+            expect(result).not.toBeNull();
+            expect(result.rowNum).toBe(recordNum);
+            expect(
+              doesAnyRowErrorContain(result, SUBMISSION_ROW_COLUMNS.BONUS_PAY),
+            ).toBeTruthy();
+          });
+        });
+      });
+    });
+
+    describe(`given a row with valid '${SUBMISSION_ROW_COLUMNS.BONUS_PAY}'`, () => {
+      const validBonusPay = VALID_DOLLAR_AMOUNTS;
+
+      // Check that validation passes for each given value of Overtime Pay
+      validBonusPay.forEach((bonusPay) => {
+        describe(`${SUBMISSION_ROW_COLUMNS.BONUS_PAY} = ${bonusPay}`, () => {
+          it('returns no errors for this column', () => {
+            // Create a sample row and uses a specific Overtime Pay value
+            const overrides = {};
+            overrides[SUBMISSION_ROW_COLUMNS.BONUS_PAY] = bonusPay;
+            const record = createSampleRecord(overrides);
+
+            const recordNum = 1;
+            const result: RowError | null = validateService.validateRecord(
+              recordNum,
+              record,
+            );
+            expect(
+              doesAnyRowErrorContain(result, SUBMISSION_ROW_COLUMNS.BONUS_PAY),
+            ).toBeFalsy();
+          });
         });
       });
     });

--- a/backend/src/v1/services/validate-service.ts
+++ b/backend/src/v1/services/validate-service.ts
@@ -1,6 +1,7 @@
 import { LocalDate, TemporalAdjusters } from '@js-joda/core';
 import { ISubmission } from './file-upload-service';
-import { JSON_REPORT_DATE_FORMAT } from './report-service';
+import { JSON_REPORT_DATE_FORMAT } from '../../constants';
+
 
 const FIELD_DATA_CONSTRAINTS = 'Data Constraints';
 const SUBMISSION_ROW_COLUMNS = {

--- a/backend/src/v1/services/validate-service.ts
+++ b/backend/src/v1/services/validate-service.ts
@@ -101,7 +101,7 @@ const validateService = {
 
     if (
       LocalDate.parse(submission.endDate)
-        .minusYears(1)
+        .minusMonths(11)
         .isBefore(LocalDate.parse(submission.startDate))
     ) {
       bodyErrors.push(

--- a/frontend/src/components/InputForm.vue
+++ b/frontend/src/components/InputForm.vue
@@ -8,10 +8,10 @@
   >
     <v-btn to="/">Back</v-btn>
   </v-banner>
-  <v-container>
+  <v-container fluid>
     <v-form ref="inputForm" @submit.prevent="submit">
       <v-row class="justify-center">
-        <v-col cols="10" class="w-100">
+        <v-col cols="12" class="w-100">
           <ReportStepper />
         </v-col>
       </v-row>
@@ -628,12 +628,17 @@ export default {
     uploadFileValue: undefined as File[] | undefined,
     maxFileUploadSize: '',
     minStartDate: LocalDate.now()
+      .with(TemporalAdjusters.firstDayOfYear())
       .minusYears(2)
       .with(TemporalAdjusters.firstDayOfMonth()),
     maxStartDate: LocalDate.now()
       .minusYears(1)
       .with(TemporalAdjusters.lastDayOfMonth()),
-    minEndDate: LocalDate.now().minusYears(1).minusMonths(1).withDayOfMonth(1),
+    minEndDate: LocalDate.now()
+      .with(TemporalAdjusters.firstDayOfYear())
+      .minusYears(1)
+      .minusMonths(1)
+      .withDayOfMonth(1),
     maxEndDate: LocalDate.now()
       .minusMonths(1)
       .with(TemporalAdjusters.lastDayOfMonth()),
@@ -723,9 +728,7 @@ export default {
     endMonthList() {
       return this.months.map((month) => {
         const selected = LocalDate.of(this.endYear, month.value, 1);
-        const disabled =
-          selected.isBefore(this.minEndDate as LocalDate) ||
-          selected.isAfter(this.maxEndDate as LocalDate);
+        const disabled = selected.isAfter(this.maxEndDate as LocalDate);
         return { ...month, props: { disabled } };
       });
     },
@@ -739,6 +742,7 @@ export default {
       if (!this.startDate) return;
       const end = LocalDate.parse(this.startDate).plusMonths(11);
       this.endMonth = end.monthValue();
+      this.endYear = end.year();
     },
     startYear() {
       //automatically update the endMonth and endYear to be one year later
@@ -753,6 +757,7 @@ export default {
       if (!this.endDate) return;
       const start = LocalDate.parse(this.endDate).minusMonths(11);
       this.startMonth = start.monthValue();
+      this.startYear = start.year();
     },
     endYear() {
       //automatically update the startMonth and startYear to be one year earlier
@@ -954,7 +959,11 @@ export default {
 };
 </script>
 
-<style lang="scss">
+<style scoped lang="scss">
+.v-container {
+  max-width: 1080px;
+}
+
 textarea::placeholder {
   text-align: right;
   transform: translateY(95px);

--- a/frontend/src/components/__tests__/InputForm.spec.ts
+++ b/frontend/src/components/__tests__/InputForm.spec.ts
@@ -213,7 +213,11 @@ describe('InputForm', () => {
     );
     //Earliest allowable start month is two years before the current month
     expect((wrapper.vm.minStartDate as LocalDate).format(formatter)).toBe(
-      dateNow.minusYears(2).withDayOfMonth(1).format(formatter),
+      dateNow
+        .with(TemporalAdjusters.firstDayOfYear())
+        .minusYears(2)
+        .withDayOfMonth(1)
+        .format(formatter),
     );
     //Latest allowable end month is the month prior the current month
     expect((wrapper.vm.maxEndDate as LocalDate).format(formatter)).toBe(


### PR DESCRIPTION

# Description

Calendar must allow users to select up to Two full calendar years in the past, from the current date.

Fixes # ([issue](https://finrms.atlassian.net/browse/GEO-387))

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)


## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have already been accepted and merged


## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


---
Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://pay-transparency-pr-339-frontend.apps.silver.devops.gov.bc.ca)