### PR TITLE
fix: reduce the default and maximum page size for the data returned 

### DIFF
--- a/backend-external/src/v1/routes/pay-transparency-routes.ts
+++ b/backend-external/src/v1/routes/pay-transparency-routes.ts
@@ -109,12 +109,15 @@ const router = express.Router();
  *         name: page
  *         schema:
  *           type: integer
+ *           minimum: 0
  *         required: false
  *         description: The page offset number to retrive reports - optional
  *       - in: query
  *         name: pageSize
  *         schema:
  *           type: integer
+ *           minimum: 1
+ *           maximum: 50
  *         required: false
  *         description: The number of records/reports per page (max 50, default 50) - optional
  *       - in: query

--- a/backend-external/src/v1/routes/pay-transparency-routes.ts
+++ b/backend-external/src/v1/routes/pay-transparency-routes.ts
@@ -87,11 +87,6 @@ const router = express.Router();
  *           type: array
  *           items:
  *             $ref: "#/components/schemas/Report"
- *         history:
- *           type: array
- *           items:
- *             $ref: "#/components/schemas/Report"
- *
  */
 
 /**
@@ -150,17 +145,17 @@ router.get(
     try {
       const startDate = req.query.startDate?.toString();
       const endDate = req.query.endDate?.toString();
-      const offset = Number((req.query.page || '0')?.toString());
-      const limit = Number((req.query.pageSize || '1000')?.toString());
-      if (isNaN(offset) || isNaN(limit)) {
+      const page = Number((req.query.page || '0')?.toString());
+      const pageSize = Number((req.query.pageSize || '50')?.toString());
+      if (isNaN(page) || isNaN(pageSize)) {
         return res.status(400).json({ error: 'Invalid offset or limit' });
       }
       const { status, data } =
         await payTransparencyService.getPayTransparencyData(
           startDate,
           endDate,
-          offset,
-          limit,
+          page * pageSize,
+          pageSize,
         );
 
       if (data.error) {

--- a/backend-external/src/v1/routes/pay-transparency-routes.ts
+++ b/backend-external/src/v1/routes/pay-transparency-routes.ts
@@ -116,7 +116,7 @@ const router = express.Router();
  *         schema:
  *           type: integer
  *         required: false
- *         description: The number of records/reports per page (max 1000) - optional
+ *         description: The number of records/reports per page (max 50, default 50) - optional
  *       - in: query
  *         name: startDate
  *         type: date

--- a/backend/src/v1/routes/external-consumer-routes.spec.ts
+++ b/backend/src/v1/routes/external-consumer-routes.spec.ts
@@ -65,7 +65,7 @@ describe('external-consumer-routes', () => {
         .expect(({ body }) => {
           expect(body).toEqual({
             page: 0,
-            pageSize: 1000,
+            pageSize: 50,
             records: [
               {
                 calculated_data: [

--- a/backend/src/v1/services/external-consumer-service.ts
+++ b/backend/src/v1/services/external-consumer-service.ts
@@ -84,6 +84,8 @@ const buildReport = (data: RawQueryResult[]) => {
   };
 };
 
+const DEFAULT_PAGE_SIZE = 50;
+
 const externalConsumerService = {
   /**
    * This function returns a list of objects with pagination details to support the analytics team.
@@ -113,8 +115,8 @@ const externalConsumerService = {
       .plusDays(1)
       .withHour(0)
       .withMinute(0);
-    if (limit > 1000 || !limit || limit <= 0) {
-      limit = 1000;
+    if (limit > DEFAULT_PAGE_SIZE || !limit || limit <= 0) {
+      limit = DEFAULT_PAGE_SIZE;
     }
     if (!offset || offset < 0) {
       offset = 0;

--- a/backend/src/v1/services/external-consumer-service.ts
+++ b/backend/src/v1/services/external-consumer-service.ts
@@ -115,7 +115,7 @@ const externalConsumerService = {
       .plusDays(1)
       .withHour(0)
       .withMinute(0);
-    if (limit > DEFAULT_PAGE_SIZE || !limit || limit <= 0) {
+    if (!limit || limit <= 0 || limit > DEFAULT_PAGE_SIZE) {
       limit = DEFAULT_PAGE_SIZE;
     }
     if (!offset || offset < 0) {


### PR DESCRIPTION

# Description

reduce the default and maximum page size for the data returned 

Fixes # ([issue](https://finrms.atlassian.net/browse/GEO-599))

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have already been accepted and merged


## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://pay-transparency-pr-481-frontend.apps.silver.devops.gov.bc.ca)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/fin-pay-transparency/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/fin-pay-transparency/actions/workflows/merge.yml)