### PR TITLE
fix: remove admin e2e from workflow

### DIFF
--- a/.github/workflows/ci_cd_on_pr_dev_sandbox.yml
+++ b/.github/workflows/ci_cd_on_pr_dev_sandbox.yml
@@ -162,10 +162,3 @@ jobs:
     with:
       frontend-url: https://pay-transparency-pr-${{ github.event.number }}-frontend.apps.silver.devops.gov.bc.ca
       external-api-base-url: https://pay-transparency-pr-${{ github.event.number }}-backend-external.apps.silver.devops.gov.bc.ca
-  test-e2e-admin:
-    name: E2E-Admin
-    needs: [builds, check-quota, deploys]
-    uses: ./.github/workflows/.e2e-admin.yml
-    secrets: inherit
-    with:
-      admin-frontend-url: https://pay-transparency-pr-${{ github.event.number }}-admin-frontend.apps.silver.devops.gov.bc.ca


### PR DESCRIPTION


---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://pay-transparency-pr-514-frontend.apps.silver.devops.gov.bc.ca)
- [Admin Frontend](https://pay-transparency-pr-514-admin-frontend.apps.silver.devops.gov.bc.ca)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/fin-pay-transparency/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/fin-pay-transparency/actions/workflows/merge.yml)