### PR TITLE
feat: GEO-861 admin announcements - search results are selectable and clickable

### DIFF
--- a/admin-frontend/src/App.vue
+++ b/admin-frontend/src/App.vue
@@ -176,6 +176,11 @@ button:disabled.v-btn {
   background-color: transparent !important;
   border: none;
   box-shadow: none;
+  font-weight: normal !important;
+  padding: 0px;
+}
+.v-btn.btn-link:hover > .v-btn__overlay {
+  opacity: 0 !important;
 }
 
 .v-alert .v-icon {

--- a/admin-frontend/src/App.vue
+++ b/admin-frontend/src/App.vue
@@ -171,13 +171,13 @@ button:disabled.v-btn {
 }
 
 .v-btn.btn-link {
-  text-decoration: underline;
   color: $link-color;
   background-color: transparent !important;
   border: none;
   box-shadow: none;
   font-weight: normal !important;
   padding: 0px;
+  letter-spacing: 1px;
 }
 .v-btn.btn-link:hover > .v-btn__overlay {
   opacity: 0 !important;

--- a/admin-frontend/src/components/AnnouncementsPage.vue
+++ b/admin-frontend/src/components/AnnouncementsPage.vue
@@ -121,10 +121,6 @@
         </v-row>
       </template>
     </v-data-table-server>
-
-    <v-row>
-      <v-col> </v-col>
-    </v-row>
   </div>
 
   <!-- dialogs -->

--- a/admin-frontend/src/components/AnnouncementsPage.vue
+++ b/admin-frontend/src/components/AnnouncementsPage.vue
@@ -118,6 +118,7 @@
             <v-btn
               class="btn-secondary"
               :disabled="!selectedAnnouncementIds.length"
+              prepend-icon="mdi-delete"
               >Delete</v-btn
             >
           </v-col>

--- a/admin-frontend/src/components/AnnouncementsPage.vue
+++ b/admin-frontend/src/components/AnnouncementsPage.vue
@@ -41,6 +41,16 @@
       "
       @update:options="updateSearch"
     >
+      <template v-slot:item.title="{ item }">
+        <v-btn
+          variant="text"
+          class="btn-link"
+          color="link"
+          @click="showAnnouncement(item)"
+        >
+          {{ item.title }}
+        </v-btn>
+      </template>
       <template v-slot:item.published_on="{ item }">
         {{ formatDate(item.published_on) }}
       </template>
@@ -84,6 +94,30 @@
       </template>
     </v-data-table-server>
   </div>
+
+  <!-- dialogs -->
+  <v-dialog
+    v-model="isAnnouncementDialogVisible"
+    :close-on-content-click="true"
+    max-width="390"
+  >
+    <v-card>
+      <v-card-title>
+        {{ activeAnnouncement?.title }}
+      </v-card-title>
+
+      <v-card-text>
+        {{ activeAnnouncement?.description }}
+      </v-card-text>
+
+      <v-card-actions>
+        <v-spacer></v-spacer>
+        <v-btn class="btn-secondary" @click="showAnnouncement(undefined)">
+          Close
+        </v-btn>
+      </v-card-actions>
+    </v-card>
+  </v-dialog>
 </template>
 
 <script lang="ts">
@@ -94,7 +128,7 @@ export default {
 
 <script setup lang="ts">
 import { storeToRefs } from 'pinia';
-import { ref } from 'vue';
+import { ref, computed } from 'vue';
 import AnnouncementSearchFilters from './announcements/AnnouncementSearchFilters.vue';
 import AnnouncementStatusChip from './announcements/AnnouncementStatusChip.vue';
 import { useAnnouncementSearchStore } from '../store/modules/announcementSearchStore';
@@ -104,6 +138,8 @@ import { AnnouncementKeys } from '../types/announcements';
 const announcementSearchStore = useAnnouncementSearchStore();
 const { searchResults, isSearching, hasSearched, totalNum, pageSize } =
   storeToRefs(announcementSearchStore);
+const activeAnnouncement = ref<any>(undefined);
+const isAnnouncementDialogVisible = ref<boolean>(false);
 
 const itemsPerPageOptions = ref([
   { value: 10, title: '10' },
@@ -148,6 +184,11 @@ const headers = ref<any>([
     sortable: false,
   },
 ]);
+
+function showAnnouncement(announcement) {
+  activeAnnouncement.value = announcement;
+  isAnnouncementDialogVisible.value = announcement != undefined;
+}
 
 async function updateSearch(options) {
   await announcementSearchStore.updateSearch(options);

--- a/admin-frontend/src/components/AnnouncementsPage.vue
+++ b/admin-frontend/src/components/AnnouncementsPage.vue
@@ -100,11 +100,7 @@
                 >
               </v-list-item>
               <v-list-item>
-                <v-btn
-                  class="text-red"
-                  variant="text"
-                  prepend-icon="mdi-delete"
-                  ref="deleteAnnouncement"
+                <v-btn class="text-red" variant="text" prepend-icon="mdi-delete"
                   >Delete</v-btn
                 >
               </v-list-item>

--- a/admin-frontend/src/components/__tests__/AnnouncementsPage.spec.ts
+++ b/admin-frontend/src/components/__tests__/AnnouncementsPage.spec.ts
@@ -99,8 +99,20 @@ describe('AnnouncementsPage', () => {
     expect(wrapper.html()).toContain(`Displaying ${mockAnnouncements.length}`);
   });
 
-  it('has search filters', async () => {
-    //await nextTick();
-    //expect(wrapper.findComponent(AnnouncementsSearchFilters)).toBe(true);
+  describe('showAnnouncement', () => {
+    describe('value is an announcement', () => {
+      it('shows the dialog', async () => {
+        const mockAnnouncement = {};
+        wrapper.vm.showAnnouncement(mockAnnouncement);
+        expect(wrapper.vm.isAnnouncementDialogVisible).toBeTruthy();
+      });
+    });
+    describe('value is undefined', () => {
+      it('hides the dialog', async () => {
+        const mockAnnouncement = undefined;
+        wrapper.vm.showAnnouncement(mockAnnouncement);
+        expect(wrapper.vm.isAnnouncementDialogVisible).toBeFalsy();
+      });
+    });
   });
 });

--- a/admin-frontend/src/components/__tests__/AnnouncementsPage.spec.ts
+++ b/admin-frontend/src/components/__tests__/AnnouncementsPage.spec.ts
@@ -1,3 +1,4 @@
+import { faker } from '@faker-js/faker';
 import { createTestingPinia } from '@pinia/testing';
 import { flushPromises, mount } from '@vue/test-utils';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -92,12 +93,32 @@ describe('AnnouncementsPage', () => {
     }
   });
 
+  // tests of UI state
+
   it('has search results', async () => {
     expect(wrapper.findAll('.search-results').length).toBe(1);
     announcementSearchStore.searchResults = mockAnnouncements;
     await nextTick();
     expect(wrapper.html()).toContain(`Displaying ${mockAnnouncements.length}`);
   });
+
+  // tests of computed properties
+
+  describe('selectedAnnouncementIds', () => {
+    describe('when two announcements are selected', () => {
+      it('property value is a list with the IDs of both selected announcements', async () => {
+        mockAnnouncements.forEach((announcement) => {
+          wrapper.vm.selectAnnouncement(announcement);
+        });
+        const result = wrapper.vm.selectedAnnouncementIds;
+        expect(result).toStrictEqual(
+          mockAnnouncements.map((a) => a.announcement_id),
+        );
+      });
+    });
+  });
+
+  // tests of functions
 
   describe('showAnnouncement', () => {
     describe('value is an announcement', () => {
@@ -112,6 +133,82 @@ describe('AnnouncementsPage', () => {
         const mockAnnouncement = undefined;
         wrapper.vm.showAnnouncement(mockAnnouncement);
         expect(wrapper.vm.isAnnouncementDialogVisible).toBeFalsy();
+      });
+    });
+  });
+
+  describe('selectAnnouncement', () => {
+    describe('select = true', () => {
+      it('adds the announcement ID as a key in the selectedAnnouncements object', async () => {
+        const mockAnnouncement = {
+          announcement_id: faker.string.uuid(),
+        };
+        wrapper.vm.selectedAnnouncements = {};
+        wrapper.vm.selectAnnouncement(mockAnnouncement, true);
+        expect(
+          wrapper.vm.selectedAnnouncements[mockAnnouncement.announcement_id],
+        ).toBeTruthy();
+      });
+    });
+    describe('select = false', () => {
+      it('adds the announcement ID as a key in the selectedAnnouncements object', async () => {
+        const mockAnnouncement = {
+          announcement_id: faker.string.uuid(),
+        };
+        wrapper.vm.selectedAnnouncements = {};
+        wrapper.vm.selectAnnouncement(mockAnnouncement, false);
+        expect(
+          wrapper.vm.selectedAnnouncements.hasOwnProperty(
+            mockAnnouncement.announcement_id,
+          ),
+        ).toBeFalsy();
+      });
+    });
+
+    describe('toggleSelectAllAnnouncements', () => {
+      describe('select = true', () => {
+        it('selects all announcements', () => {
+          wrapper.vm.selectedAnnouncements = {};
+          wrapper.vm.searchResults = mockAnnouncements;
+          wrapper.vm.toggleSelectAllAnnouncements(true);
+          expect(wrapper.vm.selectedAnnouncements).toStrictEqual(
+            Object.fromEntries(
+              mockAnnouncements.map((a) => [a.announcement_id, true]),
+            ),
+          );
+        });
+      });
+      describe('select = false', () => {
+        it('deselects all announcements', () => {
+          wrapper.vm.selectedAnnouncements = { mock_annoncement_id: true };
+          wrapper.vm.searchResults = mockAnnouncements;
+          wrapper.vm.toggleSelectAllAnnouncements(false);
+          expect(wrapper.vm.selectedAnnouncements).toStrictEqual({});
+        });
+      });
+    });
+  });
+
+  describe('clearSelectionOfNonSearchResults', () => {
+    describe("where there is one selected announcement and it isn't in the search results", () => {
+      it('deselects all announcements', () => {
+        wrapper.vm.selectedAnnouncements = { mock_annoncement_id: true };
+        wrapper.vm.searchResults = mockAnnouncements;
+        wrapper.vm.clearSelectionOfNonSearchResults();
+        expect(wrapper.vm.selectedAnnouncements).toStrictEqual({});
+      });
+    });
+    describe('where there is one selected announcement and it is in the search results', () => {
+      it('no change to the selected announcement', () => {
+        const initialSelection = Object.fromEntries([
+          [mockAnnouncements[0].announcement_id, true],
+        ]);
+        wrapper.vm.searchResults = mockAnnouncements;
+        wrapper.vm.selectedAnnouncements = initialSelection;
+        wrapper.vm.clearSelectionOfNonSearchResults();
+        expect(wrapper.vm.selectedAnnouncements).toStrictEqual(
+          initialSelection,
+        );
       });
     });
   });

--- a/backend/db/sample-data/generate_fake_announcements.sql
+++ b/backend/db/sample-data/generate_fake_announcements.sql
@@ -13,17 +13,17 @@ begin
 
   insert into pay_transparency.announcement (title, description, published_on, expires_on, status, created_by, updated_by)
 	values 
-		('announcement 1', '', now(), now() + interval '12 week', 'PUBLISHED', adminUserId, adminUserId),
-	('announcement 2', '', now() - interval '1 week', now() + interval '12 week', 'DRAFT', adminUserId, adminUserId),
-    ('announcement 3', '', now() - interval '2 week', now() + interval '10 week', 'PUBLISHED', adminUserId, adminUserId),
-    ('announcement 4', '', now() - interval '6 week', now() + interval '11 week', 'PUBLISHED', adminUserId, adminUserId),
-    ('announcement 5', '', now() - interval '7 week', now() + interval '14 week', 'DRAFT', adminUserId, adminUserId),
-	('announcement 6', '', now(), now() + interval '12 week', 'PUBLISHED', adminUserId, adminUserId),
-	('announcement 7', '', now() - interval '1 week', now() + interval '12 week', 'DRAFT', adminUserId, adminUserId),
-    ('announcement 8', '', now() - interval '2 week', now() + interval '11 week', 'PUBLISHED', adminUserId, adminUserId),
-    ('announcement 9', '', now() - interval '3 week', now() + interval '5 week', 'DRAFT', adminUserId, adminUserId),
-	('announcement 10', '', now() - interval '2 week', now() + interval '8 week', 'PUBLISHED', adminUserId, adminUserId),
-    ('announcement 11', '', now() - interval '7 week', now() + interval '13 week', 'DRAFT', adminUserId, adminUserId);
+		('Fugiat credo', 'Aeternus conculco nihil desparatus varietas curatio soleo sublime valetudo. Ulciscor comitatus tego atque deputo soluta suadeo concido compello. Et anser bos acsi alias.', now(), now() + interval '12 week', 'PUBLISHED', adminUserId, adminUserId),
+	('Totidem ambitus', 'Depraedor adfectus vita ventito stabilis. Vorax numquam sustineo cetera brevis laborum vos ex testimonium. Stultus valeo peccatus comes abscido vilis crepusculum viscus volo.', now() - interval '1 week', now() + interval '12 week', 'DRAFT', adminUserId, adminUserId),
+    ('Delibero voluptate', 'Voveo cras tamdiu tenuis dolorem. Commodi deprecator tricesimus crux solium benigne soleo crur. Temeritas tamdiu defetiscor.', now() - interval '2 week', now() + interval '10 week', 'PUBLISHED', adminUserId, adminUserId),
+    ('Vox aranea', 'Cavus utique vestrum asporto. Depono tamdiu truculenter cicuta tibi. Tubineus conatus thema ubi.', now() - interval '6 week', now() + interval '11 week', 'PUBLISHED', adminUserId, adminUserId),
+    ('Creator solum', 'Adversus quos adeptio. Eius succurro alienus verecundia qui. Spargo basium trans corroboro ustulo.', now() - interval '7 week', now() + interval '14 week', 'DRAFT', adminUserId, adminUserId),
+	('Contego aperio', 'Ducimus cras provident tracto cohors vulgivagus. Cuppedia utor turba architecto capitulus ad aperio cur admitto. Tyrannus voluptates demo arguo attero.', now(), now() + interval '12 week', 'PUBLISHED', adminUserId, adminUserId),
+	('Eum benigne', 'Consectetur adstringo calculus talis ventito cibo supplanto vomer aegrus. Arbor eos aestivus ater tibi verecundia trans casso aegre. Thesis tribuo bene aggero strenuus ciminatio ver quibusdam virgo.', now() - interval '1 week', now() + interval '12 week', 'DRAFT', adminUserId, adminUserId),
+    ('Constans validus', 'Cohaero velut temporibus antepono. Vergo pecus tondeo vergo argentum cribro distinctio torrens. Ullus temporibus facilis magnam bellicus vinum pax nobis.', now() - interval '2 week', now() + interval '11 week', 'PUBLISHED', adminUserId, adminUserId),
+    ('Numquam tenus', 'Bonus combibo crebro blanditiis acer abbas acidus. Subnecto charisma viduo sulum expedita una excepturi recusandae causa pecto. Arceo voco cursus similique tempus claudeo sono cultellus abundans decerno.', now() - interval '3 week', now() + interval '5 week', 'DRAFT', adminUserId, adminUserId),
+	('Appono itaque', 'Antiquus acervus at vinum spectaculum adulescens adstringo villa. Tergiversatio assumenda defendo conventus usque calculus aeternus abutor cernuus totus. Arcus titulus stabilis perspiciatis.', now() - interval '2 week', now() + interval '8 week', 'PUBLISHED', adminUserId, adminUserId),
+    ('Alarte Ascendare', 'Adficio sum perspiciatis umerus cetera cribro absum. Cubitum curiositas utrimque numquam aggredior talis aedificium sortitus aperio. Cetera administratio corpus suscipit patrocinor color suppono.', now() - interval '7 week', now() + interval '13 week', 'DRAFT', adminUserId, adminUserId);
 
 end
 


### PR DESCRIPTION
# Description

On the admin app's "announcements" page:

- The title of each announcement shown in the search results is now clickable.  Clicking brings up a dialog with the description.
- Each search result now has a checkbox beside it.
- A "Delete" button was added, and it's only enabled when there are selected announcements

Fixes # [GEO-861](https://finrms.atlassian.net/browse/GEO-861)

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

New unit tests

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have already been accepted and merged

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://pay-transparency-pr-633-frontend.apps.silver.devops.gov.bc.ca)
- [Admin Frontend](https://pay-transparency-pr-633-admin-frontend.apps.silver.devops.gov.bc.ca)
- [Backend external API console](https://pay-transparency-pr-633-backend-external.apps.silver.devops.gov.bc.ca/api/V1/docs)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/fin-pay-transparency/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/fin-pay-transparency/actions/workflows/merge.yml)