### PR TITLE
fix: public-facing-app-previous-reports-dashboard-GEO-1003

### DIFF
--- a/backend/src/v1/services/external-consumer-service.ts
+++ b/backend/src/v1/services/external-consumer-service.ts
@@ -130,7 +130,7 @@ const externalConsumerService = {
         },
         take: limit,
         skip: offset,
-        orderBy: [{ update_date: 'asc' }, { revision: 'asc' }],
+        orderBy: [{ update_date: 'asc' }],
       });
 
     const totalRecordsCount = await prismaReadOnlyReplica

--- a/frontend/src/components/util/ReportsTable.vue
+++ b/frontend/src/components/util/ReportsTable.vue
@@ -3,7 +3,7 @@
   <v-data-table
     :headers="headers"
     :items="reports"
-    :items-per-page="5"
+    :items-per-page="3"
     :disable-sort="true"
     no-data-text="No generated reports yet."
     :loading="isLoading"
@@ -115,6 +115,10 @@ const editReport = async (report: IReport) => {
 }
 
 .v-data-table-headers--mobile {
+  display: none !important;
+}
+
+.v-data-table-footer__items-per-page {
   display: none !important;
 }
 


### PR DESCRIPTION
https://finrms.atlassian.net/browse/GEO-1003

Hid the Items Per Page using CSS : display: none !important
Set ItemsPerPage to 3. 

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://pay-transparency-pr-612-frontend.apps.silver.devops.gov.bc.ca)
- [Admin Frontend](https://pay-transparency-pr-612-admin-frontend.apps.silver.devops.gov.bc.ca)
- [Backend external API console](https://pay-transparency-pr-612-backend-external.apps.silver.devops.gov.bc.ca/api/V1/docs)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/fin-pay-transparency/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/fin-pay-transparency/actions/workflows/merge.yml)