### PR TITLE
fix: remove end-to-end tests from pr merge

### DIFF
--- a/.github/workflows/.e2e.yml
+++ b/.github/workflows/.e2e.yml
@@ -10,12 +10,10 @@ on:
         required: true
       EXTERNAL_CONSUMER_DELETE_REPORTS_API_KEY:
         required: true
-      OPENSHIFT_FRONTEND_URL:
-        required: false
     inputs:
       frontend-url:
         description: "Frontend URL of the application"
-        required: false
+        required: true
         type: string
       external-api-base-url :
         description: "Base URL to the external service API"
@@ -39,12 +37,10 @@ on:
         required: true
       EXTERNAL_CONSUMER_DELETE_REPORTS_API_KEY:
         required: true
-      OPENSHIFT_FRONTEND_URL:
-        required: false
     inputs:
       frontend-url:
         description: "Frontend URL of the application"
-        required: false
+        required: true
         type: string
       environment:
         description: "Environment to read secrets from GitHub secrets"
@@ -87,7 +83,7 @@ jobs:
           npx playwright install --with-deps 
       - name: Run Tests
         env:
-          E2E_BASE_URL: ${{ inputs.frontend-url || secrets.OPENSHIFT_FRONTEND_URL }}
+          E2E_BASE_URL: ${{ inputs.frontend-url }}
           E2E_USERNAME: ${{ secrets.E2E_USERNAME }}
           E2E_PASSWORD: ${{ secrets.E2E_PASSWORD }}
           EXTERNAL_CONSUMER_DELETE_REPORTS_API_KEY: ${{ secrets.EXTERNAL_CONSUMER_DELETE_REPORTS_API_KEY }}

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -127,11 +127,4 @@ jobs:
     secrets: inherit
     with:
       backend-external-url: https://pay-transparency-dev-backend-external.apps.silver.devops.gov.bc.ca/api
-  test-e2e:
-    name: E2E
-    needs: [deploys]
-    uses: ./.github/workflows/.e2e.yml
-    secrets: inherit
-    with:
-      external-api-base-url: https://pay-transparency-dev-backend-external.apps.silver.devops.gov.bc.ca    
 


### PR DESCRIPTION
# Description

1. Remove end-to-end tests from pr merge

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have already been accepted and merged


## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://pay-transparency-pr-529-frontend.apps.silver.devops.gov.bc.ca)
- [Admin Frontend](https://pay-transparency-pr-529-admin-frontend.apps.silver.devops.gov.bc.ca)
- [Backend external API console](https://pay-transparency-pr-529-backend-external.apps.silver.devops.gov.bc.ca/api/V1/docs)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/fin-pay-transparency/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/fin-pay-transparency/actions/workflows/merge.yml)