### PR TITLE
feat: admin view report

### DIFF
--- a/admin-frontend/package-lock.json
+++ b/admin-frontend/package-lock.json
@@ -8086,11 +8086,10 @@
       "license": "ISC"
     },
     "node_modules/ws": {
-      "version": "8.17.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.0.tgz",
-      "integrity": "sha512-uJq6108EgZMAl20KagGkzCKfMEjxmKvZHG7Tlq0Z6nOky7YF7aq4mOx6xK8TJ/i1LeK4Qus7INktacctDgY8Ow==",
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
+      "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
       },

--- a/admin-frontend/src/components/ReportsPage.vue
+++ b/admin-frontend/src/components/ReportsPage.vue
@@ -175,10 +175,14 @@ Downloads a PDF report with the given reportId, and opens it in a new tab
 */
 async function viewReportInNewTab(reportId: string) {
   setReportDownloadInProgress(reportId);
-  const pdfAsBlob = await ApiService.getPdfReportAsBlob(reportId);
+  try {
+    const pdfAsBlob = await ApiService.getPdfReportAsBlob(reportId);
+    const objectUrl = URL.createObjectURL(pdfAsBlob);
+    window.open(objectUrl);
+  } catch (e) {
+    //Todo: show a Snackbar notification describing the error
+  }
   clearReportDownloadInProgress(reportId);
-  const objectUrl = URL.createObjectURL(pdfAsBlob);
-  window.open(objectUrl);
 }
 
 function setReportDownloadInProgress(reportId: string) {

--- a/admin-frontend/src/components/ReportsPage.vue
+++ b/admin-frontend/src/components/ReportsPage.vue
@@ -180,6 +180,7 @@ async function viewReportInNewTab(reportId: string) {
     const objectUrl = URL.createObjectURL(pdfAsBlob);
     window.open(objectUrl);
   } catch (e) {
+    console.log(e);
     //Todo: show a Snackbar notification describing the error
   }
   clearReportDownloadInProgress(reportId);

--- a/admin-frontend/src/components/__tests__/ReportsPage.spec.ts
+++ b/admin-frontend/src/components/__tests__/ReportsPage.spec.ts
@@ -1,0 +1,90 @@
+import { createTestingPinia } from '@pinia/testing';
+import { flushPromises, mount } from '@vue/test-utils';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createVuetify } from 'vuetify';
+import * as components from 'vuetify/components';
+import * as directives from 'vuetify/directives';
+import ApiService from '../../services/apiService';
+import ReportsPage from '../ReportsPage.vue';
+
+// Mock the ResizeObserver
+const ResizeObserverMock = vi.fn(() => ({
+  observe: vi.fn(),
+  unobserve: vi.fn(),
+  disconnect: vi.fn(),
+}));
+
+// Stub blobal objects needed for testing
+vi.stubGlobal('ResizeObserver', ResizeObserverMock);
+vi.stubGlobal('URL', { createObjectURL: vi.fn() });
+
+describe('ReportsPage', () => {
+  let wrapper;
+  let pinia;
+
+  const initWrapper = async (options: any = {}) => {
+    const vuetify = createVuetify({
+      components,
+      directives,
+    });
+
+    pinia = createTestingPinia({
+      initialState: {},
+    });
+    /*
+    wrapper = mount(
+      {
+        template: '<v-layout><ReportsPage/></v-layout>',
+      },
+      {
+        props: {},
+        global: {
+          components: {
+            ReportsPage,
+          },
+          plugins: [vuetify, pinia],
+        },
+      },
+    );
+    */
+    wrapper = mount(ReportsPage, {
+      global: {
+        plugins: [vuetify, pinia],
+      },
+    });
+
+    //wait for the async component to load
+    await flushPromises();
+
+    console.log('****');
+    console.log(wrapper);
+  };
+
+  beforeEach(async () => {
+    await initWrapper();
+  });
+
+  afterEach(() => {
+    if (wrapper) {
+      wrapper.unmount();
+    }
+  });
+
+  describe('viewReportInNewTab', () => {
+    describe('given a valid report id', () => {
+      it('downloads the report, and opens it in a new tab or window', async () => {
+        const mockReportId = 1;
+        const mockPdfAsBlob = new Blob(['mock pdf'], {
+          type: 'application/pdf',
+        });
+        const getPdfReportAsBlobSpy = vi
+          .spyOn(ApiService, 'getPdfReportAsBlob')
+          .mockResolvedValue(mockPdfAsBlob);
+        const windowOpenSpy = vi.spyOn(window, 'open');
+        await wrapper.vm.viewReportInNewTab(mockReportId);
+        expect(getPdfReportAsBlobSpy).toHaveBeenCalledTimes(1);
+        expect(windowOpenSpy).toHaveBeenCalledTimes(1);
+      });
+    });
+  });
+});

--- a/admin-frontend/src/components/__tests__/ReportsPage.spec.ts
+++ b/admin-frontend/src/components/__tests__/ReportsPage.spec.ts
@@ -87,4 +87,44 @@ describe('ReportsPage', () => {
       });
     });
   });
+
+  describe('isDownloadingPdf', () => {
+    describe('given a report id listed in reportsCurrentlyBeingDownloaded ', () => {
+      it('downloads the report, and opens it in a new tab or window', async () => {
+        const mockReportId1 = '1';
+        const mockReportId2 = '2';
+        wrapper.vm.reportsCurrentlyBeingDownloaded = {};
+        wrapper.vm.reportsCurrentlyBeingDownloaded[mockReportId1] = true;
+        expect(wrapper.vm.isDownloadingPdf(mockReportId1)).toBeTruthy();
+        expect(wrapper.vm.isDownloadingPdf(mockReportId2)).toBeFalsy();
+      });
+    });
+  });
+
+  describe('setReportDownloadInProgress', () => {
+    it('records that the given reportId is being downloaded', async () => {
+      const mockReportId1 = '1';
+      wrapper.vm.reportsCurrentlyBeingDownloaded = {};
+      wrapper.vm.setReportDownloadInProgress(mockReportId1);
+      expect(
+        wrapper.vm.reportsCurrentlyBeingDownloaded.hasOwnProperty(
+          mockReportId1,
+        ),
+      ).toBeTruthy();
+    });
+  });
+
+  describe('clearReportDownloadInProgress', () => {
+    it('clears the flag indicating the given reportId is being downloaded', async () => {
+      const mockReportId1 = '1';
+      wrapper.vm.reportsCurrentlyBeingDownloaded = {};
+      wrapper.vm.reportsCurrentlyBeingDownloaded[mockReportId1] = true;
+      wrapper.vm.clearReportDownloadInProgress(mockReportId1);
+      expect(
+        wrapper.vm.reportsCurrentlyBeingDownloaded.hasOwnProperty(
+          mockReportId1,
+        ),
+      ).toBeFalsy();
+    });
+  });
 });

--- a/admin-frontend/src/services/__tests__/apiService.spec.ts
+++ b/admin-frontend/src/services/__tests__/apiService.spec.ts
@@ -86,4 +86,21 @@ describe('ApiService', () => {
       });
     });
   });
+
+  describe('getPdfReportAsBlob', () => {
+    describe('when the given report id is valid', () => {
+      it('returns a blob', async () => {
+        const mockReportId = 1;
+        const mockResponse = {
+          data: new Blob([], { type: 'application/pdf' }),
+        };
+        vi.spyOn(ApiService.apiAxios, 'get').mockResolvedValueOnce(
+          mockResponse,
+        );
+
+        const resp = await ApiService.getPdfReportAsBlob(mockReportId);
+        expect(resp).toEqual(mockResponse.data);
+      });
+    });
+  });
 });

--- a/admin-frontend/src/services/apiService.ts
+++ b/admin-frontend/src/services/apiService.ts
@@ -154,6 +154,46 @@ export default {
       throw e;
     }
   },
+
+  /**
+   * Downloads a PDF of the report with the given id as a blob.
+   * Returns the blob.
+   * @param {string} reportId
+   * @returns a blob with the report's binary data
+   */
+  async getPdfReportAsBlob(reportId) {
+    try {
+      const resp = await apiAxios.get(`${ApiRoutes.REPORTS}/${reportId}`, {
+        headers: { accept: 'application/pdf' },
+        responseType: 'blob',
+      });
+
+      if (resp?.data) {
+        //get/create filename
+        let fileName = '';
+        if (resp?.headers['content-disposition']) {
+          const startFileNameIndex =
+            resp.headers['content-disposition'].indexOf('filename=') + 9;
+          const endFileNameIndex =
+            resp.headers['content-disposition'].lastIndexOf('.pdf') + 4;
+          fileName = resp.headers['content-disposition'].substring(
+            startFileNameIndex,
+            endFileNameIndex,
+          );
+        }
+        if (!fileName) fileName = 'pay_transparency_report.pdf';
+
+        //return the PDF data as a blob.
+        return resp.data;
+      } else {
+        throw new Error('Unable to get pdf report from API');
+      }
+    } catch (e) {
+      console.log(`Failed to get pdf report from API - ${e}`);
+      throw e;
+    }
+  },
+
   async lockUnlockReport(
     reportId: string,
     makeUnlocked: boolean,

--- a/admin-frontend/src/services/apiService.ts
+++ b/admin-frontend/src/services/apiService.ts
@@ -169,20 +169,6 @@ export default {
       });
 
       if (resp?.data) {
-        //get/create filename
-        let fileName = '';
-        if (resp?.headers['content-disposition']) {
-          const startFileNameIndex =
-            resp.headers['content-disposition'].indexOf('filename=') + 9;
-          const endFileNameIndex =
-            resp.headers['content-disposition'].lastIndexOf('.pdf') + 4;
-          fileName = resp.headers['content-disposition'].substring(
-            startFileNameIndex,
-            endFileNameIndex,
-          );
-        }
-        if (!fileName) fileName = 'pay_transparency_report.pdf';
-
         //return the PDF data as a blob.
         return resp.data;
       } else {

--- a/backend/src/v1/routes/admin-report-routes.spec.ts
+++ b/backend/src/v1/routes/admin-report-routes.spec.ts
@@ -1,12 +1,12 @@
-import express, { Application } from 'express';
-import router from './admin-report-routes';
-import request from 'supertest';
 import bodyParser from 'body-parser';
+import express, { Application } from 'express';
+import request from 'supertest';
+import router from './admin-report-routes';
 
 jest.mock('../services/utils-service', () => ({
   utils: {
     ...jest.requireActual('../services/utils-service').utils,
-    getSessionUser: () => ({ idir_username: 'SOME_USR'}),
+    getSessionUser: () => ({ idir_username: 'SOME_USR' }),
   },
 }));
 
@@ -18,13 +18,23 @@ jest.mock('../services/admin-report-service', () => ({
     changeReportLockStatus: (...args) => mockChangeReportLockStatus(...args),
   },
 }));
+const mockGetReportPdf = jest
+  .fn()
+  .mockResolvedValue(Buffer.from('mock pdf', 'utf8'));
+const mockGetReportFileName = jest.fn().mockResolvedValue('report.pdf');
+jest.mock('../services/report-service', () => ({
+  reportService: {
+    getReportPdf: (...args) => mockGetReportPdf(...args),
+    getReportFileName: (...args) => mockGetReportFileName(...args),
+  },
+}));
 
 let app: Application;
 describe('admin-report-routes', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     app = express();
-    app.use(bodyParser.json())
+    app.use(bodyParser.json());
     app.use(router);
   });
 
@@ -70,47 +80,66 @@ describe('admin-report-routes', () => {
     });
   });
 
+  describe('GET /:id', () => {
+    describe('if reportId is valid', () => {
+      it('should default offset=0 and limit=20', async () => {
+        const mockReportId = '4492feff-99d7-4b2b-8896-12a59a75d4e3';
+        await request(app)
+          .get(`/${mockReportId}`)
+          .set('accepts', 'application/pdf')
+          .expect(200);
+        expect(mockGetReportPdf.mock.calls[0][1]).toBe(mockReportId);
+      });
+    });
+  });
+
   describe('PATCH /:id', () => {
-    describe('400', () => { 
+    describe('400', () => {
       it('invalid body', () => {
-        return request(app).patch('/4492feff-99d7-4b2b-8896-12a59a75d4e3')
-        .send({invalid: false})
-        .expect(400)
-        .expect(({body}) => {
-          expect(body.error).toBe('Missing field "is_unlocked" in the data');
-        });
+        return request(app)
+          .patch('/4492feff-99d7-4b2b-8896-12a59a75d4e3')
+          .send({ invalid: false })
+          .expect(400)
+          .expect(({ body }) => {
+            expect(body.error).toBe('Missing field "is_unlocked" in the data');
+          });
       });
       it('fail to change report lock status', () => {
-        mockChangeReportLockStatus.mockRejectedValue({ error: 'Error happened' });
-        return request(app).patch('/4492feff-99d7-4b2b-8896-12a59a75d4e3')
-        .send({is_unlocked: false})
-        .expect(400)
-        .expect(({body}) => {
-          expect(body.error).toBe('Error happened');
+        mockChangeReportLockStatus.mockRejectedValue({
+          error: 'Error happened',
         });
+        return request(app)
+          .patch('/4492feff-99d7-4b2b-8896-12a59a75d4e3')
+          .send({ is_unlocked: false })
+          .expect(400)
+          .expect(({ body }) => {
+            expect(body.error).toBe('Error happened');
+          });
       });
-     });
+    });
     it('404 - report is not found', () => {
       mockChangeReportLockStatus.mockRejectedValue({ code: 'P2025' });
-      return request(app).patch('/4492feff-99d7-4b2b-8896-12a59a75d4e3')
-      .send({is_unlocked: false})
-      .expect(404)
-      .expect(({body}) => {
-        expect(body.error).toBe('Report not found')
-      });
+      return request(app)
+        .patch('/4492feff-99d7-4b2b-8896-12a59a75d4e3')
+        .send({ is_unlocked: false })
+        .expect(404)
+        .expect(({ body }) => {
+          expect(body.error).toBe('Report not found');
+        });
     });
     it('200 - report lock status changed', () => {
       mockChangeReportLockStatus.mockResolvedValue({
         report_id: '4492feff-99d7-4b2b-8896-12a59a75d4e3',
       });
-      return request(app).patch('/4492feff-99d7-4b2b-8896-12a59a75d4e3')
-      .send({is_unlocked: false})
-      .expect(200)
-      .expect(({body}) => {
-        expect(body).toEqual({
-          report_id: '4492feff-99d7-4b2b-8896-12a59a75d4e3',
+      return request(app)
+        .patch('/4492feff-99d7-4b2b-8896-12a59a75d4e3')
+        .send({ is_unlocked: false })
+        .expect(200)
+        .expect(({ body }) => {
+          expect(body).toEqual({
+            report_id: '4492feff-99d7-4b2b-8896-12a59a75d4e3',
+          });
         });
-      });
     });
   });
 });

--- a/backend/src/v1/routes/admin-report-routes.spec.ts
+++ b/backend/src/v1/routes/admin-report-routes.spec.ts
@@ -82,12 +82,23 @@ describe('admin-report-routes', () => {
 
   describe('GET /:id', () => {
     describe('if reportId is valid', () => {
-      it('should default offset=0 and limit=20', async () => {
+      it('should fetch a pdf report', async () => {
         const mockReportId = '4492feff-99d7-4b2b-8896-12a59a75d4e3';
         await request(app)
           .get(`/${mockReportId}`)
           .set('accepts', 'application/pdf')
           .expect(200);
+        expect(mockGetReportPdf.mock.calls[0][1]).toBe(mockReportId);
+      });
+    });
+    describe('if reportId is invalid', () => {
+      it('return an error', async () => {
+        const mockReportId = '4492feff-99d7-4b2b-8896-12a59a75d4e3';
+        mockGetReportPdf.mockResolvedValueOnce(null);
+        await request(app)
+          .get(`/${mockReportId}`)
+          .set('accepts', 'application/pdf')
+          .expect(400);
         expect(mockGetReportPdf.mock.calls[0][1]).toBe(mockReportId);
       });
     });

--- a/backend/src/v1/routes/report-routes.ts
+++ b/backend/src/v1/routes/report-routes.ts
@@ -88,8 +88,8 @@ reportRouter.put(
 
       let reportId: string = req.params.reportId;
       const report_to_publish = await reportService.getReportById(
-        bceidBusinessGuid,
         reportId,
+        bceidBusinessGuid,
       );
 
       if (!report_to_publish) {
@@ -113,8 +113,8 @@ reportRouter.put(
 
       try {
         const report = await reportService.getReportById(
-          bceidBusinessGuid,
           reportId,
+          bceidBusinessGuid,
         );
         res.status(200).send(report);
       } catch (e) {
@@ -158,8 +158,8 @@ reportRouter.get(
       if (req.accepts('application/json')) {
         // get reports by status if status param is provided
         const report = await reportService.getReportById(
-          businessGuid,
           reportId,
+          businessGuid,
         );
         if (report) return res.status(HttpStatus.OK).json(report);
       }
@@ -171,10 +171,8 @@ reportRouter.get(
       //accepts 'pdf'
       else if (req.accepts('application/pdf')) {
         const pdf: Buffer = await reportService.getReportPdf(req, reportId);
-        const filename: string = await reportService.getReportFileName(
-          businessGuid,
-          reportId,
-        );
+        const filename: string =
+          await reportService.getReportFileName(reportId);
 
         if (pdf && filename) {
           res.set('Content-Type', 'application/pdf');

--- a/backend/src/v1/services/file-upload-service.ts
+++ b/backend/src/v1/services/file-upload-service.ts
@@ -368,8 +368,8 @@ const fileUploadService = {
         correlationId,
       );
       const report: Report = await reportService.getReportById(
-        bceidBusinessGuid,
         reportId,
+        bceidBusinessGuid,
       );
       return report;
     } catch (err) {

--- a/backend/src/v1/services/report-service.spec.ts
+++ b/backend/src/v1/services/report-service.spec.ts
@@ -152,7 +152,7 @@ const mockPublishedReportInDb: pay_transparency_report = {
   is_unlocked: true,
   report_unlock_date: null,
   idir_modified_date: new Date(),
-  idir_modified_username: ""
+  idir_modified_username: '',
 };
 
 const mockPublishedReportInApi: Report =
@@ -1011,8 +1011,8 @@ describe('getReportById', () => {
     };
     mockCompanyFindFirst.mockResolvedValue(mockReportResults);
     const ret = await reportService.getReportById(
-      mockCompanyInDB.company_id,
       report.report_id,
+      mockCompanyInDB.company_id,
     );
     expect(ret).toEqual(expectedReport);
   });
@@ -1055,7 +1055,6 @@ describe('getReportFileName', () => {
       .mockResolvedValueOnce(reportInApi);
 
     const ret = await reportService.getReportFileName(
-      mockCompanyInDB.company_id,
       '32655fd3-22b7-4b9a-86de-2bfc0fcf9102',
     );
     expect(ret).toBe('pay_transparency_report_2023-01_2023-12.pdf');

--- a/backend/src/v1/services/report-service.ts
+++ b/backend/src/v1/services/report-service.ts
@@ -1363,16 +1363,23 @@ const reportService = {
 
   /**
    *
-   * @param bceidBusinessGuid
    * @param reportId
+   * @param bceidBusinessGuid optional BCeID business GUID.  if specified, the
+   * given reportId must be associated with the given BCeID business GUID.  If not
+   * specified, this requirement is omitted.
    * @returns
    *    - object for a single report or
    *    - null or undefined if report couldn't be found
    */
   async getReportById(
-    bceidBusinessGuid: string,
     reportId: string,
+    bceidBusinessGuid: string = null,
   ): Promise<Report> {
+    const limitToBceidBusinessGuid = bceidBusinessGuid
+      ? {
+          bceid_business_guid: bceidBusinessGuid,
+        }
+      : {};
     const reports = await prisma.pay_transparency_company.findFirst({
       select: {
         pay_transparency_report: {
@@ -1397,9 +1404,7 @@ const reportService = {
           take: 1,
         },
       },
-      where: {
-        bceid_business_guid: bceidBusinessGuid,
-      },
+      where: limitToBceidBusinessGuid,
     });
     if (!reports) return null;
 
@@ -1418,14 +1423,8 @@ const reportService = {
     return first;
   },
 
-  async getReportFileName(
-    bceidBusinessGuid: string,
-    reportId: string,
-  ): Promise<string> {
-    const report: Report = await this.getReportById(
-      bceidBusinessGuid,
-      reportId,
-    );
+  async getReportFileName(reportId: string): Promise<string> {
+    const report: Report = await this.getReportById(reportId);
 
     if (report) {
       const start = LocalDate.parse(report.report_start_date).format(


### PR DESCRIPTION
# Description

Changes to allow the admin-frontend to download a report PDF and open it in a new browser tab.

Fixes # [GEO-629](https://finrms.atlassian.net/browse/GEO-629)

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Existing unit tests for backend.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have already been accepted and merged



[GEO-629]: https://finrms.atlassian.net/browse/GEO-629?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://pay-transparency-pr-542-frontend.apps.silver.devops.gov.bc.ca)
- [Admin Frontend](https://pay-transparency-pr-542-admin-frontend.apps.silver.devops.gov.bc.ca)
- [Backend external API console](https://pay-transparency-pr-542-backend-external.apps.silver.devops.gov.bc.ca/api/V1/docs)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/fin-pay-transparency/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/fin-pay-transparency/actions/workflows/merge.yml)