### PR TITLE
feat: Display reporting year on dashboard table and the generated report

### DIFF
--- a/backend/src/v1/services/report-service.ts
+++ b/backend/src/v1/services/report-service.ts
@@ -993,6 +993,7 @@ const reportService = {
       companyName: report.pay_transparency_company.company_name,
       companyAddress:
         `${report.pay_transparency_company.address_line1} ${report.pay_transparency_company.address_line2}`.trim(),
+      reportingYear: report.reporting_year,
       reportStartDate: LocalDate.from(
         nativeJs(report.report_start_date, ZoneId.UTC),
       )

--- a/doc-gen-service/src/templates/report-template-header.html
+++ b/doc-gen-service/src/templates/report-template-header.html
@@ -326,6 +326,12 @@
                   </td>
                 </tr>
                 <tr>
+                  <td class="table-header">Reporting Year:</td>
+                  <td class="text-normal">
+                    <%= reportingYear %>
+                  </td>
+                </tr>
+                <tr>
                   <td class="table-header">Time Period:</td>
                   <td class="text-normal">
                     <%= reportStartDate %> - <%= reportEndDate %>

--- a/doc-gen-service/src/v1/services/doc-gen-service.spec.ts
+++ b/doc-gen-service/src/v1/services/doc-gen-service.spec.ts
@@ -13,6 +13,7 @@ const TEST_TIMEOUT_MS = 10000;
 const submittedReportData: SubmittedReportData = {
   companyName: 'Test company',
   companyAddress: 'Test',
+  reportingYear: 2024,
   reportStartDate: 'January 1, 2023',
   reportEndDate: 'January 31, 2024',
   naicsCode: '11',

--- a/doc-gen-service/src/v1/services/doc-gen-service.ts
+++ b/doc-gen-service/src/v1/services/doc-gen-service.ts
@@ -39,6 +39,7 @@ request to generate a report.
 export type SubmittedReportData = {
   companyName: string;
   companyAddress: string;
+  reportingYear: number;
   reportStartDate: string;
   reportEndDate: string;
   naicsCode: string;

--- a/frontend/src/components/Dashboard.vue
+++ b/frontend/src/components/Dashboard.vue
@@ -69,8 +69,7 @@
             <div v-if="!reports.length">No generated reports yet.</div>
             <div v-if="reports.length">
               <v-row>
-                <v-col class="font-weight-bold">Start Date</v-col>
-                <v-col class="font-weight-bold">End Date</v-col>
+                <v-col class="font-weight-bold">Reporting Year</v-col>
                 <v-col class="font-weight-bold">Submission Date</v-col>
                 <v-col class="font-weight-bold" cols="4">Action</v-col>
               </v-row>
@@ -78,12 +77,9 @@
               <template v-for="report in reports">
                 <v-row>
                   <v-col
-                    :data-testid="'report_start_date-' + report.report_id"
-                    >{{ formatDate(report.report_start_date) }}</v-col
+                    :data-testid="'reporting_year-' + report.report_id"
+                    >{{ report.reporting_year }}</v-col
                   >
-                  <v-col :data-testid="'report_end_date-' + report.report_id">{{
-                    formatDate(report.report_end_date)
-                  }}</v-col>
                   <v-col
                     :data-testid="'report_published_date-' + report.report_id"
                     >{{ formatDateTime(report.create_date) }}</v-col

--- a/frontend/src/components/__tests__/Dashboard.spec.ts
+++ b/frontend/src/components/__tests__/Dashboard.spec.ts
@@ -4,7 +4,8 @@ import { render, waitFor, fireEvent } from '@testing-library/vue';
 import Dashboard from '../Dashboard.vue';
 import { createTestingPinia } from '@pinia/testing';
 import { authStore } from '../../store/modules/auth';
-import { useReportStepperStore } from '../../store/modules/reportStepper';
+import { DateTimeFormatter, LocalDate } from '@js-joda/core';
+import { Locale } from '@js-joda/locale_en';
 
 const pinia = createTestingPinia();
 const mockRouterPush = vi.fn();
@@ -17,8 +18,8 @@ const wrappedRender = async () => {
     global: {
       plugins: [pinia],
       mocks: {
-        $router: mockRouter
-      }
+        $router: mockRouter,
+      },
     },
   });
 };
@@ -54,6 +55,7 @@ describe('Dashboard', () => {
         report_id: 'id1',
         report_start_date: '2023-01-01',
         report_end_date: '2023-02-01',
+        reporting_year: 2023,
         create_date: new Date().toISOString(),
       },
     ]);
@@ -62,11 +64,11 @@ describe('Dashboard', () => {
       expect(mockGetReports).toHaveBeenCalled();
     });
 
-    expect(getByTestId('report_start_date-id1')).toHaveTextContent(
-      'January 1, 2023',
-    );
-    expect(getByTestId('report_end_date-id1')).toHaveTextContent(
-      'February 1, 2023',
+    expect(getByTestId('reporting_year-id1')).toHaveTextContent('2023');
+    expect(getByTestId('report_published_date-id1')).toHaveTextContent(
+      LocalDate.now().format(
+        DateTimeFormatter.ofPattern('MMMM d, YYYY').withLocale(Locale.ENGLISH),
+      ),
     );
   });
   it('should open report details', async () => {
@@ -93,7 +95,7 @@ describe('Dashboard', () => {
         report_start_date: '2023-01-01',
         report_end_date: '2023-02-01',
         create_date: new Date().toISOString(),
-        is_unlocked: true
+        is_unlocked: true,
       },
     ]);
     const { getByTestId } = await wrappedRender();
@@ -104,10 +106,10 @@ describe('Dashboard', () => {
     const editReportButton = getByTestId('edit-report-id1');
     await waitFor(() => {
       expect(editReportButton).toBeInTheDocument();
-    })
+    });
     await fireEvent.click(editReportButton);
     expect(mockRouterPush).toHaveBeenCalledWith({
-      path: 'generate-report-form'
+      path: 'generate-report-form',
     });
   });
 });


### PR DESCRIPTION
# Description

Display reporting year on dashboard table and the generated report

Fixes # ([issue](https://finrms.atlassian.net/browse/GEO-462))

## Type of change
- [ ] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Verify that the reporting is displayed in the dashboard and the report


## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have already been accepted and merged


## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


---
Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://pay-transparency-pr-367-frontend.apps.silver.devops.gov.bc.ca)