### PR TITLE
feat: reporting-year-options

### DIFF
--- a/frontend/src/components/InputForm.vue
+++ b/frontend/src/components/InputForm.vue
@@ -755,10 +755,14 @@ export default {
         .format(dateFormatter);
     },
     reportYearList() {
-      const list = [
-        LocalDate.now().minusYears(1).year(),
-        LocalDate.now().year(),
-      ];
+      const list = [] as number[];
+      const yearNow = LocalDate.now().year();
+      if (yearNow >= 2025) {
+        //only include last year if the current year is at least 2025
+        list.push(LocalDate.now().minusYears(1).year());
+      }
+      //always include the current year
+      list.push(LocalDate.now().year());
       return list;
     },
     startMonthList() {


### PR DESCRIPTION
# Description

prior to 2025, the only available reporting year is the current year.  in 2025 or after both the current year and the previous year are options.

Fixes # [GEO-515](https://finrms.atlassian.net/browse/GEO-515)

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

New unit tests

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have already been accepted and merged


---
Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://pay-transparency-pr-401-frontend.apps.silver.devops.gov.bc.ca)