### PR TITLE
fix: fix/enable no-vars eslint

### DIFF
--- a/admin-frontend/package.json
+++ b/admin-frontend/package.json
@@ -97,6 +97,7 @@
       "sourceType": "module"
     },
     "rules": {
+      "no-var": "error",
       "vue/max-attributes-per-line": "off",
       "vue/first-attribute-linebreak": "off"
     }

--- a/backend-external/package.json
+++ b/backend-external/package.json
@@ -152,10 +152,8 @@
         "error",
         {
           "assertFunctionNames": [
-            [
-              "expect",
-              "request.**.expect"
-            ]
+            "expect",
+            "request.**.expect"
           ]
         }
       ]

--- a/backend/package.json
+++ b/backend/package.json
@@ -156,10 +156,8 @@
         "error",
         {
           "assertFunctionNames": [
-            [
-              "expect",
-              "request.**.expect"
-            ]
+            "expect",
+            "request.**.expect"
           ]
         }
       ]

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -98,6 +98,7 @@
       "sourceType": "module"
     },
     "rules": {
+      "no-var": "error",
       "vue/max-attributes-per-line": "off",
       "vue/first-attribute-linebreak": "off"
     }


### PR DESCRIPTION
https://finrms.atlassian.net/browse/GEO-593

frontend and admin-frontend: added no-vars rule
backend and backend-external: eslint wasn't loading due to typo in config. after fix typo 'var' keyword now flagged
doc-gen-service: no change, 'var' keyword already flagged

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://pay-transparency-pr-530-frontend.apps.silver.devops.gov.bc.ca)
- [Admin Frontend](https://pay-transparency-pr-530-admin-frontend.apps.silver.devops.gov.bc.ca)
- [Backend external API console](https://pay-transparency-pr-530-backend-external.apps.silver.devops.gov.bc.ca/api/V1/docs)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/fin-pay-transparency/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/fin-pay-transparency/actions/workflows/merge.yml)