### PR TITLE
fix: geo 657 validate end date is always before today

### DIFF
--- a/backend-external/package-lock.json
+++ b/backend-external/package-lock.json
@@ -8,6 +8,8 @@
       "name": "backend-external",
       "version": "1.0.0",
       "dependencies": {
+        "@js-joda/core": "^5.6.2",
+        "@js-joda/locale_en": "^4.11.0",
         "axios": "^1.6.7",
         "dotenv": "^16.3.1",
         "express": "^4.18.2",
@@ -1301,6 +1303,29 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@js-joda/core": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/@js-joda/core/-/core-5.6.2.tgz",
+      "integrity": "sha512-ow4R+7C24xeTjiMTTZ4k6lvxj7MRBqvqLCQjThQff3RjOmIMokMP20LNYVFhGafJtUx/Xo2Qp4qU8eNoTVH0SA=="
+    },
+    "node_modules/@js-joda/locale_en": {
+      "version": "4.11.0",
+      "resolved": "https://registry.npmjs.org/@js-joda/locale_en/-/locale_en-4.11.0.tgz",
+      "integrity": "sha512-9pjRiAXISxoic2wpw9DHmV2GCBa2KMzWlStkjH7KXCh9rbd2BmiIgoJCv1rhAxtUj6BYaR+sgAT3nMpQDBtQ6w==",
+      "peerDependencies": {
+        "@js-joda/core": ">=3.2.0",
+        "@js-joda/timezone": "^2.3.0"
+      }
+    },
+    "node_modules/@js-joda/timezone": {
+      "version": "2.21.0",
+      "resolved": "https://registry.npmjs.org/@js-joda/timezone/-/timezone-2.21.0.tgz",
+      "integrity": "sha512-doyzPp6jqVow/eE7jG7yP4jNOmtzRAyIby5bzv3MDYzZ0yJlSVrM+LhTnmGTmxcgooqbLcqWymix+v4yUnNhPw==",
+      "peer": true,
+      "peerDependencies": {
+        "@js-joda/core": ">=1.11.0"
       }
     },
     "node_modules/@jsdevtools/ono": {

--- a/backend-external/package.json
+++ b/backend-external/package.json
@@ -3,6 +3,8 @@
   "version": "1.0.0",
   "main": "src/server.ts",
   "dependencies": {
+    "@js-joda/core": "^5.6.2",
+    "@js-joda/locale_en": "^4.11.0",
     "axios": "^1.6.7",
     "dotenv": "^16.3.1",
     "express": "^4.18.2",

--- a/backend-external/src/v1/routes/pay-transparency-routes.ts
+++ b/backend-external/src/v1/routes/pay-transparency-routes.ts
@@ -144,13 +144,13 @@ const validateApiKey =
  *         type: date
  *         pattern: /([0-9]{4})-(?:[0-9]{2})-([0-9]{2})/
  *         required: false
- *         description: "Start date in UTC for the update date range filter (format: YYYY-MM-dd) - optional"
+ *         description: "Start date in UTC for the update date range filter (format: YYYY-MM-dd, default -31 days ) - optional"
  *       - in: query
  *         name: endDate
  *         type: string
  *         pattern: /([0-9]{4})-(?:[0-9]{2})-([0-9]{2})/
  *         required: false
- *         description: "End date in UTC for the update date range filter (format: YYYY-MM-dd) - optional"
+ *         description: "End date in UTC for the update date range filter (format: YYYY-MM-dd, default -1 day) - optional"
  *
  *
  *     responses:

--- a/backend-external/tests/integration/integration.spec.ts
+++ b/backend-external/tests/integration/integration.spec.ts
@@ -1,5 +1,10 @@
 import { agent } from 'supertest';
 import { config } from '../../src/config';
+import {
+  DateTimeFormatter,
+  LocalDate,
+} from '@js-joda/core';
+import { Locale } from '@js-joda/locale_en';
 
 const request = agent(config.get('server:baseURL'));
 
@@ -35,6 +40,25 @@ describe('/v1/pay-transparency/ GET', () => {
       .expect(200)
       .expect(({ body }) => {
         expect(body).toHaveProperty('records');
+      });
+    });
+    it('should not allow users to enter end date later than current - 1 day', () => {
+      //note: this test requires both backend-external and backend to be running.
+      const dateFormat = DateTimeFormatter.ofPattern(
+        'YYYY-MM-dd',
+      ).withLocale(Locale.ENGLISH);
+      const endDate = LocalDate.now().format(dateFormat);
+      
+      return request
+      .get('/v1/pay-transparency/reports?pageSize=1')
+      .query({startDate: '2015-01-01', endDate})
+      .set('x-api-key', config.get('server:apiKey'))
+      .retry(3)
+      .expect(400)
+      .expect(({ body }) => {
+        expect(body.error).toBe(
+          'End date cannot be later than current - 1 days.',
+        );
       });
   });
 });

--- a/backend/src/v1/services/external-consumer-service.spec.ts
+++ b/backend/src/v1/services/external-consumer-service.spec.ts
@@ -132,4 +132,17 @@ describe('external-consumer-service', () => {
       expect(error.message).toBe('Start date must be before the end date.');
     }
   });
+  it('should fail when endDate is in the future', async () => {
+    mockReportsViewFindMany.mockReturnValue([testData]);
+    try {
+      await externalConsumerService.exportDataWithPagination(
+        '2024-01-01',
+        '2025-01-01',
+        -1,
+        -1,
+      );
+    } catch (error) {
+      expect(error.message).toBe('End date cannot be in the future.');
+    }
+  });
 });

--- a/backend/src/v1/services/external-consumer-service.spec.ts
+++ b/backend/src/v1/services/external-consumer-service.spec.ts
@@ -1,5 +1,7 @@
 import { faker } from '@faker-js/faker';
 import { externalConsumerService } from './external-consumer-service';
+import { DateTimeFormatter, LocalDate } from '@js-joda/core';
+import { JSON_REPORT_DATE_FORMAT } from '../../constants';
 
 const mockReportsViewFindMany = jest.fn();
 const mockReportsViewCount = jest.fn();
@@ -132,17 +134,21 @@ describe('external-consumer-service', () => {
       expect(error.message).toBe('Start date must be before the end date.');
     }
   });
-  it('should fail when endDate is in the future', async () => {
+  it('should fail when endDate after yesterday', async () => {
     mockReportsViewFindMany.mockReturnValue([testData]);
+
+    const endDate = LocalDate.now().format(JSON_REPORT_DATE_FORMAT);
     try {
       await externalConsumerService.exportDataWithPagination(
         '2024-01-01',
-        '2025-01-01',
+        endDate,
         -1,
         -1,
       );
     } catch (error) {
-      expect(error.message).toBe('End date cannot be in the future.');
+      expect(error.message).toBe(
+        'End date must always be before the current date.',
+      );
     }
   });
 });

--- a/backend/src/v1/services/external-consumer-service.spec.ts
+++ b/backend/src/v1/services/external-consumer-service.spec.ts
@@ -1,6 +1,6 @@
 import { faker } from '@faker-js/faker';
 import { externalConsumerService } from './external-consumer-service';
-import { DateTimeFormatter, LocalDate } from '@js-joda/core';
+import { LocalDate } from '@js-joda/core';
 import { JSON_REPORT_DATE_FORMAT } from '../../constants';
 
 const mockReportsViewFindMany = jest.fn();
@@ -134,7 +134,7 @@ describe('external-consumer-service', () => {
       expect(error.message).toBe('Start date must be before the end date.');
     }
   });
-  it('should fail when endDate after yesterday', async () => {
+  it('should fail when endDate is later than current date - 1 days', async () => {
     mockReportsViewFindMany.mockReturnValue([testData]);
 
     const endDate = LocalDate.now().format(JSON_REPORT_DATE_FORMAT);
@@ -147,7 +147,7 @@ describe('external-consumer-service', () => {
       );
     } catch (error) {
       expect(error.message).toBe(
-        'End date must always be before the current date.',
+        'End date cannot be later than current - 1 days.',
       );
     }
   });

--- a/backend/src/v1/services/external-consumer-service.ts
+++ b/backend/src/v1/services/external-consumer-service.ts
@@ -54,7 +54,9 @@ const externalConsumerService = {
         const date = convert(LocalDate.parse(startDate)).toDate();
         startDt = LocalDateTime.from(nativeJs(date, ZoneId.UTC))
           .withHour(0)
-          .withMinute(0);
+          .withMinute(0)
+          .withSecond(0)
+          .withNano(0);
       }
 
       if (endDate) {
@@ -68,10 +70,6 @@ const externalConsumerService = {
       throw new PayTransparencyUserError(
         'Failed to parse dates. Please use date format YYYY-MM-dd',
       );
-    }
-
-    if (endDt.isAfter(currentTime)) {
-      throw new PayTransparencyUserError('End date cannot be in the future.');
     }
 
     if (startDt.isAfter(endDt)) {

--- a/backend/src/v1/services/external-consumer-service.ts
+++ b/backend/src/v1/services/external-consumer-service.ts
@@ -26,8 +26,8 @@ const externalConsumerService = {
    * if limit is greater than 50, it will default to 50.
    * calling this endpoint with no limit will default to 50.
    * calling this endpoint with no offset will default to 0.
-   * calling this endpoint with no start date will default to -1 days.
-   * calling this endpoint with no end date will default to today.
+   * calling this endpoint with no start date will default to - 31 days.
+   * calling this endpoint with no end date will default to  - 1 day.
    * consumer is responsible for making the api call in a loop to get all the records.
    * @param startDate from when records needs to be fetched
    * @param endDate till when records needs to be fetched
@@ -41,7 +41,7 @@ const externalConsumerService = {
     limit?: number,
   ) {
     const currentTime = LocalDateTime.now(ZoneId.UTC);
-    let startDt = withStartOfDay(currentTime.minusDays(1));
+    let startDt = withStartOfDay(currentTime.minusDays(31));
     let endDt = withEndOfDay(currentTime.minusDays(1));
 
     if (!limit || limit <= 0 || limit > DEFAULT_PAGE_SIZE) {

--- a/backend/src/v1/services/external-consumer-service.ts
+++ b/backend/src/v1/services/external-consumer-service.ts
@@ -32,14 +32,17 @@ const externalConsumerService = {
     offset?: number,
     limit?: number,
   ) {
+    const currentTime = LocalDateTime.now(ZoneId.UTC);
     let startDt = LocalDateTime.now(ZoneId.UTC)
       .minusMonths(1)
       .withHour(0)
-      .withMinute(0);
-    let endDt = LocalDateTime.now(ZoneId.UTC)
-      .plusDays(1)
-      .withHour(0)
-      .withMinute(0);
+      .withMinute(0)
+      .withSecond(0)
+      .withNano(0);
+
+      
+    let endDt = currentTime;
+      
     if (!limit || limit <= 0 || limit > DEFAULT_PAGE_SIZE) {
       limit = DEFAULT_PAGE_SIZE;
     }
@@ -61,9 +64,14 @@ const externalConsumerService = {
           .withMinute(59);
       }
     } catch (error) {
+      console.log(error);
       throw new PayTransparencyUserError(
         'Failed to parse dates. Please use date format YYYY-MM-dd',
       );
+    }
+
+    if (endDt.isAfter(currentTime)) {
+      throw new PayTransparencyUserError('End date cannot be in the future.');
     }
 
     if (startDt.isAfter(endDt)) {
@@ -81,10 +89,10 @@ const externalConsumerService = {
 
     /**
      * Querying the reports and their data uses 2 sql views (reports_view, calculated_data_view) that
-     * are included in the Prisma schema by enabling views feature and running a db pull. The 2 views in the 
+     * are included in the Prisma schema by enabling views feature and running a db pull. The 2 views in the
      * schema were modified to add unique columns keys and relations between the projects_view and the calculated_data_view
-     * 
-     * 
+     *
+     *
      * The prisma views
      * is still in preview and we must monitor its status to mitigate risk using the following links:
      * 1) https://www.prisma.io/docs/orm/prisma-schema/data-model/views
@@ -117,9 +125,9 @@ const externalConsumerService = {
         where: whereClause,
       });
 
-    records.forEach(report => {
+    records.forEach((report) => {
       delete report.report_change_id;
-    })
+    });
 
     return {
       totalRecords: totalRecordsCount,

--- a/backend/src/v1/services/external-consumer-service.ts
+++ b/backend/src/v1/services/external-consumer-service.ts
@@ -41,8 +41,7 @@ const externalConsumerService = {
     limit?: number,
   ) {
     const currentTime = LocalDateTime.now(ZoneId.UTC);
-    let startDt = withStartOfDay(LocalDateTime.now(ZoneId.UTC).minusMonths(1));
-
+    let startDt = withStartOfDay(currentTime.minusDays(1));
     let endDt = withEndOfDay(currentTime.minusDays(1));
 
     if (!limit || limit <= 0 || limit > DEFAULT_PAGE_SIZE) {


### PR DESCRIPTION
# Description

Validate end date is always before today

Fixes # ([issue](https://finrms.atlassian.net/browse/GEO-657))

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have already been accepted and merged


## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://pay-transparency-pr-513-frontend.apps.silver.devops.gov.bc.ca)
- [Admin Frontend](https://pay-transparency-pr-513-admin-frontend.apps.silver.devops.gov.bc.ca)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/fin-pay-transparency/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/fin-pay-transparency/actions/workflows/merge.yml)