### PR TITLE
bugfix - preserve create_date from previously published report

### DIFF
--- a/backend/src/v1/services/report-service.ts
+++ b/backend/src/v1/services/report-service.ts
@@ -1175,6 +1175,7 @@ const reportService = {
         },
         data: {
           report_status: enumReportStatus.Published,
+          create_date: existing_published_report?.create_date || report_to_publish.create_date
         },
       });
     });


### PR DESCRIPTION
# Description

Publishing a draft report should use the `create_date` of a previously published report.

Fixes # ([issue](https://finrms.atlassian.net/browse/GEO-493))

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have already been accepted and merged


## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
