### PR TITLE
Add a spinner to the Upload File button in the Input form till the fi…

### DIFF
--- a/frontend/src/components/InputForm.vue
+++ b/frontend/src/components/InputForm.vue
@@ -451,7 +451,8 @@
             <v-btn
               color="primary"
               type="button"
-              @click="($refs.uploadFile as VFileInput).click()"
+              @click="selectFile"
+              :loading="isSelectingFile"
             >
               Upload file
             </v-btn>
@@ -639,7 +640,9 @@ export default {
       return;
     }
 
-    const response = await (this.$refs as any).confirmBackDialog.open('Please Confirm');
+    const response = await (this.$refs as any).confirmBackDialog.open(
+      'Please Confirm',
+    );
     next(response);
   },
   data: () => ({
@@ -659,6 +662,7 @@ export default {
     comments: null,
     isSubmit: false, //whether or not the submit button has been pressed
     isProcessing: false,
+    isSelectingFile: false,
     uploadFileValue: undefined as File[] | undefined,
     maxFileUploadSize: '',
     minStartDate: LocalDate.now()
@@ -932,6 +936,11 @@ export default {
         obj?.hasOwnProperty('rowErrors') &&
         obj?.hasOwnProperty('generalErrors')
       );
+    },
+    async selectFile() {
+      this.isSelectingFile = true;
+      await (this.$refs.uploadFile as VFileInput).click();
+      this.isSelectingFile = false;
     },
     async submit() {
       this.isSubmit = true;


### PR DESCRIPTION
# Description

Add a spinner to the Upload File button in the Input form till the file browser opens

Fixes # ([issue](https://finrms.atlassian.net/browse/GEO-460))

## Type of change
- [ ] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
If the file browser is slow to open, a loading spinner should be displayed in the button


## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have already been accepted and merged


## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
