### PR TITLE
feat: update reporting year validation on backend

### DIFF
--- a/backend/src/v1/services/validate-service.ts
+++ b/backend/src/v1/services/validate-service.ts
@@ -109,10 +109,11 @@ const validateService = {
       );
     }
 
-    const allowedReportingYears = [
-      LocalDate.now().year() - 1,
-      LocalDate.now().year(),
-    ];
+    const currentYear = LocalDate.now().year();
+    const allowedReportingYears = [currentYear];
+    if (currentYear >= 2025) {
+      allowedReportingYears.push(currentYear - 1);
+    }
     if (!allowedReportingYears.includes(submission.reportingYear)) {
       const text = allowedReportingYears.join(' or ');
       bodyErrors.push(`Reporting year must be ${text}.`);


### PR DESCRIPTION
# Description

Backend now validates reporting year according to the following rule:

- If currentYear is >= 2025 then valid reporting years are [currentYear, currentYear - 1]

- If currentYear is < 2025 then valid reporting years are [currentYear]

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

New unit tests

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have already been accepted and merged

---
Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://pay-transparency-pr-404-frontend.apps.silver.devops.gov.bc.ca)