### PR TITLE
fix: GEO-988 - use UTC timezone for dates saved to the pay_transparency_reports table

### DIFF
--- a/backend/src/v1/services/admin-report-service.spec.ts
+++ b/backend/src/v1/services/admin-report-service.spec.ts
@@ -591,6 +591,31 @@ describe('admin-report-service', () => {
       expect(report.admin_modified_date).toBe(report.report_unlock_date);
       expect(report.admin_user_id).toBe('1234');
     });
+    it('should update the report_unlock_date to the current date/time in UTC', async () => {
+      const updateSpy = jest.spyOn(
+        prismaClient.pay_transparency_report,
+        'update',
+      );
+      await adminReportService.changeReportLockStatus(
+        '4492feff-99d7-4b2b-8896-12a59a75d4e2',
+        '5678',
+        false,
+      );
+
+      const updateParam: any = updateSpy.mock.calls[0][0];
+      expect(updateParam.data.admin_modified_date).toBe(
+        updateParam.data.report_unlock_date,
+      );
+
+      //check that the unlock report date/time submitted to the database is approximately
+      //equal to the current UTC date/time
+      const currentDateUtc = convert(ZonedDateTime.now(ZoneId.UTC)).toDate();
+      const unlockDateDiffMs =
+        currentDateUtc.getTime() -
+        updateParam.data.report_unlock_date.getTime();
+      expect(unlockDateDiffMs).toBeGreaterThanOrEqual(0);
+      expect(unlockDateDiffMs).toBeLessThan(10000); //10 seconds
+    });
   });
 
   describe('getReportPdf', () => {

--- a/backend/src/v1/services/admin-report-service.ts
+++ b/backend/src/v1/services/admin-report-service.ts
@@ -1,4 +1,4 @@
-import { LocalDateTime, ZoneId, convert } from '@js-joda/core';
+import { convert, ZonedDateTime, ZoneId } from '@js-joda/core';
 import { Prisma } from '@prisma/client';
 import prisma from '../prisma/prisma-client';
 import prismaReadOnlyReplica from '../prisma/prisma-client-readonly-replica';
@@ -134,14 +134,14 @@ const adminReportService = {
       where: { report_id: reportId },
     });
 
-    const currentDate = convert(LocalDateTime.now(ZoneId.UTC)).toDate();
+    const currentDateUtc = convert(ZonedDateTime.now(ZoneId.UTC)).toDate();
 
     await prisma.pay_transparency_report.update({
       where: { report_id: reportId },
       data: {
         is_unlocked: isUnLocked,
-        report_unlock_date: currentDate,
-        admin_modified_date: currentDate,
+        report_unlock_date: currentDateUtc,
+        admin_modified_date: currentDateUtc,
         admin_user: { connect: { idir_user_guid: idirGuid } },
       },
     });

--- a/backend/src/v1/services/report-service.spec.ts
+++ b/backend/src/v1/services/report-service.spec.ts
@@ -2,6 +2,7 @@ import {
   LocalDate,
   TemporalAdjusters,
   ZoneId,
+  ZonedDateTime,
   convert,
   nativeJs,
 } from '@js-joda/core';
@@ -877,6 +878,14 @@ describe('publishReport', () => {
       expect(updateStatement.where.report_id).toBe(
         mockPublishedReportInDb.report_id,
       );
+
+      // Expect the update date to be approximately equal to the current date
+      // in the UTC timezone (within 10 seconds)
+      const currentDateUtc = convert(ZonedDateTime.now(ZoneId.UTC)).toDate();
+      const dateDiffMs =
+        currentDateUtc.getTime() - updateStatement.data.update_date.getTime();
+      expect(dateDiffMs).toBeGreaterThanOrEqual(0);
+      expect(dateDiffMs).toBeLessThan(10000); //10 seconds
     });
   });
   describe('if the given report has status=Draft, and there is an existing Published and locked report', () => {

--- a/backend/src/v1/services/report-service.ts
+++ b/backend/src/v1/services/report-service.ts
@@ -1,8 +1,8 @@
 import {
   LocalDate,
-  LocalDateTime,
   TemporalAdjusters,
   ZoneId,
+  ZonedDateTime,
   convert,
   nativeJs,
 } from '@js-joda/core';
@@ -1321,7 +1321,7 @@ const reportService = {
             pay_transparency_user: {
               connect: { user_id: full_report_to_publish.user_id },
             },
-            update_date: convert(LocalDateTime.now(ZoneId.UTC)).toDate(),
+            update_date: convert(ZonedDateTime.now(ZoneId.UTC)).toDate(), //current date/time in the UTC timezone
             update_user: full_report_to_publish.update_user,
             pay_transparency_calculated_data: {
               createMany: {


### PR DESCRIPTION
# Description

Several "event" dates (update_date, report_unlock_date, admin_modified_date) saved to the pay_transparency_report table were being saved with the incorrect timezone. Corrected the code to save these with the UTC timezone.

Fixes # [GEO-988](https://finrms.atlassian.net/browse/GEO-988)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Updated existing tests.  Added new tests.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have already been accepted and merged

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://pay-transparency-pr-604-frontend.apps.silver.devops.gov.bc.ca)
- [Admin Frontend](https://pay-transparency-pr-604-admin-frontend.apps.silver.devops.gov.bc.ca)
- [Backend external API console](https://pay-transparency-pr-604-backend-external.apps.silver.devops.gov.bc.ca/api/V1/docs)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/fin-pay-transparency/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/fin-pay-transparency/actions/workflows/merge.yml)

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://pay-transparency-pr-604-frontend.apps.silver.devops.gov.bc.ca)
- [Admin Frontend](https://pay-transparency-pr-604-admin-frontend.apps.silver.devops.gov.bc.ca)
- [Backend external API console](https://pay-transparency-pr-604-backend-external.apps.silver.devops.gov.bc.ca/api/V1/docs)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/fin-pay-transparency/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/fin-pay-transparency/actions/workflows/merge.yml)