### PR TITLE
feat: changed the error handling behaviour in HtmlReport.loadReport().  Now…

### DIFF
--- a/frontend/src/components/util/HtmlReport.vue
+++ b/frontend/src/components/util/HtmlReport.vue
@@ -1,6 +1,21 @@
 <template>
   <div class="mb-8">
-    <div v-dompurify-html="reportHtml"></div>
+    <div
+      v-if="reportHtml"
+      v-dompurify-html="reportHtml"
+      class="report-preview"
+    ></div>
+    <div
+      v-if="loadReportError && !reportHtml && !loading"
+      class="load-report-error"
+    >
+      <v-alert dense outlined class="bootstrap-error mb-3">
+        Unable to load the report. This may be a temporary problem. If the
+        problem persists, please report it to a system administrator.
+      </v-alert>
+      <p class="mt-2 mb-2"></p>
+      <v-btn color="secondary" @click="loadReport">Try again</v-btn>
+    </div>
   </div>
   <v-overlay
     :persistent="true"
@@ -23,16 +38,19 @@ import { useRouter } from 'vue-router';
 const { reportId } = storeToRefs(useReportStepperStore());
 const reportHtml = ref();
 const loading = ref<boolean>(true);
+const loadReportError = ref<boolean>(false);
 const router = useRouter();
 const emit = defineEmits(['html-report-loaded']);
 
 const loadReport = async () => {
   try {
+    loadReportError.value = false;
     loading.value = true;
     reportHtml.value = await ApiService.getHtmlReport(reportId.value);
     emit('html-report-loaded');
   } catch (error) {
-    router.replace('/');
+    reportHtml.value = null;
+    loadReportError.value = true;
   } finally {
     loading.value = false;
   }

--- a/frontend/src/components/util/HtmlReport.vue
+++ b/frontend/src/components/util/HtmlReport.vue
@@ -10,8 +10,9 @@
       class="load-report-error"
     >
       <v-alert dense outlined class="bootstrap-error mb-3">
-        Unable to load the report. This may be a temporary problem. If the
-        problem persists, please report it to a system administrator.
+        Unable to load the report. This may be a temporary problem. Please
+        re-try. If the problem persists, please report it to a system
+        administrator
       </v-alert>
       <p class="mt-2 mb-2"></p>
       <v-btn color="secondary" @click="loadReport">Try again</v-btn>

--- a/frontend/src/components/util/__tests__/HtmlReport.spec.ts
+++ b/frontend/src/components/util/__tests__/HtmlReport.spec.ts
@@ -1,0 +1,74 @@
+import { createTestingPinia } from '@pinia/testing';
+import { mount } from '@vue/test-utils';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createVuetify } from 'vuetify';
+import * as components from 'vuetify/components';
+import * as directives from 'vuetify/directives';
+import ApiService from '../../../common/apiService';
+import HtmlReport from '../HtmlReport.vue';
+
+// Mock the ResizeObserver
+const ResizeObserverMock = vi.fn(() => ({
+  observe: vi.fn(),
+  unobserve: vi.fn(),
+  disconnect: vi.fn(),
+}));
+
+// Stub the global ResizeObserver
+vi.stubGlobal('ResizeObserver', ResizeObserverMock);
+
+describe('HtmlReport', () => {
+  let wrapper;
+  let pinia;
+
+  beforeEach(() => {
+    //create an instance of vuetify so we can inject it
+    //into the mounted component, allowing it to behave as it would
+    //in a browser
+    const vuetify = createVuetify({
+      components,
+      directives,
+    });
+
+    pinia = createTestingPinia({
+      initialState: {
+        //mock the values in the reportStepper store
+        reportStepper: { reportId: 'mock-report-id' },
+      },
+    });
+
+    wrapper = mount(HtmlReport, {
+      global: {
+        plugins: [vuetify, pinia],
+      },
+    });
+  });
+
+  afterEach(() => {
+    if (wrapper) {
+      wrapper.unmount();
+    }
+  });
+
+  describe('When the report HTML is successfully retrieved from the backend', () => {
+    it('The report HTML is shown', async () => {
+      const mockReportHtml = '<html></html>';
+      vi.spyOn(ApiService, 'getHtmlReport').mockResolvedValue(mockReportHtml);
+      await wrapper.vm.loadReport();
+      expect(wrapper.vm.reportHtml).toBe(mockReportHtml);
+      expect(wrapper.vm.loadReportError).toBeFalsy();
+      expect(wrapper.findAll('.report-preview').length).toBe(1);
+      expect(wrapper.findAll('.load-report-error').length).toBe(0);
+    });
+  });
+  describe('When the report HTML cannot be retrieved from the backend', () => {
+    it('An error is shown', async () => {
+      vi.spyOn(ApiService, 'getHtmlReport').mockRejectedValue(new Error());
+      await wrapper.vm.loadReport();
+      expect(wrapper.vm.reportHtml).toBeNull();
+      expect(wrapper.vm.loadReportError).toBeTruthy();
+      expect(wrapper.findAll('.report-preview').length).toBe(0);
+      expect(wrapper.findAll('.load-report-error').length).toBe(1);
+    });
+  });
+});


### PR DESCRIPTION
# Description

When the frontend HtmlReport component is unable to fetch the HTML from the backend (due to an unexpected backend error), it now shows an error message like this in place of the report.
![image](https://github.com/bcgov/fin-pay-transparency/assets/1737873/2d3906e2-9579-4201-b762-080c0d95b11d)
(The HtmlReport component is embedded in both the DraftReport and the PublishedReport components.)

There is a "Try again" button because unexpected backend problems may self correct.  One common cause of a unexpected errors fetching HTML reports is a timeout from the backend due to the Pod running the doc-gen-service not having adequate resources.  This is most likely in the dev sandbox where resources are more limited.

It's a bit difficult to observe the new frontend error message in a deployed system because API timeout errors are irregular.  New unit tests should give some confidence that this works.

Fixes # [GEO-457](https://finrms.atlassian.net/browse/GEO-457)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

New unit tests

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have already been accepted and merged


---
Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://pay-transparency-pr-347-frontend.apps.silver.devops.gov.bc.ca)

---
Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://pay-transparency-pr-347-frontend.apps.silver.devops.gov.bc.ca)