### PR TITLE
feat: GEO-698 Save errors in db

### DIFF
--- a/.github/workflows/.deploy.yml
+++ b/.github/workflows/.deploy.yml
@@ -132,6 +132,7 @@ jobs:
           --set-string global.secrets.bceidWsOnlineServiceId="${{ secrets.BCEID_WS_ONLINE_SERVICE_ID }}"  \
           --set-string global.secrets.externalConsumerApiKey="${{ secrets.EXTERNAL_CONSUMER_API_KEY }}"  \
           --set-string global.secrets.externalConsumerDeleteReportsApiKey="${{ secrets.EXTERNAL_CONSUMER_DELETE_REPORTS_API_KEY }}" \
+          --set-string global.secrets.externalConsumerErrorReportsApiKey="${{ secrets.EXTERNAL_CONSUMER_ERROR_REPORTS_API_KEY }}" \
           --set-string global.secrets.chesTokenURL="${{ secrets.CHES_TOKEN_ENDPOINT }}" \
           --set-string global.secrets.chesClientID="${{ secrets.CHES_CLIENT_ID }}" \
           --set-string global.secrets.chesClientSecret="${{ secrets.CHES_CLIENT_SECRET }}"  \

--- a/backend-external/src/config/index.ts
+++ b/backend-external/src/config/index.ts
@@ -11,7 +11,11 @@ config.defaults({
     morganFormat: 'dev',
     apiKey: process.env.EXTERNAL_CONSUMER_API_KEY || 'api-key',
     deleteReportsApiKey:
-      process.env.EXTERNAL_CONSUMER_DELETE_REPORTS_API_KEY || 'api-delete-reports-key',
+      process.env.EXTERNAL_CONSUMER_DELETE_REPORTS_API_KEY ||
+      'api-delete-reports-key',
+    errorReportsApiKey:
+      process.env.EXTERNAL_CONSUMER_ERROR_REPORTS_API_KEY ||
+      'api-error-reports-key',
     port: process.env.PORT || 3002,
     rateLimit: {
       enabled: process.env.IS_RATE_LIMIT_ENABLED || false, // Disable if rate limiting is not required

--- a/backend-external/src/v1/routes/pay-transparency-routes.spec.ts
+++ b/backend-external/src/v1/routes/pay-transparency-routes.spec.ts
@@ -4,10 +4,12 @@ import router from './pay-transparency-routes';
 
 const mockGetPayTransparencyData = jest.fn();
 const mockDeleteReports = jest.fn();
+const mockGetReportErrors = jest.fn();
 jest.mock('../services/pay-transparency-service', () => ({
   payTransparencyService: {
     getPayTransparencyData: (...args) => mockGetPayTransparencyData(...args),
     deleteReports: (...args) => mockDeleteReports(...args),
+    getReportErrors: (...args) => mockGetReportErrors(...args),
   },
 }));
 
@@ -60,7 +62,7 @@ describe('pay-transparency-routes', () => {
     describe('should default to max page size 50', () => {
       it('when specified page size if greater than 50', () => {
         mockGetPayTransparencyData.mockImplementation((...args) => {
-          expect(args[3]).toBe(50)
+          expect(args[3]).toBe(50);
           return {
             status: 200,
             data: [{ id: 1 }],
@@ -114,6 +116,71 @@ describe('pay-transparency-routes', () => {
         .delete('/')
         .set('x-api-key', 'api-delete-reports-key')
         .expect(404);
+    });
+  });
+
+  describe('GET /errors', () => {
+    it('should return data if user does not send query params', async () => {
+      mockGetReportErrors.mockReturnValue({
+        status: 200,
+        data: [{ id: 1 }],
+      });
+      await request(app)
+        .get('/errors')
+        .set('x-api-key', 'api-error-reports-key')
+        .expect(200)
+        .expect(({ body }) => {
+          expect(body).toHaveLength(1);
+        });
+      expect(mockGetReportErrors).toHaveBeenCalledWith(
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+      );
+    });
+    it('should forward all parameters to the function', async () => {
+      mockGetReportErrors.mockReturnValue({
+        status: 200,
+        data: [{ id: 1 }],
+      });
+      await request(app)
+        .get('/errors')
+        .set('x-api-key', 'api-error-reports-key')
+        .query({
+          startDate: 'start',
+          endDate: 'end',
+          page: '1',
+          pageSize: '50',
+        })
+        .expect(200)
+        .expect(({ body }) => {
+          expect(body).toHaveLength(1);
+        });
+      expect(mockGetReportErrors).toHaveBeenCalledWith(
+        'start',
+        'end',
+        '1',
+        '50',
+      );
+    });
+
+    it('should return 400 if the function has an error', () => {
+      mockGetReportErrors.mockReturnValue({
+        data: { message: 'Failed to get data', error: true },
+      });
+      return request(app)
+        .get('/errors')
+        .set('x-api-key', 'api-error-reports-key')
+        .expect(400);
+    });
+
+    it('should fail if request fails', () => {
+      mockGetReportErrors.mockRejectedValue({ message: 'Error happened' });
+      return request(app)
+        .get('/errors')
+        .set('x-api-key', 'api-error-reports-key')
+        .expect(500);
     });
   });
 });

--- a/backend-external/src/v1/services/pay-transparency-service.spec.ts
+++ b/backend-external/src/v1/services/pay-transparency-service.spec.ts
@@ -16,6 +16,7 @@ describe('pay-transparency-service', () => {
   beforeEach(() => {
     jest.clearAllMocks();
   });
+
   describe('getPayTransparencyData', () => {
     it('should forward to request  to the backend api', async () => {
       mockGet.mockReturnValue({});
@@ -25,14 +26,17 @@ describe('pay-transparency-service', () => {
         0,
         1000,
       );
-      expect(mockGet).toHaveBeenCalledWith('/external-consumer-api/v1/reports', {
-        params: {
-          startDate: 'start',
-          endDate: 'end',
-          offset: 0,
-          limit: 1000,
+      expect(mockGet).toHaveBeenCalledWith(
+        '/external-consumer-api/v1/reports',
+        {
+          params: {
+            startDate: 'start',
+            endDate: 'end',
+            offset: 0,
+            limit: 1000,
+          },
         },
-      });
+      );
     });
   });
 
@@ -49,6 +53,24 @@ describe('pay-transparency-service', () => {
           params: { companyName: '1234567890' },
           headers: {
             'x-api-key': 'api-key',
+          },
+        },
+      );
+    });
+  });
+
+  describe('getReportErrors', () => {
+    it('should forward to request to the backend api', async () => {
+      mockGet.mockReturnValue({});
+      await payTransparencyService.getReportErrors('start', 'end', '0', '1000');
+      expect(mockGet).toHaveBeenCalledWith(
+        '/external-consumer-api/v1/reports/errors',
+        {
+          params: {
+            startDate: 'start',
+            endDate: 'end',
+            page: '0',
+            limit: '1000',
           },
         },
       );

--- a/backend-external/src/v1/services/pay-transparency-service.ts
+++ b/backend-external/src/v1/services/pay-transparency-service.ts
@@ -23,6 +23,7 @@ export const payTransparencyService = {
       .get('/external-consumer-api/v1/reports', axiosConfig);
     return { status, data };
   },
+
   async deleteReports(req: Request) {
     const axiosConfig: AxiosRequestConfig = {
       params: req.query,
@@ -34,6 +35,26 @@ export const payTransparencyService = {
       error: boolean;
       message: string;
     }>('/external-consumer-api/v1/reports', axiosConfig);
+    return { status, data };
+  },
+
+  async getReportErrors(
+    startDate: string,
+    endDate: string,
+    page: string,
+    limit: string,
+  ) {
+    const axiosConfig = {
+      params: {
+        startDate,
+        endDate,
+        page,
+        limit,
+      },
+    };
+    const { status, data } = await utils
+      .backendAxios()
+      .get('/external-consumer-api/v1/reports/errors', axiosConfig);
     return { status, data };
   },
 };

--- a/backend/db/migrations/V1.0.26__error_table.sql
+++ b/backend/db/migrations/V1.0.26__error_table.sql
@@ -1,0 +1,17 @@
+SET search_path TO pay_transparency;
+
+create table if not exists user_error
+(
+    user_error_id   uuid            default gen_random_uuid()   not null,
+    user_id         uuid                                        not null,
+    company_id      uuid                                        not null,
+    error           varchar(255)                                not null,
+    create_date     timestamp       default current_timestamp   not null,
+    constraint user_error_id_pk primary key (user_error_id),
+    constraint error_pt_user_id_fk foreign key (user_id) references pay_transparency_user (user_id),
+    constraint error_pt_company_id_fk foreign key (company_id) references pay_transparency_company (company_id)
+
+);
+
+CREATE INDEX "user_error_create_date_idx" ON "user_error"("create_date");
+

--- a/backend/src/v1/prisma/schema.prisma
+++ b/backend/src/v1/prisma/schema.prisma
@@ -105,6 +105,7 @@ model pay_transparency_company {
   company_history         company_history[]
   pay_transparency_report pay_transparency_report[]
   report_history          report_history[]
+  user_error              user_error[]
 
   @@index([bceid_business_guid])
 }
@@ -154,6 +155,7 @@ model pay_transparency_user {
   update_date             DateTime                  @default(now()) @db.Timestamp(6)
   pay_transparency_report pay_transparency_report[]
   report_history          report_history[]
+  user_error              user_error[]
 
   @@index([bceid_user_guid, bceid_business_guid])
 }
@@ -211,6 +213,18 @@ model calculated_data_history {
   report_history             report_history   @relation(fields: [report_history_id], references: [report_history_id], onDelete: NoAction, onUpdate: NoAction, map: "calculated_data_history_report_id_fk")
 
   @@unique([report_history_id, calculation_code_id])
+}
+
+model user_error {
+  user_error_id            String                   @id(map: "user_error_id_pk") @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  user_id                  String                   @db.Uuid
+  company_id               String                   @db.Uuid
+  error                    String                   @db.VarChar(255)
+  create_date              DateTime                 @default(now()) @db.Timestamp(6)
+  pay_transparency_company pay_transparency_company @relation(fields: [company_id], references: [company_id], onDelete: NoAction, onUpdate: NoAction, map: "error_pt_company_id_fk")
+  pay_transparency_user    pay_transparency_user    @relation(fields: [user_id], references: [user_id], onDelete: NoAction, onUpdate: NoAction, map: "error_pt_user_id_fk")
+
+  @@index([create_date])
 }
 
 view reports_view {

--- a/backend/src/v1/routes/external-consumer-routes.ts
+++ b/backend/src/v1/routes/external-consumer-routes.ts
@@ -2,6 +2,7 @@ import express, { Request, Response } from 'express';
 import { externalConsumerService } from '../services/external-consumer-service';
 import { utils } from '../services/utils-service';
 import { reportService } from '../services/report-service';
+import { errorService } from '../services/error-service';
 
 const router = express.Router();
 
@@ -38,5 +39,40 @@ router.delete('/', async (req, res) => {
     res.json({ error: true, message: error.message });
   }
 });
+
+/**
+ * GET /external-consumer-api/v1/reports/errors ?startDate= &endDate= &page= &limit=
+ */
+router.get(
+  '/errors',
+  utils.asyncHandler(
+    async (
+      req: Request<
+        null,
+        null,
+        null,
+        {
+          startDate: string;
+          endDate: string;
+          page: string;
+          limit: string;
+        }
+      >,
+      res: Response,
+    ) => {
+      try {
+        const results = await errorService.retrieveErrors(
+          req.query.startDate,
+          req.query.endDate,
+          req.query.page,
+          req.query.limit,
+        );
+        res.status(200).json(results);
+      } catch (e) {
+        res.json({ error: true, message: e.message });
+      }
+    },
+  ),
+);
 
 export default router;

--- a/backend/src/v1/routes/file-upload-routes.spec.ts
+++ b/backend/src/v1/routes/file-upload-routes.spec.ts
@@ -1,16 +1,32 @@
 import express, { Application } from 'express';
 import request from 'supertest';
 import { fileUploadRouter } from './file-upload-routes';
+import { SubmissionError } from '../services/file-upload-service';
 let app: Application;
 
+// Mock the module, but only override handleSubmission
 const mockHandleSubmission = jest.fn().mockResolvedValue({});
-const mockGetCompanies = jest.fn();
-jest.mock('../services/file-upload-service', () => ({
-  fileUploadService: {
-    handleSubmission: jest.fn((...args) => mockHandleSubmission(...args)),
-    getCompanies: () => mockGetCompanies(),
+jest.mock('../services/file-upload-service', () => {
+  const actualFileUploadService = jest.requireActual(
+    '../services/file-upload-service',
+  );
+  return {
+    ...actualFileUploadService,
+    fileUploadService: {
+      ...actualFileUploadService.fileUploadService,
+      handleSubmission: jest.fn((...args) => mockHandleSubmission(...args)),
+    },
+  };
+});
+
+const mockStoreError = jest.fn();
+jest.mock('../services/error-service', () => ({
+  errorService: {
+    storeError: () => mockStoreError(),
+    retrieveErrors: jest.fn(),
   },
 }));
+
 describe('file-upload', () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -19,8 +35,21 @@ describe('file-upload', () => {
   });
 
   describe('/', () => {
-    it('/ [POST] - should return 200', () => {
-      return request(app).post('/');
+    it('/ [POST] - should return 200', async () => {
+      await request(app).post('/').expect(200);
+      expect(mockStoreError).not.toHaveBeenCalled();
+    });
+    it('/ [POST] - should return 400', async () => {
+      mockHandleSubmission.mockResolvedValue(new SubmissionError('test'));
+      await request(app).post('/').expect(400);
+      expect(mockStoreError).toHaveBeenCalled();
+    });
+    it('/ [POST] - should return 500', async () => {
+      mockHandleSubmission.mockImplementation(() => {
+        throw Error('test');
+      });
+      await request(app).post('/').expect(500);
+      expect(mockStoreError).toHaveBeenCalled();
     });
   });
 });

--- a/backend/src/v1/services/error-service.spec.ts
+++ b/backend/src/v1/services/error-service.spec.ts
@@ -1,0 +1,212 @@
+import { DateTimeFormatter, ZoneId, ZonedDateTime } from '@js-joda/core';
+import prisma from '../prisma/prisma-client';
+import prismaReadOnlyReplica from '../prisma/prisma-client-readonly-replica';
+import { errorService } from './error-service';
+import { SubmissionError } from './file-upload-service';
+import { ValidationError, RowError } from './validate-service';
+
+jest.mock('../prisma/prisma-client', () => {
+  return {
+    user_error: {
+      createMany: jest.fn(),
+    },
+  };
+});
+
+jest.mock('../prisma/prisma-client-readonly-replica', () => {
+  return {
+    pay_transparency_user: {
+      findFirst: jest.fn(),
+    },
+    pay_transparency_company: {
+      findFirst: jest.fn(),
+    },
+    user_error: {
+      findMany: jest.fn(),
+      count: jest.fn(),
+    },
+  };
+});
+
+const mockCompanyInDB = {
+  company_id: 'cf175a22-217f-4f3f-b2a4-8b43dd19a9a2', // random guid
+};
+const mockUserInDB = {
+  user_id: '727dc60a-95a3-4a83-9b6b-1fb0e1de7cc3', // random guid
+};
+
+const mockUserInfo = {
+  _json: {
+    bceid_user_guid: '727dc60a-95a3-4a83-9b6b-1fb0e1de7cc3', // random guid
+    bceid_business_guid: 'cf175a22-217f-4f3f-b2a4-8b43dd19a9a2', // random guid
+  },
+};
+
+const mockValidationError = new ValidationError(
+  //bodyErrors
+  [
+    'Minimum allowed start date is 2024.',
+    'Start date and end date must always be 12 months apart.',
+  ],
+  //rowErrors
+  [
+    new RowError(13, [
+      'Hours Worked must not contain data when Special Salary contains data.',
+      'Ordinary Pay must not be blank or 0 when Hours Worked contains data.',
+    ]),
+    new RowError(1142, [
+      "Invalid Gender Code 'D' (expected one of: M, W, F, X, U).",
+    ]),
+  ],
+  //GeneralErrors
+  ['Something went wrong.'],
+);
+
+const mockArray = [
+  'Minimum allowed start date is 2024.',
+  'Start date and end date must always be 12 months apart.',
+  'Hours Worked must not contain data when Special Salary contains data.',
+  'Ordinary Pay must not be blank or 0 when Hours Worked contains data.',
+  "Invalid Gender Code 'D' (expected one of: M, W, F, X, U).",
+  'Something went wrong.',
+];
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('storeError', () => {
+  (
+    prismaReadOnlyReplica.pay_transparency_company.findFirst as jest.Mock
+  ).mockResolvedValue(mockCompanyInDB);
+  (
+    prismaReadOnlyReplica.pay_transparency_user.findFirst as jest.Mock
+  ).mockResolvedValue(mockUserInDB);
+
+  it('stores SubmissionError with ValidationError', async () => {
+    await errorService.storeError(
+      mockUserInfo,
+      new SubmissionError(mockValidationError),
+    );
+    const createMany = (prisma.user_error.createMany as jest.Mock).mock
+      .calls[0][0];
+    expect(createMany.data.map((x) => x.error)).toStrictEqual(mockArray);
+  });
+
+  it('stores SubmissionError with string', async () => {
+    const error = 'Something went wrong';
+    const subError = new SubmissionError(error);
+    await errorService.storeError(mockUserInfo, subError);
+    const createMany = (prisma.user_error.createMany as jest.Mock).mock
+      .calls[0][0];
+    expect(createMany.data.map((x) => x.error)).toStrictEqual([error]);
+  });
+
+  it('stores Error', async () => {
+    const error = 'test error';
+    const errorObj = new Error(error);
+    await errorService.storeError(mockUserInfo, errorObj);
+    const createMany = (prisma.user_error.createMany as jest.Mock).mock
+      .calls[0][0];
+    expect(createMany.data.map((x) => x.error)).toStrictEqual([error]);
+  });
+
+  it('does not store anything if there are no errors', async () => {
+    await errorService.storeError(
+      mockUserInfo,
+      new SubmissionError(new ValidationError([], [], [])),
+    );
+
+    expect(prisma.user_error.createMany).toHaveBeenCalledTimes(0);
+  });
+});
+
+describe('retrieveErrors', () => {
+  it('runs with default values', async () => {
+    await errorService.retrieveErrors();
+    expect(prismaReadOnlyReplica.user_error.findMany).toHaveBeenCalled();
+  });
+
+  it('limit is calculated correctly', async () => {
+    await errorService.retrieveErrors(undefined, undefined, '5', '20');
+    expect(prismaReadOnlyReplica.user_error.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        skip: 100,
+      }),
+    );
+  });
+
+  it('accepts ISO-8601 dates', async () => {
+    await errorService.retrieveErrors(
+      '2024-05-20T00:00-07:00',
+      '2024-05-20T23:59-07:00',
+    );
+    expect(prismaReadOnlyReplica.user_error.findMany).toHaveBeenCalled();
+  });
+
+  it('accepts ISO-8601 UTC dates', async () => {
+    await errorService.retrieveErrors('2024-05-20T00:00Z', '2024-05-20T23:59Z');
+    expect(prismaReadOnlyReplica.user_error.findMany).toHaveBeenCalled();
+  });
+
+  it('accepts yyyy-MM-dd HH:mm dates', async () => {
+    await errorService.retrieveErrors('2024-05-20 00:00', '2024-05-20 23:59');
+    expect(prismaReadOnlyReplica.user_error.findMany).toHaveBeenCalled();
+  });
+
+  it('limit: throws error if parameter is not valid', async () => {
+    await expect(
+      errorService.retrieveErrors(undefined, undefined, undefined, '0'),
+    ).rejects.toThrow();
+    await expect(
+      errorService.retrieveErrors(undefined, undefined, undefined, '-1'),
+    ).rejects.toThrow();
+    await expect(
+      errorService.retrieveErrors(undefined, undefined, undefined, '1001'),
+    ).rejects.toThrow();
+    await expect(
+      errorService.retrieveErrors(undefined, undefined, undefined, 'abc'),
+    ).rejects.toThrow();
+  });
+
+  it('page: throws error if parameter is not valid', async () => {
+    await expect(
+      errorService.retrieveErrors(undefined, undefined, '-1'),
+    ).rejects.toThrow();
+    await expect(
+      errorService.retrieveErrors(undefined, undefined, 'abc'),
+    ).rejects.toThrow();
+  });
+
+  it('end date: throws error if parameter is not valid', async () => {
+    await expect(
+      errorService.retrieveErrors(undefined, 'hello'),
+    ).rejects.toThrow();
+  });
+
+  it('end date: throws error if parameter is in the future', async () => {
+    await expect(
+      errorService.retrieveErrors(
+        undefined,
+        ZonedDateTime.now(ZoneId.UTC)
+          .plusMinutes(1)
+          .format(DateTimeFormatter.ISO_DATE_TIME),
+      ),
+    ).rejects.toThrow();
+  });
+
+  it('start date: throws error if parameter is not valid', async () => {
+    await expect(errorService.retrieveErrors('hello')).rejects.toThrow();
+  });
+
+  it('start date: throws error if parameter is after end date', async () => {
+    await expect(
+      errorService.retrieveErrors(
+        ZonedDateTime.now(ZoneId.UTC)
+          .plusDays(1)
+          .format(DateTimeFormatter.ISO_DATE_TIME),
+        ZonedDateTime.now(ZoneId.UTC).format(DateTimeFormatter.ISO_DATE_TIME),
+      ),
+    ).rejects.toThrow();
+  });
+});

--- a/backend/src/v1/services/error-service.ts
+++ b/backend/src/v1/services/error-service.ts
@@ -1,0 +1,164 @@
+import {
+  DateTimeFormatter,
+  LocalDate,
+  LocalDateTime,
+  TemporalAccessor,
+  TemporalQueries,
+  ZoneId,
+  ZonedDateTime,
+  convert,
+} from '@js-joda/core';
+import prisma from '../prisma/prisma-client';
+import prismaReadOnlyReplica from '../prisma/prisma-client-readonly-replica';
+import { SubmissionError } from '../services/file-upload-service';
+import { ValidationError } from './validate-service';
+
+function ConvertStringToZonedISO(str: string): ZonedDateTime {
+  str = str.toUpperCase().trim();
+  const DATETIMEZONE_FORMATTER = DateTimeFormatter.ofPattern(
+    `yyyy-MM-dd[' ']['T'][' ']HH:mm[:ss][.SSS][' '][VV]`,
+  );
+
+  const dateTimeQuery = {
+    queryFrom: function (temporal: TemporalAccessor) {
+      if (temporal.query(TemporalQueries.zoneId()))
+        return ZonedDateTime.from(temporal);
+      else return LocalDateTime.from(temporal).atZone(ZoneId.UTC);
+    },
+  };
+
+  return DATETIMEZONE_FORMATTER.parse(str, dateTimeQuery);
+}
+
+const errorService = {
+  /**
+   * Stores the errors in the database
+   * @param userInfo
+   * @param errors - supports classes Error, SubmissionError, ValidationError
+   */
+  async storeError(userInfo, errors: Error) {
+    let errorArr = [];
+    if (
+      errors instanceof SubmissionError &&
+      errors.error instanceof ValidationError
+    ) {
+      const bodyErrors = errors.error.bodyErrors ?? [];
+      const generalErrors = errors.error.generalErrors ?? [];
+      const rowErrorMessages =
+        errors.error.rowErrors?.flatMap((rowError) => rowError.errorMsgs) ?? [];
+
+      errorArr = [...bodyErrors, ...rowErrorMessages, ...generalErrors];
+    } else if (errors instanceof SubmissionError) {
+      errorArr = [errors.error];
+    } else {
+      errorArr = [errors.message];
+    }
+
+    if (errorArr.length) {
+      const payTransparencyUser =
+        await prismaReadOnlyReplica.pay_transparency_user.findFirst({
+          where: {
+            bceid_user_guid: userInfo._json.bceid_user_guid,
+            bceid_business_guid: userInfo._json.bceid_business_guid,
+          },
+        });
+
+      const payTransparencyCompany =
+        await prismaReadOnlyReplica.pay_transparency_company.findFirst({
+          where: {
+            bceid_business_guid: userInfo._json.bceid_business_guid,
+          },
+        });
+
+      const now = ZonedDateTime.now(ZoneId.UTC).format(
+        DateTimeFormatter.ISO_DATE_TIME,
+      );
+      await prisma.user_error.createMany({
+        data: errorArr.map((message) => ({
+          user_id: payTransparencyUser.user_id,
+          company_id: payTransparencyCompany.company_id,
+          error: message,
+          create_date: now,
+        })),
+      });
+    }
+  },
+
+  /**
+   * Retrieves the errors from the database.
+   * The submitted dates are only valid up to the minute, seconds will be
+   *   truncated. For example, 10:30:40 will be truncated to 10:30.
+   * @param startDate - The DateTime of the first minute which will be included in the output.
+   * @param endDate - The DateTime of the last minute which will be included in the output.
+   *   For example, 10:59 means everything before 11:00, but not including 11:00.
+   * @param pageStr - Pagination count
+   * @param pageSizeStr - Number of records to retrieve
+   * @returns - Pagination object
+   */
+  async retrieveErrors(
+    startDate: string = LocalDate.now(ZoneId.UTC)
+      .atStartOfDay(ZoneId.UTC)
+      .minusDays(31)
+      .format(DateTimeFormatter.ISO_DATE_TIME),
+    endDate: string = ZonedDateTime.now(ZoneId.UTC)
+      .minusMinutes(1)
+      .format(DateTimeFormatter.ISO_DATE_TIME),
+    pageStr: string = '0',
+    pageSizeStr: string = '1000',
+  ) {
+    // ensure that seconds weren't provided because they are ignored.
+    // and convert 'end' to be after the last provided minute.
+    const start: ZonedDateTime = ConvertStringToZonedISO(startDate)
+      ?.withSecond(0)
+      .withNano(0);
+    const end: ZonedDateTime = ConvertStringToZonedISO(endDate)
+      ?.plusMinutes(1)
+      .withSecond(0)
+      .withNano(0);
+
+    if (start.isAfter(end))
+      throw Error('Invalid start date; start date cannot be after end date');
+    if (end.isAfter(ZonedDateTime.now(ZoneId.UTC)))
+      throw Error('Invalid end date; cannot specify date in future');
+
+    const pageSize = parseInt(pageSizeStr);
+    if (Number.isNaN(pageSize) || pageSize <= 0 || pageSize > 1000)
+      throw Error('Invalid pageSize; must be > 0 && <= 1000');
+    const page = parseInt(pageStr);
+    if (Number.isNaN(page) || page < 0)
+      throw Error('Invalid page; must be >= 0');
+
+    const offset = page * pageSize;
+
+    const records = await prismaReadOnlyReplica.user_error.findMany({
+      include: { pay_transparency_company: true },
+      where: {
+        create_date: {
+          gte: convert(start).toDate(),
+          lt: convert(end).toDate(),
+        },
+      },
+      skip: offset,
+      take: pageSize,
+      orderBy: [{ create_date: 'asc' }, { user_error_id: 'asc' }],
+    });
+
+    const totalRecordsCount = await prismaReadOnlyReplica.user_error.count({
+      where: {
+        create_date: {
+          gte: convert(start).toDate(),
+          lt: convert(end).toDate(),
+        },
+      },
+    });
+
+    return {
+      totalRecords: totalRecordsCount,
+      page: offset / pageSize,
+      pageSize: pageSize,
+      records,
+    };
+  },
+};
+
+export { errorService };

--- a/backend/src/v1/services/error-service.ts
+++ b/backend/src/v1/services/error-service.ts
@@ -16,7 +16,7 @@ import { ValidationError } from './validate-service';
 function ConvertStringToZonedISO(str: string): ZonedDateTime {
   str = str.toUpperCase().trim();
   const DATETIMEZONE_FORMATTER = DateTimeFormatter.ofPattern(
-    `yyyy-MM-dd[' ']['T'][' ']HH:mm[:ss][.SSS][' '][VV]`,
+    `yyyy-MM-dd[' ']['T'][' ']HH:mm[:ss][.SSS][.S][' '][VV]`,
   );
 
   const dateTimeQuery = {

--- a/charts/fin-pay-transparency/charts/backend-external/templates/deployment.yaml
+++ b/charts/fin-pay-transparency/charts/backend-external/templates/deployment.yaml
@@ -55,6 +55,11 @@ spec:
                 secretKeyRef:
                   name: {{.Release.Name}}
                   key: EXTERNAL_CONSUMER_DELETE_REPORTS_API_KEY
+            - name: EXTERNAL_CONSUMER_ERROR_REPORTS_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{.Release.Name}}
+                  key: EXTERNAL_CONSUMER_ERROR_REPORTS_API_KEY
             - name: PORT
               value: {{ .Values.service.targetPort | quote }}
             - name: BACKEND_EXTERNAL_API_KEY

--- a/charts/fin-pay-transparency/templates/secret.yaml
+++ b/charts/fin-pay-transparency/templates/secret.yaml
@@ -39,6 +39,7 @@ data:
   DOC_GEN_API_KEY: {{ $docGenApiKey | quote }}
   EXTERNAL_CONSUMER_API_KEY: {{ .Values.global.secrets.externalConsumerApiKey | b64enc | quote }}
   EXTERNAL_CONSUMER_DELETE_REPORTS_API_KEY: {{ .Values.global.secrets.externalConsumerDeleteReportsApiKey | b64enc | quote }}
+  EXTERNAL_CONSUMER_ERROR_REPORTS_API_KEY: {{ .Values.global.secrets.externalConsumerErrorReportsApiKey | b64enc | quote }}
   BACKEND_EXTERNAL_API_KEY: {{ $backendExternalApiKey | quote }}
   CHES_TOKEN_URL: {{ .Values.global.secrets.chesTokenURL | b64enc | quote }}
   CHES_CLIENT_ID: {{ .Values.global.secrets.chesClientID | b64enc | quote }}

--- a/charts/fin-pay-transparency/values-dev.yaml
+++ b/charts/fin-pay-transparency/values-dev.yaml
@@ -22,6 +22,7 @@ global:
     bceidWsOnlineServiceId: ~
     externalConsumerApiKey: ~
     externalConsumerDeleteReportsApiKey: ~
+    externalConsumerErrorReportsApiKey: ~
     chesClientID: ~
     chesTokenURL: ~
     chesClientSecret: ~

--- a/charts/fin-pay-transparency/values-pr.yaml
+++ b/charts/fin-pay-transparency/values-pr.yaml
@@ -21,6 +21,7 @@ global:
     bceidWsOnlineServiceId: ~
     externalConsumerApiKey: ~
     externalConsumerDeleteReportsApiKey: ~
+    externalConsumerErrorReportsApiKey: ~
     chesClientID: ~
     chesTokenURL: ~
     chesClientSecret: ~

--- a/charts/fin-pay-transparency/values-prod.yaml
+++ b/charts/fin-pay-transparency/values-prod.yaml
@@ -22,6 +22,7 @@ global:
     bceidWsOnlineServiceId: ~
     externalConsumerApiKey: ~
     externalConsumerDeleteReportsApiKey: ~
+    externalConsumerErrorReportsApiKey: ~
     chesClientID: ~
     chesTokenURL: ~
     chesClientSecret: ~
@@ -212,7 +213,7 @@ crunchy:
         accessModes: "ReadWriteOnce"
         storage: 64Mi
         storageClassName: netapp-file-backup
-    
+
     config:
       requests:
         cpu: 5m

--- a/charts/fin-pay-transparency/values-test.yaml
+++ b/charts/fin-pay-transparency/values-test.yaml
@@ -22,6 +22,7 @@ global:
     bceidWsOnlineServiceId: ~
     externalConsumerApiKey: ~
     externalConsumerDeleteReportsApiKey: ~
+    externalConsumerErrorReportsApiKey: ~
     chesClientID: ~
     chesTokenURL: ~
     chesClientSecret: ~

--- a/charts/fin-pay-transparency/values.schema.json
+++ b/charts/fin-pay-transparency/values.schema.json
@@ -389,6 +389,9 @@
             "externalConsumerDeleteReportsApiKey": {
               "type": "string"
             },
+            "externalConsumerErrorReportsApiKey": {
+              "type": "string"
+            },
             "chestApiUrl": {
               "type": "string",
               "format": "uri"
@@ -419,7 +422,8 @@
             "bceidWsOnlineServiceId",
             "bceidWsUrl",
             "externalConsumerApiKey",
-            "externalConsumerDeleteReportsApiKey"
+            "externalConsumerDeleteReportsApiKey",
+            "externalConsumerErrorReportsApiKey"
           ]
         },
         "domain": {

--- a/charts/fin-pay-transparency/values.yaml
+++ b/charts/fin-pay-transparency/values.yaml
@@ -22,6 +22,7 @@ global:
     bceidWsOnlineServiceId: ~
     externalConsumerApiKey: ~
     externalConsumerDeleteReportsApiKey: ~
+    externalConsumerErrorReportsApiKey: ~
     chesClientID: ~
     chesTokenURL: ~
     chesClientSecret: ~


### PR DESCRIPTION
https://finrms.atlassian.net/browse/GEO-698

This PR Creates a new table, stores errors in the DB, and provides an API to retrive the errors.

Still todo is a scheduler to delete old records, and a switch to turn this feature on or off. Those will come later.

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://pay-transparency-pr-551-frontend.apps.silver.devops.gov.bc.ca)
- [Admin Frontend](https://pay-transparency-pr-551-admin-frontend.apps.silver.devops.gov.bc.ca)
- [Backend external API console](https://pay-transparency-pr-551-backend-external.apps.silver.devops.gov.bc.ca/api/V1/docs)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/fin-pay-transparency/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/fin-pay-transparency/actions/workflows/merge.yml)