### PR TITLE
feat: admin report page improvements

### DIFF
--- a/admin-frontend/src/components/ReportSearchFilters.vue
+++ b/admin-frontend/src/components/ReportSearchFilters.vue
@@ -123,7 +123,7 @@
         <h5>Locked/Unlocked</h5>
         <v-select
           v-model="selectedLockedValues"
-          :items="[null, 'Locked', 'Unlocked']"
+          :items="lockedOptions"
           variant="solo"
           density="compact"
         >
@@ -234,6 +234,7 @@ const selectedEmployeeCount = ref([]);
 
 const { employeeCountRanges, naicsCodes } = storeToRefs(codeStore);
 const reportYearOptions = ref([null, 2024, 2023]);
+const lockedOptions = ref([null, 'Locked', 'Unlocked']);
 
 function getReportSearchFilters(): ReportFilterType {
   const filters = [];
@@ -287,6 +288,13 @@ function getReportSearchFilters(): ReportFilterType {
       key: 'employee_count_range_id',
       operation: 'in',
       value: selectedEmployeeCount.value?.map((d) => d.employee_count_range_id),
+    });
+  }
+  if (selectedLockedValues.value) {
+    filters.push({
+      key: 'is_unlocked',
+      operation: 'eq',
+      value: selectedLockedValues.value == 'Unlocked',
     });
   }
   return filters;

--- a/admin-frontend/src/components/ReportsPage.vue
+++ b/admin-frontend/src/components/ReportsPage.vue
@@ -7,10 +7,10 @@
     </v-col>
   </v-row>
 
-  <div class="search-results w-100" v-if="searchResults">
+  <div class="search-results w-100">
     <v-row class="mt-0 w-100" no-gutters>
       <v-col sm="8" md="8" lg="6" xl="4" class="d-flex align-center">
-        <h4>
+        <h4 v-if="searchResults?.length">
           Displaying {{ searchResults.length }} report<span
             v-if="searchResults.length != 1"
             >s</span
@@ -28,6 +28,7 @@
           class="btn-primary"
           prepend-icon="mdi-export"
           @click="exportResults()"
+          :disabled="!searchResults?.length"
         >
           Export results
         </v-btn>
@@ -42,7 +43,9 @@
       :loading="isSearching"
       :items-per-page-options="itemsPerPageOptions"
       search=""
-      no-data-text="No reports matched the search criteria"
+      :no-data-text="
+        hasSearched ? 'No reports matched the search criteria' : ''
+      "
       @update:options="updateSearch"
     >
       <template v-slot:item.update_date="{ item }">
@@ -91,15 +94,15 @@ const displayDateFormatter = DateTimeFormatter.ofPattern(
 ).withLocale(Locale.CANADA);
 
 const reportSearchStore = useReportSearchStore();
-const { searchResults, isSearching, totalNum, pageSize } =
+const { searchResults, isSearching, hasSearched, totalNum, pageSize } =
   storeToRefs(reportSearchStore);
 const confirmDialog = ref<typeof ConfirmationDialog>();
 const itemsPerPageOptions = ref([
   { value: 1, title: '1' },
   { value: 2, title: '2' },
-  { value: 10, title: '10' },
-  { value: 20, title: '20' },
-  { value: 40, title: '40' },
+  { value: 50, title: '50' },
+  { value: 100, title: '100' },
+  { value: 150, title: '150' },
 ]);
 
 const headers = ref([

--- a/admin-frontend/src/store/modules/reportSearchStore.ts
+++ b/admin-frontend/src/store/modules/reportSearchStore.ts
@@ -9,7 +9,7 @@ import {
   SORT_KEY_MAPPING,
 } from '../../types';
 
-export const DEFAULT_PAGE_SIZE = 10;
+export const DEFAULT_PAGE_SIZE = 100;
 
 /*
 Stores report search results and provides functions to fetch new 
@@ -32,6 +32,10 @@ export const useReportSearchStore = defineStore('reportSearch', () => {
       totalNum.value !== 0 ||
       pageSize.value !== DEFAULT_PAGE_SIZE ||
       lastSubmittedReportSearchParams.value !== undefined,
+  );
+  const hasSearched = computed(
+    () =>
+      !isSearching.value && lastSubmittedReportSearchParams.value !== undefined,
   );
 
   //public actions
@@ -158,6 +162,7 @@ export const useReportSearchStore = defineStore('reportSearch', () => {
     totalNum,
     pageSize,
     isDirty,
+    hasSearched,
     //actions
     searchReports,
     updateSearch,


### PR DESCRIPTION
Improvements to the report (search) page, including:

- Default page size is now 100
- Fixed a problem with the locked/unlocked filter
- Data table is auto populated with reports on page load (no need to first click the search button)

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://pay-transparency-pr-543-frontend.apps.silver.devops.gov.bc.ca)
- [Admin Frontend](https://pay-transparency-pr-543-admin-frontend.apps.silver.devops.gov.bc.ca)
- [Backend external API console](https://pay-transparency-pr-543-backend-external.apps.silver.devops.gov.bc.ca/api/V1/docs)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/fin-pay-transparency/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/fin-pay-transparency/actions/workflows/merge.yml)