### PR TITLE
feat: env vars to configure user error logging

### DIFF
--- a/backend/src/config/index.ts
+++ b/backend/src/config/index.ts
@@ -46,6 +46,14 @@ config.defaults({
     reportUnlockDurationInDays: parseInt(
       process.env.REPORT_UNLOCK_DURATION_IN_DAYS || '2',
     ),
+    userErrorLogging: {
+      isEnabled:
+        process.env.IS_USER_ERROR_LOGGING_ENABLED?.toUpperCase() == 'TRUE' ||
+        false,
+      deleteScheduleCronTime: process.env.DELETE_USER_ERRORS_CRON_CRONTIME,
+      numMonthsOfUserErrorsToKeep:
+        process.env.NUM_MONTHS_OF_USER_ERRORS_TO_KEEP || 6,
+    },
     rateLimit: {
       enabled: process.env.IS_RATE_LIMIT_ENABLED || false, // Disable if rate limiting is not required
       windowMs: process.env.RATE_LIMIT_WINDOW_MS || 60000, // 1 minute
@@ -108,4 +116,5 @@ config.defaults({
     emailRecipients: process.env.CHES_EMAIL_RECIPIENTS?.split(','), // comma separated email addresses
   },
 });
+
 export { config };

--- a/backend/src/schedulers/run.all.spec.ts
+++ b/backend/src/schedulers/run.all.spec.ts
@@ -9,6 +9,15 @@ jest.mock('./lock-reports-scheduler', () => ({
   },
 }));
 
+const mockDeleteUserErrorsLock = jest.fn();
+jest.mock('./delete-user-errors-scheduler', () => ({
+  __esModule: true,
+
+  default: {
+    start: () => mockDeleteUserErrorsLock(),
+  },
+}));
+
 const mockDeleteDraftReportLock = jest.fn();
 jest.mock('./delete-draft-service-scheduler', () => ({
   __esModule: true,
@@ -22,6 +31,7 @@ describe('run.all', () => {
   it('should start all jobs', async () => {
     run();
     expect(mockDeleteDraftReportLock).toHaveBeenCalled();
+    expect(mockDeleteUserErrorsLock).toHaveBeenCalled();
     expect(mockStartReportLock).toHaveBeenCalled();
   });
 });

--- a/backend/src/schedulers/run.all.ts
+++ b/backend/src/schedulers/run.all.ts
@@ -1,11 +1,13 @@
 import { logger } from '../logger';
 import deleteDraftReportsJob from './delete-draft-service-scheduler';
+import deleteUserErrorsJob from './delete-user-errors-scheduler';
 import lockReportsJob from './lock-reports-scheduler';
 
 export const run = () => {
   try {
-    deleteDraftReportsJob.start();
-    lockReportsJob.start();
+    deleteDraftReportsJob?.start();
+    deleteUserErrorsJob?.start();
+    lockReportsJob?.start();
   } catch (error) {
     /* istanbul ignore next */
     logger.error(error);

--- a/charts/fin-pay-transparency/templates/configmap.yaml
+++ b/charts/fin-pay-transparency/templates/configmap.yaml
@@ -2,15 +2,33 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ .Release.Name }}
-  labels: {{- include "labels" . | nindent 4 }}
+  name: { { .Release.Name } }
+  labels: { { - include "labels" . | nindent 4 } }
 data:
-  UPLOAD_FILE_MAX_SIZE: {{ .Values.global.config.upload_file_max_size | quote }}
-  TEMPLATE_PATH: {{ .Values.global.config.template_path | quote }}
-  REPORT_EDIT_DURATION_IN_DAYS: {{ .Values.global.config.report_edit_duration_in_days | quote }}
-  REPORT_UNLOCK_DURATION_IN_DAYS: {{ .Values.global.config.report_unlock_duration_in_days | quote }}
-  DELETE_DRAFT_REPORT_CRON_CRONTIME: {{ .Values.global.config.delete_draft_report_cron_crontime | quote }}
-  LOCK_REPORT_CRON_CRONTIME: {{ .Values.global.config.lock_report_cron_crontime | quote }}
-  REPORTS_SCHEDULER_CRON_TIMEZONE: {{ .Values.global.config.reports_scheduler_cron_timezone | quote }}
-  FIRST_YEAR_WITH_PREV_REPORTING_YEAR_OPTION: {{ .Values.global.config.first_year_with_prev_reporting_year_option | quote }}
-  DB_CONNECTION_POOL_SIZE: {{ .Values.global.config.db_connection_pool_size | quote }}
+  UPLOAD_FILE_MAX_SIZE:
+    { { .Values.global.config.upload_file_max_size | quote } }
+  TEMPLATE_PATH: { { .Values.global.config.template_path | quote } }
+  REPORT_EDIT_DURATION_IN_DAYS:
+    { { .Values.global.config.report_edit_duration_in_days | quote } }
+  REPORT_UNLOCK_DURATION_IN_DAYS:
+    { { .Values.global.config.report_unlock_duration_in_days | quote } }
+  DELETE_DRAFT_REPORT_CRON_CRONTIME:
+    { { .Values.global.config.delete_draft_report_cron_crontime | quote } }
+  DELETE_USER_ERRORS_CRON_CRONTIME:
+    { { .Values.global.config.delete_user_errors_cron_crontime | quote } }
+  LOCK_REPORT_CRON_CRONTIME:
+    { { .Values.global.config.lock_report_cron_crontime | quote } }
+  REPORTS_SCHEDULER_CRON_TIMEZONE:
+    { { .Values.global.config.reports_scheduler_cron_timezone | quote } }
+  FIRST_YEAR_WITH_PREV_REPORTING_YEAR_OPTION:
+    {
+      {
+        .Values.global.config.first_year_with_prev_reporting_year_option | quote,
+      },
+    }
+  DB_CONNECTION_POOL_SIZE:
+    { { .Values.global.config.db_connection_pool_size | quote } }
+  IS_USER_ERROR_LOGGING_ENABLED: 
+  { { .Values.global.config.is_user_error_logging_enabled | quote } }
+  NUM_MONTHS_OF_USER_ERRORS_TO_KEEP:
+    { { .Values.global.config.num_months_of_user_errors_to_keep | quote } }

--- a/charts/fin-pay-transparency/values-dev.yaml
+++ b/charts/fin-pay-transparency/values-dev.yaml
@@ -44,11 +44,13 @@ global:
     report_unlock_duration_in_days: "2"
     template_path: "./dist/templates"
     delete_draft_report_cron_crontime: "0 0 0 * * *" # 12:00 AM PST/PDT
+    delete_user_errors_cron_crontime: "0 30 1 */6 *" #At 12:30 AM on the 1st day of every 6th month
     lock_report_cron_crontime: "0 15 0 * * *" # 12:15 AM PST/PDT
     reports_scheduler_cron_timezone: "America/Vancouver"
     first_year_with_prev_reporting_year_option: "2025"
     db_connection_pool_size: "5"
-
+    num_months_of_user_errors_to_keep: "6"
+    is_user_error_logging_enabled: true
   crunchyEnabled: true
 backend:
   enabled: true

--- a/charts/fin-pay-transparency/values-pr.yaml
+++ b/charts/fin-pay-transparency/values-pr.yaml
@@ -34,6 +34,8 @@ global:
   domain: "apps.silver.devops.gov.bc.ca" # it is required, apps.silver.devops.gov.bc.ca for silver cluster
   autoscaling:
     enabled: false
+  config:
+    is_user_error_logging_enabled: true
   crunchyEnabled: false
   seedData: true
 backend:

--- a/charts/fin-pay-transparency/values-prod.yaml
+++ b/charts/fin-pay-transparency/values-prod.yaml
@@ -44,10 +44,13 @@ global:
     report_unlock_duration_in_days: "2"
     template_path: "./dist/templates"
     delete_draft_report_cron_crontime: "0 0 0 * * *" # 12:00 AM PST/PDT
+    delete_user_errors_cron_crontime: "0 30 1 */6 *" #At 12:30 AM on the 1st day of every 6th month
     lock_report_cron_crontime: "0 15 0 * * *" # 12:15 AM PST/PDT
     reports_scheduler_cron_timezone: "America/Vancouver"
     first_year_with_prev_reporting_year_option: "2025"
     db_connection_pool_size: "5"
+    num_months_of_user_errors_to_keep: "6"
+    is_user_error_logging_enabled: true
   crunchyEnabled: true
 backend:
   enabled: true

--- a/charts/fin-pay-transparency/values-test.yaml
+++ b/charts/fin-pay-transparency/values-test.yaml
@@ -44,10 +44,13 @@ global:
     report_unlock_duration_in_days: "2"
     template_path: "./dist/templates"
     delete_draft_report_cron_crontime: "0 0 0 * * *" # 12:00 AM PST/PDT
+    delete_user_errors_cron_crontime: "0 30 1 */6 *" #At 12:30 AM on the 1st day of every 6th month
     lock_report_cron_crontime: "0 15 0 * * *" # 12:15 AM PST/PDT
     reports_scheduler_cron_timezone: "America/Vancouver"
     first_year_with_prev_reporting_year_option: "2025"
     db_connection_pool_size: "5"
+    num_months_of_user_errors_to_keep: "6"
+    is_user_error_logging_enabled: true
   crunchyEnabled: true
 backend:
   enabled: true

--- a/charts/fin-pay-transparency/values.yaml
+++ b/charts/fin-pay-transparency/values.yaml
@@ -44,10 +44,13 @@ global:
     report_unlock_duration_in_days: "2"
     template_path: "./dist/templates"
     delete_draft_report_cron_crontime: "0 0 0 * * *" # 12:00 AM PST/PDT
+    delete_user_errors_cron_crontime: "0 30 1 */6 *" #At 12:30 AM on the 1st day of every 6th month
     lock_report_cron_crontime: "0 15 0 * * *" # 12:15 AM PST/PDT
     reports_scheduler_cron_timezone: "America/Vancouver"
     first_year_with_prev_reporting_year_option: "2025"
     db_connection_pool_size: "5"
+    num_months_of_user_errors_to_keep: "6"
+    is_user_error_logging_enabled: false
   crunchyEnabled: true
   seedData: false # this controls whether the seed data should be loaded or not, mostly used for PR deployments.
 backend:


### PR DESCRIPTION
# Description

Added a scheduled job to periodically delete old records from the 'user_error' database table.  Added two new env vars to control the scheduled delete (DELETE_USER_ERRORS_CRON_CRONTIME and NUM_MONTHS_OF_USER_ERRORS_TO_KEEP), and also added one new env var to enable/disable user error logging altogether (IS_USER_ERROR_LOGGING_ENABLED).

Note: for local testing add the following to backend .env file:

IS_USER_ERROR_LOGGING_ENABLED=FALSE
DELETE_USER_ERRORS_CRON_CRONTIME="30 0 1 * *"
NUM_MONTHS_OF_USER_ERRORS_TO_KEEP=6

Fixes # [GEO-700](https://finrms.atlassian.net/browse/GEO-700) and [GEO-899](https://finrms.atlassian.net/browse/GEO-889)

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

New unit tests.  Updated existing unit tests.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have already been accepted and merged