### PR TITLE
feat - adding report unlock date and default is unlocked to true

### DIFF
--- a/backend/db/migrations/V1.0.20__add_report_locking_date.sql
+++ b/backend/db/migrations/V1.0.20__add_report_locking_date.sql
@@ -1,0 +1,8 @@
+SET search_path TO pay_transparency;
+
+alter table pay_transparency_report add column report_unlock_date timestamp null;
+alter table report_history add column report_unlock_date timestamp null;
+alter table pay_transparency_report alter column is_unlocked set default true;
+alter table report_history alter column is_unlocked set default true;
+
+create index "pay_transparency_report_report_unlock_date_is_unlocked_idx" on "pay_transparency_report"("report_unlock_date", "is_unlocked");

--- a/backend/src/config/index.ts
+++ b/backend/src/config/index.ts
@@ -33,6 +33,9 @@ config.defaults({
     reportEditDurationInDays: parseInt(
       process.env.REPORT_EDIT_DURATION_IN_DAYS || '30',
     ),
+    reportUnlockDurationInDays: parseInt(
+      process.env.REPORT_UNLOCK_DURATION_IN_DAYS || '1',
+    ),
     rateLimit: {
       enabled: process.env.IS_RATE_LIMIT_ENABLED || false, // Disable if rate limiting is not required
       windowMs: process.env.RATE_LIMIT_WINDOW_MS || 60000, // 1 minute

--- a/backend/src/v1/prisma/schema.prisma
+++ b/backend/src/v1/prisma/schema.prisma
@@ -120,7 +120,8 @@ model pay_transparency_report {
   report_status                                             String?                            @default("Draft") @db.VarChar(255)
   revision                                                  Decimal                            @db.Decimal
   data_constraints                                          String?                            @db.VarChar(3000)
-  is_unlocked                                               Boolean                            @default(false)
+  is_unlocked                                               Boolean                            @default(true)
+  report_unlock_date                                        DateTime?                          @db.Timestamp(6)
   reporting_year                                            Decimal                            @db.Decimal
   pay_transparency_calculated_data                          pay_transparency_calculated_data[]
   naics_code_pay_transparency_report_naics_codeTonaics_code naics_code                         @relation("pay_transparency_report_naics_codeTonaics_code", fields: [naics_code], references: [naics_code], onDelete: NoAction, onUpdate: NoAction, map: "pay_transparency_report_naics_code_fk")
@@ -164,7 +165,8 @@ model report_history {
   naics_code                                       String                    @db.VarChar(5)
   data_constraints                                 String?                   @db.VarChar(3000)
   revision                                         Decimal                   @db.Decimal
-  is_unlocked                                      Boolean                   @default(false)
+  report_unlock_date                               DateTime?                 @db.Timestamp(6)
+  is_unlocked                                      Boolean                   @default(true)
   reporting_year                                   Decimal                   @db.Decimal
   calculated_data_history                          calculated_data_history[]
   pay_transparency_company                         pay_transparency_company  @relation(fields: [company_id], references: [company_id], onDelete: NoAction, onUpdate: NoAction, map: "report_history_company_id_fk")

--- a/backend/src/v1/services/report-service.spec.ts
+++ b/backend/src/v1/services/report-service.spec.ts
@@ -136,6 +136,7 @@ const mockPublishedReportInDb: pay_transparency_report = {
   revision: new Prisma.Decimal(1),
   data_constraints: null,
   is_unlocked: true,
+  report_unlock_date: null
 };
 
 const mockPublishedReportInApi: Report =
@@ -910,6 +911,7 @@ describe('getReportFileName', () => {
       create_user: 'User',
       update_user: 'User',
       is_unlocked: false,
+      report_unlock_date: null
     };
     const reportInApi = reportServicePrivate.prismaReportToReport(reportInDb);
 

--- a/backend/src/v1/services/scheduler-service.spec.ts
+++ b/backend/src/v1/services/scheduler-service.spec.ts
@@ -43,6 +43,7 @@ const mockDraftReport: pay_transparency_report = {
   revision: new Prisma.Decimal(1),
   data_constraints: null,
   is_unlocked: true,
+  report_unlock_date: null,
 };
 
 const mockCalculatedDatasInDB = [
@@ -61,11 +62,9 @@ describe('deleteDraftReports', () => {
     );
     await schedulerService.deleteDraftReports();
 
-    expect(prisma.pay_transparency_report.findMany).toHaveBeenCalledTimes(1);
-
     //verify that it was called with one day previous
     const delete_date = LocalDate.now(ZoneId.UTC).minusDays(1).toString();
-    const call = (prisma.pay_transparency_report.findMany as jest.Mock).mock
+    const call = (prisma.pay_transparency_report.deleteMany as jest.Mock).mock
       .calls[0][0];
     const callDate = LocalDateTime.from(
       nativeJs(new Date(call.where.create_date.lte), ZoneId.UTC),

--- a/charts/fin-pay-transparency/templates/configmap.yaml
+++ b/charts/fin-pay-transparency/templates/configmap.yaml
@@ -8,5 +8,6 @@ data:
   UPLOAD_FILE_MAX_SIZE: {{ .Values.global.config.upload_file_max_size | quote }}
   TEMPLATE_PATH: {{ .Values.global.config.template_path | quote }}
   REPORT_EDIT_DURATION_IN_DAYS: {{ .Values.global.config.report_edit_duration_in_days | quote }}
+  REPORT_UNLOCK_DURATION_IN_DAYS: {{ .Values.global.config.report_unlock_duration_in_days | quote }}
   DELETE_DRAFT_REPORT_CRON_CRONTIME: {{ .Values.global.config.delete_draft_report_cron_crontime | quote }}
   DELETE_DRAFT_REPORT_CRON_TIMEZONE: {{ .Values.global.config.delete_draft_report_cron_timezone | quote }}

--- a/charts/fin-pay-transparency/values-dev.yaml
+++ b/charts/fin-pay-transparency/values-dev.yaml
@@ -27,6 +27,7 @@ global:
   config:
     upload_file_max_size: "8388608"
     report_edit_duration_in_days: "30"
+    report_unlock_duration_in_days: "1"
     template_path: "./dist/templates"
     delete_draft_report_cron_crontime: "0 0 0 * * *" # 12:00 AM PST/PDT
     delete_draft_report_cron_timezone: "America/Vancouver"

--- a/charts/fin-pay-transparency/values-prod.yaml
+++ b/charts/fin-pay-transparency/values-prod.yaml
@@ -27,6 +27,7 @@ global:
   config:
     upload_file_max_size: "8388608"
     report_edit_duration_in_days: "30"
+    report_unlock_duration_in_days: "1"
     template_path: "./dist/templates"
     delete_draft_report_cron_crontime: "0 0 0 * * *" # 12:00 AM PST/PDT
     delete_draft_report_cron_timezone: "America/Vancouver"

--- a/charts/fin-pay-transparency/values-test.yaml
+++ b/charts/fin-pay-transparency/values-test.yaml
@@ -27,6 +27,7 @@ global:
   config:
     upload_file_max_size: "8388608"
     report_edit_duration_in_days: "30"
+    report_unlock_duration_in_days: "1"
     template_path: "./dist/templates"
     delete_draft_report_cron_crontime: "0 0 0 * * *" # 12:00 AM PST/PDT
     delete_draft_report_cron_timezone: "America/Vancouver"

--- a/charts/fin-pay-transparency/values.yaml
+++ b/charts/fin-pay-transparency/values.yaml
@@ -27,6 +27,7 @@ global:
   config:
     upload_file_max_size: "8388608"
     report_edit_duration_in_days: "30"
+    report_unlock_duration_in_days: "1"
     template_path: "./dist/templates"
     delete_draft_report_cron_crontime: "0 0 0 * * *" # 12:00 AM PST/PDT
     delete_draft_report_cron_timezone: "America/Vancouver"


### PR DESCRIPTION
# Description

adding report unlock date and default is unlocked to true

Fixes # ([issue](https://finrms.atlassian.net/browse/GEO-474))

## Type of change

- [ ] New feature (non-breaking change which adds functionality)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have already been accepted and merged


## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


---
Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://pay-transparency-pr-354-frontend.apps.silver.devops.gov.bc.ca)