### PR TITLE
fix:  geo 480 im able to override locked published reports

### DIFF
--- a/backend/src/v1/routes/report-routes.ts
+++ b/backend/src/v1/routes/report-routes.ts
@@ -106,6 +106,12 @@ reportRouter.put(
 
       try {
         await reportService.publishReport(report_to_publish);
+      } catch (error) {
+        logger.error(error);
+        return res.status(HttpStatus.BAD_REQUEST).send(error.message);
+      }
+
+      try {
         const reportHtml = await reportService.getReportHtml(req, reportId);
         res.type('html').status(200).send(reportHtml);
       } catch (e) {

--- a/backend/src/v1/services/report-service.ts
+++ b/backend/src/v1/services/report-service.ts
@@ -1152,6 +1152,12 @@ const reportService = {
           },
         });
 
+      if (existing_published_report && !existing_published_report.is_unlocked) {
+        throw new Error(
+          'A report for this time period already exists and cannot be updated.',
+        );
+      }
+
       // If there is an existing Published report, move it into
       // report_history
       if (existing_published_report) {

--- a/frontend/src/common/apiService.ts
+++ b/frontend/src/common/apiService.ts
@@ -2,7 +2,7 @@ import axios from 'axios';
 import { saveAs } from 'file-saver';
 import { ApiRoutes } from '../utils/constant';
 import AuthService from './authService';
-import { IConfigValue } from './types';
+import { IConfigValue, IReport } from './types';
 
 export enum REPORT_FORMATS {
   HTML = 'html',
@@ -168,7 +168,7 @@ export default {
     reporting_year?: number;
   }) {
     try {
-      const resp = await apiAxios.get(ApiRoutes.REPORT, {
+      const resp = await apiAxios.get<IReport[]>(ApiRoutes.REPORT, {
         params: filters,
       });
       if (resp?.data) {

--- a/frontend/src/common/types/index.ts
+++ b/frontend/src/common/types/index.ts
@@ -7,6 +7,7 @@ export interface IReport {
   report_id: string;
   report_start_date: string;
   report_end_date: string;
+  reporting_year: number;
   create_date: string;
   is_unlocked: boolean;
   naics_code: string;

--- a/frontend/src/components/DraftReportPage.vue
+++ b/frontend/src/components/DraftReportPage.vue
@@ -141,6 +141,13 @@ async function tryGenerateReport() {
 
   let shouldGenerateReport = true;
   const reportAlreadyExists = existingPublished.length;
+  if (existingPublished.some((report) => !report.is_unlocked)) {
+    NotificationService.pushNotificationError(
+      'A report for this time period already exists and cannot be updated.',
+    );
+    return;
+  }
+
   if (reportAlreadyExists) {
     shouldGenerateReport = await confirmDialog.value?.open(
       'Please Confirm',

--- a/frontend/src/components/DraftReportPage.vue
+++ b/frontend/src/components/DraftReportPage.vue
@@ -144,6 +144,8 @@ async function tryGenerateReport() {
   if (existingPublished.some((report) => !report.is_unlocked)) {
     NotificationService.pushNotificationError(
       'A report for this time period already exists and cannot be updated.',
+      undefined,
+      5000
     );
     return;
   }


### PR DESCRIPTION
# Description

Prevent users from updating/overriding a locked report

Fixes # ([issue](https://finrms.atlassian.net/browse/GEO-480))

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have already been accepted and merged


## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


---
Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://pay-transparency-pr-366-frontend.apps.silver.devops.gov.bc.ca)