### PR TITLE
fix: geo 556 footer accessibility issue

### DIFF
--- a/frontend/src/components/Footer.vue
+++ b/frontend/src/components/Footer.vue
@@ -37,9 +37,14 @@
           </v-col>
         </v-row>
       </v-col>
-      <v-col class="justify-right" role="listbox" aria-label="More information links">
+      <v-col
+        class="justify-right"
+        role="listbox"
+        id="more-info"
+        aria-label="More information links"
+      >
         <p class="more-info-title">MORE INFO</p>
-        <v-row role="presentation" aria-labelledby="">
+        <v-row role="presentation" aria-labelledby="more-info">
           <v-col class="links" style="text-align: left">
             <v-list>
               <v-list-item
@@ -49,7 +54,6 @@
                 :data-testid="link.id"
                 role="listitem"
                 :aria-label="link.label"
-                tabindex="0"
               >
                 <v-list-item-title v-text="link.label"></v-list-item-title>
               </v-list-item>
@@ -61,8 +65,8 @@
                 class="footer-btn pl-1 pr-1"
                 v-for="link in settings.links.right"
                 v-bind:href="sanitizeUrl(link.to)"
+                :aria-label="link.label"
                 :data-testid="link.id"
-                tabindex="0"
               >
                 <v-list-item-title v-text="link.label"></v-list-item-title>
               </v-list-item>

--- a/frontend/src/components/Footer.vue
+++ b/frontend/src/components/Footer.vue
@@ -1,5 +1,15 @@
 <template>
   <v-footer color="#fff" dark absolute class="margin-top" app>
+    <div class="first-nation-acknowledgement">
+      <div>
+        The B.C. Public Service acknowledges the territories of First Nations
+        around B.C. and is grateful to carry out our work on these lands. We
+        acknowledge the rights, interests, priorities, and concerns of all
+        Indigenous Peoples - First Nations, Métis, and Inuit - respecting and
+        acknowledging their distinct cultures, histories, rights, laws, and
+        governments.
+      </div>
+    </div>
     <v-row>
       <v-col class="justify-left" style="text-align: left">
         <v-row>
@@ -27,9 +37,9 @@
           </v-col>
         </v-row>
       </v-col>
-      <v-col class="justify-right">
+      <v-col class="justify-right" role="listbox" aria-label="More information links">
         <p class="more-info-title">MORE INFO</p>
-        <v-row>
+        <v-row role="presentation" aria-labelledby="">
           <v-col class="links" style="text-align: left">
             <v-list>
               <v-list-item
@@ -37,6 +47,9 @@
                 v-for="link in settings.links.left"
                 v-bind:href="sanitizeUrl(link.to)"
                 :data-testid="link.id"
+                role="listitem"
+                :aria-label="link.label"
+                tabindex="0"
               >
                 <v-list-item-title v-text="link.label"></v-list-item-title>
               </v-list-item>
@@ -49,6 +62,7 @@
                 v-for="link in settings.links.right"
                 v-bind:href="sanitizeUrl(link.to)"
                 :data-testid="link.id"
+                tabindex="0"
               >
                 <v-list-item-title v-text="link.label"></v-list-item-title>
               </v-list-item>
@@ -57,16 +71,6 @@
         </v-row>
       </v-col>
     </v-row>
-  </v-footer>
-  <v-footer dark absolute class="bordered first-nation-acknowledgement" app>
-    <div>
-      The B.C. Public Service acknowledges the territories of First Nations
-      around B.C. and is grateful to carry out our work on these lands. We
-      acknowledge the rights, interests, priorities, and concerns of all
-      Indigenous Peoples - First Nations, Métis, and Inuit - respecting and
-      acknowledging their distinct cultures, histories, rights, laws, and
-      governments.
-    </div>
   </v-footer>
 </template>
 
@@ -142,18 +146,9 @@ p {
   min-width: 100%;
   font-size: $font-size;
   z-index: 0 !important;
-}
+  padding: 0 !important;
 
-.v-footer.bordered {
-  border-top: 4px solid $border-color !important;
-  border-bottom: 4px solid $border-color !important;
-  overflow: hidden;
-
-  &.margin-top {
-    padding-top: 50px;
-  }
-
-  &.first-nation-acknowledgement {
+  .first-nation-acknowledgement {
     background-color: rgb(41, 41, 41);
     display: flex;
     flex-direction: row;
@@ -164,6 +159,11 @@ p {
     font-size: 14px;
     line-height: 21px;
     transition: none !important;
+    width: 100%;
+    margin-bottom: 50px;
+    border-top: 4px solid $border-color !important;
+    border-bottom: 4px solid $border-color !important;
+    overflow: hidden;
 
     div {
       max-width: 1120px;


### PR DESCRIPTION
# Description

There are two footers, first, the territory acknowledgement, and second, the BC more info links.
The narrator appears to skip the first footer, the territory acknowledgement.
What actually happens is it reads aloud the second footer first, then the first footer afterwards.

Fixes # ([issue](https://finrms.atlassian.net/browse/GEO-556))

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)


## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have already been accepted and merged


## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
