### PR TITLE
feat: admin app - restrict access to pages based on role

### DIFF
--- a/admin-frontend/src/App.vue
+++ b/admin-frontend/src/App.vue
@@ -73,6 +73,11 @@ export default {
       this.isBreadcrumbTrailVisible =
         to?.meta?.isBreadcrumbTrailVisible &&
         this.doesUserHaveRole(USER_ROLE_NAME);
+      console.log(
+        '===============' +
+          this.doesUserHaveRole(USER_ROLE_NAME) +
+          JSON.stringify(to),
+      );
     },
   },
   async created() {},

--- a/admin-frontend/src/App.vue
+++ b/admin-frontend/src/App.vue
@@ -27,7 +27,7 @@
 
 <script>
 import { appStore } from './store/modules/app';
-import { mapState } from 'pinia';
+import { mapActions, mapState } from 'pinia';
 import Header from './components/Header.vue';
 import SideBar from './components/SideBar.vue';
 import MsieBanner from './components/MsieBanner.vue';
@@ -35,6 +35,7 @@ import SnackBar from './components/util/SnackBar.vue';
 import BreadcrumbTrail from './components/BreadcrumbTrail.vue';
 import { NotificationService } from './services/notificationService';
 import { authStore } from './store/modules/auth';
+import { USER_ROLE_NAME } from './constants';
 
 export default {
   name: 'App',
@@ -69,12 +70,15 @@ export default {
       }
       this.areHeaderAndSidebarVisible = to.meta.requiresAuth;
       this.isTitleVisible = to?.meta?.isTitleVisible && to?.meta?.pageTitle;
-      this.isBreadcrumbTrailVisible = to?.meta?.isBreadcrumbTrailVisible;
+      this.isBreadcrumbTrailVisible =
+        to?.meta?.isBreadcrumbTrailVisible &&
+        this.doesUserHaveRole(USER_ROLE_NAME);
     },
   },
   async created() {},
   methods: {
     appStore,
+    ...mapActions(authStore, ['doesUserHaveRole']),
   },
 };
 </script>

--- a/admin-frontend/src/App.vue
+++ b/admin-frontend/src/App.vue
@@ -62,7 +62,17 @@ export default {
     },
   },
   watch: {
-    $route(to, from) {
+    $route: {
+      handler(to, from) {
+        this.onRouteChanged(to, from);
+      },
+    },
+  },
+  async created() {},
+  methods: {
+    appStore,
+    ...mapActions(authStore, ['doesUserHaveRole']),
+    onRouteChanged(to, from) {
       this.activeRoute = to;
       if (to.fullPath != '/error') {
         //Reset error page message back to the default
@@ -73,17 +83,7 @@ export default {
       this.isBreadcrumbTrailVisible =
         to?.meta?.isBreadcrumbTrailVisible &&
         this.doesUserHaveRole(USER_ROLE_NAME);
-      console.log(
-        '===============' +
-          this.doesUserHaveRole(USER_ROLE_NAME) +
-          JSON.stringify(to),
-      );
     },
-  },
-  async created() {},
-  methods: {
-    appStore,
-    ...mapActions(authStore, ['doesUserHaveRole']),
   },
 };
 </script>

--- a/admin-frontend/src/__tests__/App.spec.ts
+++ b/admin-frontend/src/__tests__/App.spec.ts
@@ -1,5 +1,6 @@
 import { createTestingPinia } from '@pinia/testing';
 import { flushPromises, mount } from '@vue/test-utils';
+import { getActivePinia, setActivePinia } from 'pinia';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { createRouter, createWebHistory } from 'vue-router';
 import { createVuetify } from 'vuetify';
@@ -25,12 +26,7 @@ const setupComponentEnvironment = async (options: any = {}) => {
     directives,
   });
 
-  const pinia = createTestingPinia({
-    initialState: {
-      code: {},
-      config: {},
-    },
-  });
+  const pinia = getActivePinia();
 
   const auth = authStore();
   auth.getJwtToken = vi.fn().mockResolvedValue(null);
@@ -57,7 +53,7 @@ const setupComponentEnvironment = async (options: any = {}) => {
         components: {
           App,
         },
-        plugins: [vuetify, pinia, mockRouter],
+        plugins: [vuetify, pinia as any, mockRouter],
       },
     },
   );
@@ -76,7 +72,15 @@ const setupComponentEnvironment = async (options: any = {}) => {
   };
 };
 
-beforeEach(async () => {});
+beforeEach(async () => {
+  const pinia = createTestingPinia({
+    initialState: {
+      code: {},
+      config: {},
+    },
+  });
+  setActivePinia(pinia);
+});
 
 afterEach(() => {
   vi.clearAllMocks();

--- a/admin-frontend/src/__tests__/App.spec.ts
+++ b/admin-frontend/src/__tests__/App.spec.ts
@@ -1,10 +1,13 @@
 import { createTestingPinia } from '@pinia/testing';
 import { flushPromises, mount } from '@vue/test-utils';
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createRouter, createWebHistory } from 'vue-router';
 import { createVuetify } from 'vuetify';
 import * as components from 'vuetify/components';
 import * as directives from 'vuetify/directives';
 import App from '../App.vue';
+import router from '../router';
+import { authStore } from '../store/modules/auth';
 
 // Mock the ResizeObserver
 const ResizeObserverMock = vi.fn(() => ({
@@ -16,73 +19,103 @@ const ResizeObserverMock = vi.fn(() => ({
 // Stub the global ResizeObserver
 vi.stubGlobal('ResizeObserver', ResizeObserverMock);
 
-describe('App', () => {
-  let wrapper;
-  let pinia;
-  let app;
+const setupComponentEnvironment = async (options: any = {}) => {
+  const vuetify = createVuetify({
+    components,
+    directives,
+  });
 
-  const initWrapper = async (options: any = {}) => {
-    const vuetify = createVuetify({
-      components,
-      directives,
-    });
+  const pinia = createTestingPinia({
+    initialState: {
+      code: {},
+      config: {},
+    },
+  });
 
-    pinia = createTestingPinia({
-      initialState: {
-        code: {},
-        config: {},
-      },
-    });
+  const auth = authStore();
+  auth.getJwtToken = vi.fn().mockResolvedValue(null);
+  auth.doesUserHaveRole = vi.fn().mockReturnValue(true);
 
-    wrapper = mount(
-      {
-        //SideBar depends on vuetify components, so it must be mounted within a v-layout.
-        //It is also an async component because one of its dependencies (v-navigation-drawer)
-        //is async, so it must be mounted with a Suspense component.  Some
-        //additional info about using the Suspense component are in the vue-test-utils docs
-        //here:
-        //https://test-utils.vuejs.org/guide/advanced/async-suspense.html#Testing-asynchronous-setup
-        template: '<Suspense><App/></Suspense>',
-      },
-      {
-        props: {},
-        global: {
-          components: {
-            App,
-          },
-          plugins: [vuetify, pinia],
+  const mockRouter = createRouter({
+    history: createWebHistory(),
+    routes: router.getRoutes(),
+  });
+
+  const wrapper = mount(
+    {
+      //SideBar depends on vuetify components, so it must be mounted within a v-layout.
+      //It is also an async component because one of its dependencies (v-navigation-drawer)
+      //is async, so it must be mounted with a Suspense component.  Some
+      //additional info about using the Suspense component are in the vue-test-utils docs
+      //here:
+      //https://test-utils.vuejs.org/guide/advanced/async-suspense.html#Testing-asynchronous-setup
+      template: '<Suspense><App/></Suspense>',
+    },
+    {
+      props: {},
+      global: {
+        components: {
+          App,
         },
+        plugins: [vuetify, pinia, mockRouter],
       },
-    );
+    },
+  );
 
-    //wait for the async App component to load
-    await flushPromises();
+  //wait for the async App component to load
+  await flushPromises();
 
-    app = await wrapper.findComponent(App);
+  const app = await wrapper.findComponent(App);
+
+  return {
+    wrapper: wrapper,
+    pinia: pinia,
+    app: app,
+    router: mockRouter,
+    auth: auth,
   };
+};
 
-  beforeEach(async () => {
-    await initWrapper();
-  });
-
-  afterEach(() => {
-    if (wrapper) {
-      wrapper.unmount();
-    }
-  });
+describe('App', () => {
+  beforeEach(async () => {});
 
   describe('if the header and sidebar are supposed to be visible', () => {
-    it('they are both actually visible', () => {
-      app.vm.areHeaderAndSidebarVisible = true;
-      expect(app.find('header')).toBeTruthy();
-      expect(app.find('SideBar')).toBeTruthy();
+    it('they are both actually visible', async () => {
+      const componentEnv = await setupComponentEnvironment();
+      componentEnv.app.vm.areHeaderAndSidebarVisible = true;
+      await componentEnv.app.vm.$nextTick();
+      expect(componentEnv.app.find('header')).toBeTruthy();
+      expect(componentEnv.app.find('SideBar')).toBeTruthy();
     });
   });
   describe('if the header and sidebar are supposed to be hidden', () => {
-    it('they are both actually hidden', () => {
-      app.vm.areHeaderAndSidebarVisible = false;
-      expect(app.find('header').exists()).toBeFalsy();
-      expect(app.find('SideBar').exists()).toBeFalsy();
+    it('they are both actually hidden', async () => {
+      const componentEnv = await setupComponentEnvironment();
+      componentEnv.app.vm.areHeaderAndSidebarVisible = false;
+      await componentEnv.app.vm.$nextTick();
+      expect(componentEnv.app.find('header').exists()).toBeFalsy();
+      expect(componentEnv.app.find('SideBar').exists()).toBeFalsy();
+    });
+  });
+
+  describe('when the route changes to /user-management, and the user has permission to view the breadbrumb trail', async () => {
+    it('breadcrumb trail is visible', async () => {
+      const componentEnv = await setupComponentEnvironment();
+      componentEnv.auth.doesUserHaveRole.mockReturnValue(true);
+      componentEnv.router.push('/user-management');
+      await componentEnv.router.isReady();
+      await componentEnv.app.vm.$nextTick();
+      expect(componentEnv.app.vm.isBreadcrumbTrailVisible).toBeTruthy();
+    });
+  });
+  describe("when the route changes to /user-management, and the user doesn't have permission to view the breadbrumb trail", async () => {
+    it('breadcrumb trail is hidden', async () => {
+      const componentEnv = await setupComponentEnvironment();
+      componentEnv.auth.doesUserHaveRole.mockReturnValue(false);
+      componentEnv.router.push('/user-management');
+      await componentEnv.router.isReady();
+      await componentEnv.app.vm.$nextTick();
+      expect(componentEnv.app.vm.isBreadcrumbTrailVisible).toBeFalsy();
     });
   });
 });

--- a/admin-frontend/src/__tests__/App.spec.ts
+++ b/admin-frontend/src/__tests__/App.spec.ts
@@ -1,6 +1,6 @@
 import { createTestingPinia } from '@pinia/testing';
 import { flushPromises, mount } from '@vue/test-utils';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { createRouter, createWebHistory } from 'vue-router';
 import { createVuetify } from 'vuetify';
 import * as components from 'vuetify/components';
@@ -76,9 +76,13 @@ const setupComponentEnvironment = async (options: any = {}) => {
   };
 };
 
-describe('App', () => {
-  beforeEach(async () => {});
+beforeEach(async () => {});
 
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('App', () => {
   describe('if the header and sidebar are supposed to be visible', () => {
     it('they are both actually visible', async () => {
       const componentEnv = await setupComponentEnvironment();
@@ -119,8 +123,8 @@ describe('App', () => {
     });
   });
   describe('onRouteChanged', () => {
-    describe('', () => {
-      it('', async () => {
+    describe('when the route changes', () => {
+      it('various state variables are updated', async () => {
         const componentEnv = await setupComponentEnvironment();
         const to = {
           meta: {

--- a/admin-frontend/src/__tests__/App.spec.ts
+++ b/admin-frontend/src/__tests__/App.spec.ts
@@ -118,4 +118,25 @@ describe('App', () => {
       expect(componentEnv.app.vm.isBreadcrumbTrailVisible).toBeFalsy();
     });
   });
+  describe('onRouteChanged', () => {
+    describe('', () => {
+      it('', async () => {
+        const componentEnv = await setupComponentEnvironment();
+        const to = {
+          meta: {
+            requiresAuth: false,
+            isBreadcrumbTrailVisible: true,
+            pageTitle: 'sample route',
+          },
+        };
+        componentEnv.auth.doesUserHaveRole.mockReturnValue(false);
+        componentEnv.app.vm.onRouteChanged(to, null);
+        expect(componentEnv.app.vm.activeRoute).toStrictEqual(to);
+        expect(componentEnv.app.vm.areHeaderAndSidebarVisible).toBe(
+          to.meta.requiresAuth,
+        );
+        expect(componentEnv.app.vm.isBreadcrumbTrailVisible).toBe(false);
+      });
+    });
+  });
 });

--- a/admin-frontend/src/components/SideBar.vue
+++ b/admin-frontend/src/components/SideBar.vue
@@ -26,51 +26,60 @@
       </div>
     </div>
     <v-list-item
+      id="link-dashboard"
       link
       to="dashboard"
       title="Dashboard"
       :class="{ active: activeRoute == 'dashboard' }"
+      v-if="auth.doesUserHaveRole(USER_ROLE_NAME)"
     >
       <template v-slot:prepend>
         <v-icon icon="mdi-home"></v-icon>
       </template>
     </v-list-item>
     <v-list-item
+      id="link-reports"
       link
       to="reports"
       title="Reports"
       :class="{ active: activeRoute == 'reports' }"
+      v-if="auth.doesUserHaveRole(USER_ROLE_NAME)"
     >
       <template v-slot:prepend>
         <v-icon icon="mdi-magnify"></v-icon>
       </template>
     </v-list-item>
     <v-list-item
+      id="link-announcements"
       link
       to="announcements"
       title="Announcements"
       :class="{ active: activeRoute == 'announcements' }"
+      v-if="auth.doesUserHaveRole(USER_ROLE_NAME)"
     >
       <template v-slot:prepend>
         <v-icon icon="mdi-bullhorn"></v-icon>
       </template>
     </v-list-item>
     <v-list-item
+      id="link-user-management"
       link
       to="user-management"
       title="User Management"
       :class="{ active: activeRoute == 'user-management' }"
-      v-if="userInfo?.role == ADMIN_ROLE_NAME"
+      v-if="auth.doesUserHaveRole(ADMIN_ROLE_NAME)"
     >
       <template v-slot:prepend>
         <v-icon icon="mdi-account-multiple"></v-icon>
       </template>
     </v-list-item>
     <v-list-item
+      id="link-analytics"
       link
       to="analytics"
       title="Analytics"
       :class="{ active: activeRoute == 'analytics' }"
+      v-if="auth.doesUserHaveRole(USER_ROLE_NAME)"
     >
       <template v-slot:prepend>
         <v-icon icon="mdi-chart-bar"></v-icon>
@@ -90,9 +99,9 @@ export default {
 import { watch, ref } from 'vue';
 import { useRoute } from 'vue-router';
 import { authStore } from '../store/modules/auth';
-import { ADMIN_ROLE_NAME } from '../constants';
+import { ADMIN_ROLE_NAME, USER_ROLE_NAME } from '../constants';
 
-const { userInfo } = authStore();
+const auth = authStore();
 const route = useRoute();
 const activeRoute = ref();
 const isExpanded = ref(true);

--- a/admin-frontend/src/components/SideBar.vue
+++ b/admin-frontend/src/components/SideBar.vue
@@ -26,7 +26,6 @@
       </div>
     </div>
     <v-list-item
-      id="link-dashboard"
       link
       to="dashboard"
       title="Dashboard"
@@ -38,7 +37,6 @@
       </template>
     </v-list-item>
     <v-list-item
-      id="link-reports"
       link
       to="reports"
       title="Reports"
@@ -50,7 +48,6 @@
       </template>
     </v-list-item>
     <v-list-item
-      id="link-announcements"
       link
       to="announcements"
       title="Announcements"
@@ -62,7 +59,6 @@
       </template>
     </v-list-item>
     <v-list-item
-      id="link-user-management"
       link
       to="user-management"
       title="User Management"
@@ -74,7 +70,6 @@
       </template>
     </v-list-item>
     <v-list-item
-      id="link-analytics"
       link
       to="analytics"
       title="Analytics"

--- a/admin-frontend/src/router.js
+++ b/admin-frontend/src/router.js
@@ -13,7 +13,7 @@ import { PAGE_TITLES } from './utils/constant';
 import Login from './components/Login.vue';
 import { authStore } from './store/modules/auth';
 import Logout from './components/Logout.vue';
-import { ADMIN_ROLE_NAME } from './constants';
+import { ADMIN_ROLE_NAME, USER_ROLE_NAME } from './constants';
 
 const router = createRouter({
   history: createWebHistory(),
@@ -37,6 +37,7 @@ const router = createRouter({
       meta: {
         pageTitle: PAGE_TITLES.DASHBOARD,
         requiresAuth: true,
+        requiresRole: USER_ROLE_NAME,
         isTitleVisible: true,
       },
     },
@@ -47,6 +48,7 @@ const router = createRouter({
       meta: {
         pageTitle: PAGE_TITLES.REPORTS,
         requiresAuth: true,
+        requiresRole: USER_ROLE_NAME,
         isTitleVisible: true,
         isBreadcrumbTrailVisible: true,
       },
@@ -58,6 +60,7 @@ const router = createRouter({
       meta: {
         pageTitle: PAGE_TITLES.ANNOUNCEMENTS,
         requiresAuth: true,
+        requiresRole: USER_ROLE_NAME,
         isTitleVisible: true,
         isBreadcrumbTrailVisible: true,
       },
@@ -69,7 +72,7 @@ const router = createRouter({
       meta: {
         pageTitle: PAGE_TITLES.USER_MANAGEMENT,
         requiresAuth: true,
-        role: ADMIN_ROLE_NAME,
+        requiresRole: ADMIN_ROLE_NAME,
         isTitleVisible: true,
         isBreadcrumbTrailVisible: true,
       },
@@ -81,6 +84,7 @@ const router = createRouter({
       meta: {
         pageTitle: PAGE_TITLES.ANALYTICS,
         requiresAuth: true,
+        requiresRole: USER_ROLE_NAME,
         isTitleVisible: true,
         isBreadcrumbTrailVisible: true,
       },
@@ -125,14 +129,13 @@ const router = createRouter({
       name: 'NotFound',
       component: NotFoundPage,
       meta: {
-        requiresAuth: true,
+        requiresAuth: false,
       },
     },
   ],
 });
 
 router.beforeEach((to, _from, next) => {
-  // this section is to set page title in vue store
   if (!to.meta.requiresAuth) {
     //Proceed normally to the requested route
     const apStore = appStore();
@@ -141,7 +144,6 @@ router.beforeEach((to, _from, next) => {
     return;
   }
 
-  // requires bceid info
   const aStore = authStore();
 
   aStore
@@ -155,12 +157,16 @@ router.beforeEach((to, _from, next) => {
       aStore
         .getUserInfo()
         .then(() => {
-          if (to.meta.role && aStore.userInfo?.role !== to.meta.role) {
-            next('notfound')
+          if (
+            to.meta.requiresRole &&
+            !aStore.doesUserHaveRole(to.meta.requiresRole)
+          ) {
+            next('notfound');
           }
           next();
         })
-        .catch(() => {
+        .catch((e) => {
+          console.log(e);
           next('error');
         });
     })

--- a/admin-frontend/src/router.js
+++ b/admin-frontend/src/router.js
@@ -165,8 +165,7 @@ router.beforeEach((to, _from, next) => {
           }
           next();
         })
-        .catch((e) => {
-          console.log(e);
+        .catch(() => {
           next('error');
         });
     })

--- a/admin-frontend/src/store/modules/__tests__/auth.spec.ts
+++ b/admin-frontend/src/store/modules/__tests__/auth.spec.ts
@@ -54,4 +54,24 @@ describe('AuthStore', () => {
     await auth.getJwtToken();
     expect(localStorage.getItem(LOCAL_STORAGE_KEY_JWT)).toBeTruthy();
   });
+  describe('doesUserHaveRole', () => {
+    describe("if the user doesn't have the given role", () => {
+      it('return false', () => {
+        const mockRole = 'MOCK_ROLE';
+        auth.userInfo = {
+          roles: [],
+        };
+        expect(auth.doesUserHaveRole(mockRole)).toBeFalsy();
+      });
+    });
+    describe('if the user has the given role', () => {
+      it('return true', () => {
+        const mockRole = 'MOCK_ROLE';
+        auth.userInfo = {
+          roles: [mockRole],
+        };
+        expect(auth.doesUserHaveRole(mockRole)).toBeTruthy();
+      });
+    });
+  });
 });

--- a/admin-frontend/src/store/modules/auth.js
+++ b/admin-frontend/src/store/modules/auth.js
@@ -81,7 +81,6 @@ export const authStore = defineStore('auth', {
       this.userInfo = userInfoRes.data;
     },
     doesUserHaveRole(roleToCheckFor) {
-      console.log('*******************');
       return (
         this?.userInfo?.roles?.length &&
         this?.userInfo?.roles.indexOf(roleToCheckFor) >= 0

--- a/admin-frontend/src/store/modules/auth.js
+++ b/admin-frontend/src/store/modules/auth.js
@@ -80,6 +80,13 @@ export const authStore = defineStore('auth', {
       const userInfoRes = await ApiService.getUserInfo();
       this.userInfo = userInfoRes.data;
     },
+    doesUserHaveRole(roleToCheckFor) {
+      console.log('*******************');
+      return (
+        this?.userInfo?.roles?.length &&
+        this?.userInfo?.roles.indexOf(roleToCheckFor) >= 0
+      );
+    },
     //retrieves the json web token from local storage. If not in local storage, retrieves it from API
     async getJwtToken() {
       await this.setError(false);

--- a/backend/src/v1/services/admin-auth-service.ts
+++ b/backend/src/v1/services/admin-auth-service.ts
@@ -73,7 +73,7 @@ class AdminAuth extends AuthBase {
     }
     const userInfoFrontend = {
       displayName: userInfo._json.display_name,
-      role: userInfo._json.client_roles?.[0]
+      roles: userInfo._json?.client_roles,
     };
     return res.status(HttpStatus.OK).json(userInfoFrontend);
   }


### PR DESCRIPTION
# Description

In the admin frontend, restrict access to pages based on role.  Also hide links from the sidebar if the user doesn't have appropriate permissions for them.

Fixes # [GEO-924](https://finrms.atlassian.net/browse/GEO-924)

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Existing unit tests

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have already been accepted and merged


---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://pay-transparency-pr-559-frontend.apps.silver.devops.gov.bc.ca)
- [Admin Frontend](https://pay-transparency-pr-559-admin-frontend.apps.silver.devops.gov.bc.ca)
- [Backend external API console](https://pay-transparency-pr-559-backend-external.apps.silver.devops.gov.bc.ca/api/V1/docs)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/fin-pay-transparency/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/fin-pay-transparency/actions/workflows/merge.yml)