### PR TITLE
fix: use datetime range for external get reports

### DIFF
--- a/backend-external/package-lock.json
+++ b/backend-external/package-lock.json
@@ -15,6 +15,7 @@
         "express": "^4.18.2",
         "express-prom-bundle": "^7.0.0",
         "express-rate-limit": "^7.1.5",
+        "express-validator": "^7.1.0",
         "helmet": "^7.1.0",
         "http-status-codes": "^2.3.0",
         "lodash": "^4.17.21",
@@ -4091,6 +4092,18 @@
       },
       "peerDependencies": {
         "express": "4 || 5 || ^5.0.0-beta.1"
+      }
+    },
+    "node_modules/express-validator": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/express-validator/-/express-validator-7.1.0.tgz",
+      "integrity": "sha512-ePn6NXjHRZiZkwTiU1Rl2hy6aUqmi6Cb4/s8sfUsKH7j2yYl9azSpl8xEHcOj1grzzQ+UBEoLWtE1s6FDxW++g==",
+      "dependencies": {
+        "lodash": "^4.17.21",
+        "validator": "~13.12.0"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
       }
     },
     "node_modules/express/node_modules/debug": {

--- a/backend-external/package.json
+++ b/backend-external/package.json
@@ -10,6 +10,7 @@
     "express": "^4.18.2",
     "express-prom-bundle": "^7.0.0",
     "express-rate-limit": "^7.1.5",
+    "express-validator": "^7.1.0",
     "helmet": "^7.1.0",
     "http-status-codes": "^2.3.0",
     "lodash": "^4.17.21",

--- a/backend-external/src/v1/routes/pay-transparency-routes.ts
+++ b/backend-external/src/v1/routes/pay-transparency-routes.ts
@@ -142,15 +142,15 @@ const validateApiKey =
  *       - in: query
  *         name: startDate
  *         type: date
- *         pattern: /([0-9]{4})-(?:[0-9]{2})-([0-9]{2})T([0-9]{2}):([0-9]{2}):([0-9]{2})/
+ *         pattern: /([0-9]{4})-(?:[0-9]{2})-([0-9]{2})\s([0-9]{2}):([0-9]{2}):([0-9]{2})/
  *         required: false
- *         description: "Start date in UTC for the update date range filter (format: YYYY-MM-ddTHH:mm:ss, default -31 days ) - optional"
+ *         description: "Start date in UTC for the update date range filter (format: YYYY-MM-dd HH:mm:ss, default -31 days ) - optional"
  *       - in: query
  *         name: endDate
  *         type: string
- *         pattern: /([0-9]{4})-(?:[0-9]{2})-([0-9]{2})T([0-9]{2}):([0-9]{2}):([0-9]{2})/
+ *         pattern: /([0-9]{4})-(?:[0-9]{2})-([0-9]{2})\s([0-9]{2}):([0-9]{2}):([0-9]{2})/
  *         required: false
- *         description: "End date in UTC for the update date range filter (format: YYYY-MM-ddTHH:mm:ss, default -1 day) - optional"
+ *         description: "End date in UTC for the update date range filter (format: YYYY-MM-dd HH:mm:ss, default now) - optional"
  *
  *
  *     responses:
@@ -182,7 +182,7 @@ router.get(
       }
 
       const maxPageSize = 50;
-      if (pageSize > maxPageSize) {
+      if (pageSize > maxPageSize || pageSize <= 0) {
         pageSize = maxPageSize;
       }
 

--- a/backend-external/src/v1/routes/pay-transparency-routes.ts
+++ b/backend-external/src/v1/routes/pay-transparency-routes.ts
@@ -142,15 +142,15 @@ const validateApiKey =
  *       - in: query
  *         name: startDate
  *         type: date
- *         pattern: /([0-9]{4})-(?:[0-9]{2})-([0-9]{2})\s([0-9]{2}):([0-9]{2}):([0-9]{2})/
+ *         pattern: /([0-9]{4})-(?:[0-9]{2})-([0-9]{2})\s([0-9]{2}):([0-9]{2})/
  *         required: false
- *         description: "Start date in UTC for the update date range filter (format: YYYY-MM-dd HH:mm:ss, default -31 days ) - optional"
+ *         description: "Start date in UTC for the update date range filter (format: YYYY-MM-dd HH:mm, default -31 days ) - optional"
  *       - in: query
  *         name: endDate
  *         type: string
- *         pattern: /([0-9]{4})-(?:[0-9]{2})-([0-9]{2})\s([0-9]{2}):([0-9]{2}):([0-9]{2})/
+ *         pattern: /([0-9]{4})-(?:[0-9]{2})-([0-9]{2})\s([0-9]{2}):([0-9]{2})/
  *         required: false
- *         description: "End date in UTC for the update date range filter (format: YYYY-MM-dd HH:mm:ss, default now) - optional"
+ *         description: "End date in UTC for the update date range filter (format: YYYY-MM-dd HH:mm, default now) - optional"
  *
  *
  *     responses:
@@ -171,7 +171,6 @@ router.get(
     .withMessage('Invalid start date format'),
   query('endDate').isISO8601().withMessage('Invalid end date format'),
   utils.asyncHandler(async (req: Request, res: Response) => {
-    console.log(req.query)
     try {
       const startDate = req.query.startDate?.toString();
       const endDate = req.query.endDate?.toString();

--- a/backend-external/src/v1/routes/pay-transparency-routes.ts
+++ b/backend-external/src/v1/routes/pay-transparency-routes.ts
@@ -3,11 +3,11 @@ import { payTransparencyService } from '../services/pay-transparency-service';
 import { utils } from '../../utils';
 import { logger } from '../../logger';
 import { config } from '../../config';
+import { query } from 'express-validator';
 
 const router = express.Router();
 const validateApiKey =
-  (validKey: string) =>
-  (req: Request, res: Response, next: NextFunction) => {
+  (validKey: string) => (req: Request, res: Response, next: NextFunction) => {
     const apiKey = req.header('x-api-key');
     if (apiKey) {
       if (validKey === apiKey) {
@@ -142,15 +142,15 @@ const validateApiKey =
  *       - in: query
  *         name: startDate
  *         type: date
- *         pattern: /([0-9]{4})-(?:[0-9]{2})-([0-9]{2})/
+ *         pattern: /([0-9]{4})-(?:[0-9]{2})-([0-9]{2})T([0-9]{2}):([0-9]{2}):([0-9]{2})/
  *         required: false
- *         description: "Start date in UTC for the update date range filter (format: YYYY-MM-dd, default -31 days ) - optional"
+ *         description: "Start date in UTC for the update date range filter (format: YYYY-MM-ddTHH:mm:ss, default -31 days ) - optional"
  *       - in: query
  *         name: endDate
  *         type: string
- *         pattern: /([0-9]{4})-(?:[0-9]{2})-([0-9]{2})/
+ *         pattern: /([0-9]{4})-(?:[0-9]{2})-([0-9]{2})T([0-9]{2}):([0-9]{2}):([0-9]{2})/
  *         required: false
- *         description: "End date in UTC for the update date range filter (format: YYYY-MM-dd, default -1 day) - optional"
+ *         description: "End date in UTC for the update date range filter (format: YYYY-MM-ddTHH:mm:ss, default -1 day) - optional"
  *
  *
  *     responses:
@@ -166,7 +166,12 @@ const validateApiKey =
 router.get(
   '/',
   validateApiKey(config.get('server:apiKey')),
+  query('startDate')
+    .isISO8601()
+    .withMessage('Invalid start date format'),
+  query('endDate').isISO8601().withMessage('Invalid end date format'),
   utils.asyncHandler(async (req: Request, res: Response) => {
+    console.log(req.query)
     try {
       const startDate = req.query.startDate?.toString();
       const endDate = req.query.endDate?.toString();
@@ -178,7 +183,7 @@ router.get(
 
       const maxPageSize = 50;
       if (pageSize > maxPageSize) {
-        pageSize = maxPageSize
+        pageSize = maxPageSize;
       }
 
       const { status, data } =
@@ -229,9 +234,7 @@ router.get(
  */
 router.delete(
   '/',
-  validateApiKey(
-    config.get('server:deleteReportsApiKey'),
-  ),
+  validateApiKey(config.get('server:deleteReportsApiKey')),
   async (req, res) => {
     try {
       if (!req.query.companyName) {
@@ -239,7 +242,7 @@ router.delete(
           .status(404)
           .json({ message: 'companyName query parameter is missing.' });
       }
-      
+
       const { data } = await payTransparencyService.deleteReports(req);
       if (data.error) {
         return res.status(400).json({ message: data.message });

--- a/backend-external/tests/integration/integration.spec.ts
+++ b/backend-external/tests/integration/integration.spec.ts
@@ -42,23 +42,12 @@ describe('/v1/pay-transparency/ GET', () => {
         expect(body).toHaveProperty('records');
       });
     });
-    it('should not allow users to enter end date later than current - 1 day', () => {
-      //note: this test requires both backend-external and backend to be running.
-      const dateFormat = DateTimeFormatter.ofPattern(
-        'YYYY-MM-dd',
-      ).withLocale(Locale.ENGLISH);
-      const endDate = LocalDate.now().format(dateFormat);
-      
+    it('should parse dates', () => {
       return request
       .get('/v1/pay-transparency/reports?pageSize=1')
-      .query({startDate: '2015-01-01', endDate})
+      .query({startDate: '2015-01-01 10:01:01', endDate: '2017-01-01 10:10:10'})
       .set('x-api-key', config.get('server:apiKey'))
       .retry(3)
-      .expect(400)
-      .expect(({ body }) => {
-        expect(body.error).toBe(
-          'End date cannot be later than current - 1 days.',
-        );
-      });
+      .expect(200);
   });
 });

--- a/backend-external/tests/integration/integration.spec.ts
+++ b/backend-external/tests/integration/integration.spec.ts
@@ -45,7 +45,7 @@ describe('/v1/pay-transparency/ GET', () => {
     it('should parse dates', () => {
       return request
       .get('/v1/pay-transparency/reports?pageSize=1')
-      .query({startDate: '2015-01-01 10:01:01', endDate: '2017-01-01 10:10:10'})
+      .query({startDate: '2015-01-01 10:01', endDate: '2017-01-01 10:10'})
       .set('x-api-key', config.get('server:apiKey'))
       .retry(3)
       .expect(200);

--- a/backend/src/v1/services/external-consumer-service.spec.ts
+++ b/backend/src/v1/services/external-consumer-service.spec.ts
@@ -1,7 +1,6 @@
 import { faker } from '@faker-js/faker';
-import { externalConsumerService } from './external-consumer-service';
-import { LocalDate } from '@js-joda/core';
-import { JSON_REPORT_DATE_FORMAT } from '../../constants';
+import { externalConsumerService, inputDateTimeFormatter } from './external-consumer-service';
+import { LocalDateTime, ZoneId } from '@js-joda/core';
 
 const mockReportsViewFindMany = jest.fn();
 const mockReportsViewCount = jest.fn();
@@ -98,8 +97,8 @@ describe('external-consumer-service', () => {
   it('should parse date strings', async () => {
     mockReportsViewFindMany.mockReturnValue([testData]);
     const results = await externalConsumerService.exportDataWithPagination(
-      '2024-01-01',
-      '2024-01-01',
+      '2024-01-01 11:00:00',
+      '2024-01-01 11:00:00',
       -1,
       -1,
     );
@@ -110,14 +109,14 @@ describe('external-consumer-service', () => {
     mockReportsViewFindMany.mockReturnValue([testData]);
     try {
       await externalConsumerService.exportDataWithPagination(
-        '20241-01-01',
-        '20241-01-01',
+        '20241-01-01 11:00:00',
+        '20241-01-02 11:00:00 ',
         -1,
         -1,
       );
     } catch (error) {
       expect(error.message).toBe(
-        'Failed to parse dates. Please use date format YYYY-MM-dd',
+        'Failed to parse dates. Please use date format YYYY-MM-dd HH:mm:ss',
       );
     }
   });
@@ -125,32 +124,43 @@ describe('external-consumer-service', () => {
     mockReportsViewFindMany.mockReturnValue([testData]);
     try {
       await externalConsumerService.exportDataWithPagination(
-        '2024-01-01',
-        '2023-01-01',
+        '2024-01-01 11:00:00',
+        '2023-01-01 11:00:00',
         -1,
         -1,
       );
     } catch (error) {
-      expect(error.message).toBe('Start date must be before the end date.');
+      expect(error.message).toBe('Start date time must be before the end date time.');
     }
   });
-  it('should fail when endDate is later than current date - 1 days', async () => {
-    mockReportsViewFindMany.mockReturnValue([testData]);
 
-    const endDate = LocalDate.now().format(JSON_REPORT_DATE_FORMAT);
+  it('should fail if startDate is in the future', async () => {
+    mockReportsViewFindMany.mockReturnValue([testData]);
     try {
       await externalConsumerService.exportDataWithPagination(
-        '2024-01-01',
-        endDate,
+        LocalDateTime.now().atZone(ZoneId.UTC).plusHours(24).format(inputDateTimeFormatter),
+        '2023-01-01 11:00:00',
         -1,
         -1,
       );
     } catch (error) {
-      expect(error.message).toBe(
-        'End date cannot be later than current - 1 days.',
-      );
+      expect(error.message).toBe('Start date cannot be in the future');
     }
   });
+  it('should fail if endDate is in the future', async () => {
+    mockReportsViewFindMany.mockReturnValue([testData]);
+    try {
+      await externalConsumerService.exportDataWithPagination(
+        '2023-01-01 11:00:00',
+        LocalDateTime.now().atZone(ZoneId.UTC).plusHours(24).format(inputDateTimeFormatter),
+        -1,
+        -1,
+      );
+    } catch (error) {
+      expect(error.message).toBe('End date cannot be in the future');
+    }
+  });
+
 
   describe('should default page size to 50', () => {
     it('when page size is not specified', async () => {
@@ -159,8 +169,8 @@ describe('external-consumer-service', () => {
         return [testData]
       });
       await externalConsumerService.exportDataWithPagination(
-        '2024-01-01',
-        '2024-01-01',
+        '2024-01-01 11:00:00',
+        '2024-01-01 11:00:00',
         0,
         undefined,
       );
@@ -172,8 +182,8 @@ describe('external-consumer-service', () => {
         return [testData]
       });
       await externalConsumerService.exportDataWithPagination(
-        '2024-01-01',
-        '2024-01-01',
+        '2024-01-01 11:00:00',
+        '2024-01-01 11:00:00',
         0,
         100,
       );
@@ -185,8 +195,8 @@ describe('external-consumer-service', () => {
         return [testData]
       });
       await externalConsumerService.exportDataWithPagination(
-        '2024-01-01',
-        '2024-01-01',
+        '2024-01-01 11:00:00',
+        '2024-01-01 11:00:00',
         0,
         -1,
       );

--- a/backend/src/v1/services/external-consumer-service.spec.ts
+++ b/backend/src/v1/services/external-consumer-service.spec.ts
@@ -97,8 +97,8 @@ describe('external-consumer-service', () => {
   it('should parse date strings', async () => {
     mockReportsViewFindMany.mockReturnValue([testData]);
     const results = await externalConsumerService.exportDataWithPagination(
-      '2024-01-01 11:00:00',
-      '2024-01-01 11:00:00',
+      '2024-01-01 11:00',
+      '2024-01-01 11:00',
       -1,
       -1,
     );
@@ -109,8 +109,8 @@ describe('external-consumer-service', () => {
     mockReportsViewFindMany.mockReturnValue([testData]);
     try {
       await externalConsumerService.exportDataWithPagination(
-        '20241-01-01 11:00:00',
-        '20241-01-02 11:00:00 ',
+        '20241-01-01 11:00',
+        '20241-01-02 11:00',
         -1,
         -1,
       );
@@ -124,8 +124,8 @@ describe('external-consumer-service', () => {
     mockReportsViewFindMany.mockReturnValue([testData]);
     try {
       await externalConsumerService.exportDataWithPagination(
-        '2024-01-01 11:00:00',
-        '2023-01-01 11:00:00',
+        '2024-01-01 11:00',
+        '2023-01-01 11:00',
         -1,
         -1,
       );
@@ -139,7 +139,7 @@ describe('external-consumer-service', () => {
     try {
       await externalConsumerService.exportDataWithPagination(
         LocalDateTime.now().atZone(ZoneId.UTC).plusHours(24).format(inputDateTimeFormatter),
-        '2023-01-01 11:00:00',
+        '2023-01-01 11:00',
         -1,
         -1,
       );
@@ -151,7 +151,7 @@ describe('external-consumer-service', () => {
     mockReportsViewFindMany.mockReturnValue([testData]);
     try {
       await externalConsumerService.exportDataWithPagination(
-        '2023-01-01 11:00:00',
+        '2023-01-01 11:00',
         LocalDateTime.now().atZone(ZoneId.UTC).plusHours(24).format(inputDateTimeFormatter),
         -1,
         -1,
@@ -169,8 +169,8 @@ describe('external-consumer-service', () => {
         return [testData]
       });
       await externalConsumerService.exportDataWithPagination(
-        '2024-01-01 11:00:00',
-        '2024-01-01 11:00:00',
+        '2024-01-01 11:00',
+        '2024-01-01 11:00',
         0,
         undefined,
       );
@@ -182,8 +182,8 @@ describe('external-consumer-service', () => {
         return [testData]
       });
       await externalConsumerService.exportDataWithPagination(
-        '2024-01-01 11:00:00',
-        '2024-01-01 11:00:00',
+        '2024-01-01 11:00',
+        '2024-01-01 11:00',
         0,
         100,
       );
@@ -195,8 +195,8 @@ describe('external-consumer-service', () => {
         return [testData]
       });
       await externalConsumerService.exportDataWithPagination(
-        '2024-01-01 11:00:00',
-        '2024-01-01 11:00:00',
+        '2024-01-01 11:00',
+        '2024-01-01 11:00',
         0,
         -1,
       );

--- a/backend/src/v1/services/external-consumer-service.ts
+++ b/backend/src/v1/services/external-consumer-service.ts
@@ -16,11 +16,7 @@ const withStartOfDay = (input: ZonedDateTime): ZonedDateTime => {
   return input.withHour(0).withMinute(0).withSecond(0).withNano(0);
 };
 
-const withEndOfDay = (input: ZonedDateTime): ZonedDateTime => {
-  return input.withHour(23).withMinute(59).withSecond(59);
-};
-
-const inputDateTimeFormat = 'yyyy-MM-dd HH:mm:ss';
+const inputDateTimeFormat = 'yyyy-MM-dd HH:mm';
 export const inputDateTimeFormatter = DateTimeFormatter.ofPattern(
   inputDateTimeFormat,
 ).withLocale(Locale.ENGLISH);
@@ -48,7 +44,7 @@ const externalConsumerService = {
   ) {
     const currentTime = LocalDateTime.now(ZoneId.UTC).atZone(ZoneId.UTC);
     let startDt = withStartOfDay(currentTime.minusDays(31));
-    let endDt = withEndOfDay(currentTime.minusDays(1));
+    let endDt = currentTime;
 
     if (!limit || limit <= 0 || limit > DEFAULT_PAGE_SIZE) {
       limit = DEFAULT_PAGE_SIZE;
@@ -74,7 +70,7 @@ const externalConsumerService = {
       if (endDatetime) {
         endDt = LocalDateTime.parse(endDatetime, inputDateTimeFormatter)
           .atZone(ZoneId.UTC)
-          .plusSeconds(1);
+          .plusMinutes(1);
 
         if (endDt.isAfter(currentTime)) {
           throw new PayTransparencyUserError(


### PR DESCRIPTION
# Description

Using datetime range instead of just date range to filter reports

Fixes # ([issue](https://finrms.atlassian.net/browse/GEO-737))

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)



## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have already been accepted and merged


## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://pay-transparency-pr-538-frontend.apps.silver.devops.gov.bc.ca)
- [Admin Frontend](https://pay-transparency-pr-538-admin-frontend.apps.silver.devops.gov.bc.ca)
- [Backend external API console](https://pay-transparency-pr-538-backend-external.apps.silver.devops.gov.bc.ca/api/V1/docs)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/fin-pay-transparency/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/fin-pay-transparency/actions/workflows/merge.yml)