### PR TITLE
fix: remove-revision-from-the-sort-of-get-in-external-consumer-api-GEO-619

### DIFF
--- a/backend/src/v1/services/external-consumer-service.ts
+++ b/backend/src/v1/services/external-consumer-service.ts
@@ -130,7 +130,7 @@ const externalConsumerService = {
         },
         take: limit,
         skip: offset,
-        orderBy: [{ update_date: 'asc' }, { revision: 'asc' }],
+        orderBy: [{ update_date: 'asc' }],
       });
 
     const totalRecordsCount = await prismaReadOnlyReplica


### PR DESCRIPTION
https://finrms.atlassian.net/browse/GEO-619

Removed the Revision sort as Update_Date is now being updated. Locally JSON results are the same now that Update_Date is updated with a report status change. Needs to be tested with DEV/TEST data.

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://pay-transparency-pr-608-frontend.apps.silver.devops.gov.bc.ca)
- [Admin Frontend](https://pay-transparency-pr-608-admin-frontend.apps.silver.devops.gov.bc.ca)
- [Backend external API console](https://pay-transparency-pr-608-backend-external.apps.silver.devops.gov.bc.ca/api/V1/docs)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/fin-pay-transparency/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/fin-pay-transparency/actions/workflows/merge.yml)