### PR TITLE
feat: reporting year options

### DIFF
--- a/charts/fin-pay-transparency/values-dev.yaml
+++ b/charts/fin-pay-transparency/values-dev.yaml
@@ -37,7 +37,7 @@ global:
     delete_draft_report_cron_crontime: "0 0 0 * * *" # 12:00 AM PST/PDT
     lock_report_cron_crontime: "0 15 0 * * *" # 12:15 AM PST/PDT
     reports_scheduler_cron_timezone: "America/Vancouver"
-    first_year_with_prev_reporting_year_option: "2024"
+    first_year_with_prev_reporting_year_option: "2025"
 
   crunchyEnabled: true
 backend:

--- a/charts/fin-pay-transparency/values.yaml
+++ b/charts/fin-pay-transparency/values.yaml
@@ -37,7 +37,7 @@ global:
     delete_draft_report_cron_crontime: "0 0 0 * * *" # 12:00 AM PST/PDT
     lock_report_cron_crontime: "0 15 0 * * *" # 12:15 AM PST/PDT
     reports_scheduler_cron_timezone: "America/Vancouver"
-    first_year_with_prev_reporting_year_option: "2024"
+    first_year_with_prev_reporting_year_option: "2025"
   crunchyEnabled: true
 backend:
   enabled: true


### PR DESCRIPTION
# Description

The PR sandbox and dev environments currently offer 2023 and 2024 as reporting year options.  This PR removes 2023 as an option.  (The 2023 option was only needed for testing, and that testing is now complete.)  

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Visual inspection in PR sandbox.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have already been accepted and merged


---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://pay-transparency-pr-432-frontend.apps.silver.devops.gov.bc.ca)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/fin-pay-transparency/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/fin-pay-transparency/actions/workflows/merge.yml)