### PR TITLE
feat: GEO-1005 admin app - delete announcements (two ways)

### DIFF
--- a/admin-frontend/src/App.vue
+++ b/admin-frontend/src/App.vue
@@ -229,6 +229,12 @@ button:disabled.v-btn {
   color: #f8bb47 !important;
 }
 
+.v-chip.error {
+  background-color: #f4e1e2 !important;
+  border-color: #f4e1e2 !important;
+  color: #ce3e39 !important;
+}
+
 @media screen and (max-width: 370px) {
   .v-toolbar__title {
     font-size: 0.9rem;

--- a/admin-frontend/src/components/AnnouncementsPage.vue
+++ b/admin-frontend/src/components/AnnouncementsPage.vue
@@ -81,15 +81,20 @@
       </template>
       <template v-slot:footer.prepend="">
         <v-row class="d-flex justify-start">
-          <v-col>
-            <v-btn
-              class="btn-secondary"
-              :disabled="!selectedAnnouncementIds.length || isDeleting"
-              :loading="isDeleting"
-              @click="deleteAnnouncements(selectedAnnouncementIds)"
-              prepend-icon="mdi-delete"
-              >Delete</v-btn
-            >
+          <v-col class="d-flex justify-start">
+            <div class="mt-3 d-flex flex-column align-center">
+              <v-btn
+                class="btn-secondary"
+                :disabled="!selectedAnnouncementIds.length || isDeleting"
+                :loading="isDeleting"
+                @click="deleteAnnouncements(selectedAnnouncementIds)"
+                prepend-icon="mdi-delete"
+                >Delete</v-btn
+              >
+              <small v-if="selectedAnnouncementIds.length">
+                {{ selectedAnnouncementIds.length }} selected
+              </small>
+            </div>
           </v-col>
         </v-row>
       </template>

--- a/admin-frontend/src/components/AnnouncementsPage.vue
+++ b/admin-frontend/src/components/AnnouncementsPage.vue
@@ -77,43 +77,16 @@
         <AnnouncementStatusChip :status="item.status"></AnnouncementStatusChip>
       </template>
       <template v-slot:item.actions="{ item }">
-        <v-btn
-          aria-label="Actions"
-          density="compact"
-          variant="plain"
-          icon="mdi-dots-vertical"
-          color="black"
-          class="btn-actions"
-        >
-          <v-icon color="black"></v-icon>
-          <v-menu activator="parent">
-            <v-list>
-              <v-list-item>
-                <v-btn variant="text" prepend-icon="mdi-pencil">Edit</v-btn>
-              </v-list-item>
-              <v-list-item v-if="item.status == 'DRAFT'">
-                <v-btn variant="text" prepend-icon="mdi-publish">Publish</v-btn>
-              </v-list-item>
-              <v-list-item v-if="item.status == 'PUBLISHED'">
-                <v-btn variant="text" prepend-icon="mdi-cancel"
-                  >Unpublish</v-btn
-                >
-              </v-list-item>
-              <v-list-item>
-                <v-btn class="text-red" variant="text" prepend-icon="mdi-delete"
-                  >Delete</v-btn
-                >
-              </v-list-item>
-            </v-list>
-          </v-menu>
-        </v-btn>
+        <AnnouncementActions :announcement="item"></AnnouncementActions>
       </template>
       <template v-slot:footer.prepend="">
         <v-row class="d-flex justify-start">
           <v-col>
             <v-btn
               class="btn-secondary"
-              :disabled="!selectedAnnouncementIds.length"
+              :disabled="!selectedAnnouncementIds.length || isDeleting"
+              :loading="isDeleting"
+              @click="deleteAnnouncements(selectedAnnouncementIds)"
               prepend-icon="mdi-delete"
               >Delete</v-btn
             >
@@ -159,9 +132,11 @@ import { storeToRefs } from 'pinia';
 import { ref, watch, computed } from 'vue';
 import AnnouncementSearchFilters from './announcements/AnnouncementSearchFilters.vue';
 import AnnouncementStatusChip from './announcements/AnnouncementStatusChip.vue';
+import AnnouncementActions from './announcements/AnnouncementActions.vue';
 import { useAnnouncementSearchStore } from '../store/modules/announcementSearchStore';
 import { formatDate } from '../utils/date';
 import { AnnouncementKeys } from '../types/announcements';
+import ApiService from '../services/apiService';
 
 const announcementSearchStore = useAnnouncementSearchStore();
 const { searchResults, isSearching, hasSearched, totalNum, pageSize } =
@@ -170,6 +145,7 @@ const announcementInDialog = ref<any>(undefined);
 const isAnnouncementDialogVisible = ref<boolean>(false);
 const isSelectedAnnouncementsHeaderChecked = ref<boolean>(false);
 const selectedAnnouncements = ref<object>({});
+const isDeleting = ref<boolean>(false);
 const selectedAnnouncementIds = computed(() =>
   Object.entries(selectedAnnouncements.value)
     .filter(([_, value]) => value)
@@ -280,6 +256,17 @@ async function repeatSearch() {
 
 async function addAnnouncement() {
   console.log('TODO: add announcement');
+}
+
+async function deleteAnnouncements(announcementIds: string[]) {
+  isDeleting.value = true;
+  try {
+    await ApiService.deleteAnnouncements(announcementIds);
+    announcementSearchStore.repeatSearch();
+  } catch (e) {
+  } finally {
+    isDeleting.value = false;
+  }
 }
 </script>
 

--- a/admin-frontend/src/components/AnnouncementsPage.vue
+++ b/admin-frontend/src/components/AnnouncementsPage.vue
@@ -97,6 +97,7 @@
   </div>
 
   <!-- dialogs -->
+  <ConfirmationDialog ref="confirmDialog"> </ConfirmationDialog>
   <v-dialog
     v-model="isAnnouncementDialogVisible"
     :close-on-content-click="true"
@@ -137,11 +138,13 @@ import { useAnnouncementSearchStore } from '../store/modules/announcementSearchS
 import { formatDate } from '../utils/date';
 import { AnnouncementKeys } from '../types/announcements';
 import ApiService from '../services/apiService';
+import ConfirmationDialog from './util/ConfirmationDialog.vue';
 
 const announcementSearchStore = useAnnouncementSearchStore();
 const { searchResults, isSearching, hasSearched, totalNum, pageSize } =
   storeToRefs(announcementSearchStore);
 const announcementInDialog = ref<any>(undefined);
+const confirmDialog = ref<typeof ConfirmationDialog>();
 const isAnnouncementDialogVisible = ref<boolean>(false);
 const isSelectedAnnouncementsHeaderChecked = ref<boolean>(false);
 const selectedAnnouncements = ref<object>({});
@@ -259,13 +262,23 @@ async function addAnnouncement() {
 }
 
 async function deleteAnnouncements(announcementIds: string[]) {
-  isDeleting.value = true;
-  try {
-    await ApiService.deleteAnnouncements(announcementIds);
-    announcementSearchStore.repeatSearch();
-  } catch (e) {
-  } finally {
-    isDeleting.value = false;
+  const isConfirmed = await confirmDialog.value?.open(
+    'Confirm Deletion',
+    `Are you sure you want to delete the selected announcement${announcementIds.length != 1 ? 's' : ''}?  This action cannot be undone.`,
+    {
+      titleBold: true,
+      resolveText: `Confirm`,
+    },
+  );
+  if (isConfirmed) {
+    isDeleting.value = true;
+    try {
+      await ApiService.deleteAnnouncements(announcementIds);
+      announcementSearchStore.repeatSearch();
+    } catch (e) {
+    } finally {
+      isDeleting.value = false;
+    }
   }
 }
 </script>

--- a/admin-frontend/src/components/__tests__/AnnouncementsPage.spec.ts
+++ b/admin-frontend/src/components/__tests__/AnnouncementsPage.spec.ts
@@ -46,10 +46,12 @@ const ResizeObserverMock = vi.fn(() => ({
 }));
 
 const mockGetAnnouncements = vi.fn();
+const mockDeleteAnnouncements = vi.fn();
 
 vi.mock('../../services/apiService', () => ({
   default: {
     getAnnouncements: (...args) => mockGetAnnouncements(...args),
+    deleteAnnouncements: (...args) => mockDeleteAnnouncements(...args),
   },
 }));
 
@@ -210,6 +212,17 @@ describe('AnnouncementsPage', () => {
           initialSelection,
         );
       });
+    });
+  });
+
+  describe('deleteAnnouncement', async () => {
+    it('delegates to the ApiService', async () => {
+      const announcementIds = ['1', '2'];
+      const repeatSearchSpy = vi.spyOn(announcementSearchStore, 'repeatSearch');
+      const resp = await wrapper.vm.deleteAnnouncements(announcementIds);
+      expect(mockDeleteAnnouncements).toHaveBeenCalledWith(announcementIds);
+      expect(repeatSearchSpy).toHaveBeenCalledTimes(1);
+      expect(wrapper.vm.isDeleting).toBeFalsy();
     });
   });
 });

--- a/admin-frontend/src/components/__tests__/AnnouncementsPage.spec.ts
+++ b/admin-frontend/src/components/__tests__/AnnouncementsPage.spec.ts
@@ -216,13 +216,41 @@ describe('AnnouncementsPage', () => {
   });
 
   describe('deleteAnnouncement', async () => {
-    it('delegates to the ApiService', async () => {
-      const announcementIds = ['1', '2'];
-      const repeatSearchSpy = vi.spyOn(announcementSearchStore, 'repeatSearch');
-      const resp = await wrapper.vm.deleteAnnouncements(announcementIds);
-      expect(mockDeleteAnnouncements).toHaveBeenCalledWith(announcementIds);
-      expect(repeatSearchSpy).toHaveBeenCalledTimes(1);
-      expect(wrapper.vm.isDeleting).toBeFalsy();
+    describe('confirm delete', () => {
+      it('delegates to the ApiService', async () => {
+        const announcementIds = ['1', '2'];
+        const repeatSearchSpy = vi.spyOn(
+          announcementSearchStore,
+          'repeatSearch',
+        );
+
+        //mock the confirm delete dialog.
+        //simulate the user clicking the 'confirm' button
+        vi.spyOn(wrapper.vm.confirmDialog, 'open').mockResolvedValue(true);
+
+        const resp = await wrapper.vm.deleteAnnouncements(announcementIds);
+        expect(mockDeleteAnnouncements).toHaveBeenCalledWith(announcementIds);
+        expect(repeatSearchSpy).toHaveBeenCalledTimes(1);
+        expect(wrapper.vm.isDeleting).toBeFalsy();
+      });
+    });
+    describe('cancel delete', () => {
+      it("doesn't delete anything", async () => {
+        const announcementIds = ['1', '2'];
+        const repeatSearchSpy = vi.spyOn(
+          announcementSearchStore,
+          'repeatSearch',
+        );
+
+        //mock the confirm delete dialog.
+        //simulate the user clicking the 'cancel' button
+        vi.spyOn(wrapper.vm.confirmDialog, 'open').mockResolvedValue(false);
+
+        const resp = await wrapper.vm.deleteAnnouncements(announcementIds);
+        expect(mockDeleteAnnouncements).toHaveBeenCalledTimes(0);
+        expect(repeatSearchSpy).toHaveBeenCalledTimes(0);
+        expect(wrapper.vm.isDeleting).toBeFalsy();
+      });
     });
   });
 });

--- a/admin-frontend/src/components/announcements/AnnouncementActions.vue
+++ b/admin-frontend/src/components/announcements/AnnouncementActions.vue
@@ -33,6 +33,9 @@
       </v-list>
     </v-menu>
   </v-btn>
+
+  <!-- dialogs -->
+  <ConfirmationDialog ref="confirmDialog"> </ConfirmationDialog>
 </template>
 
 <script lang="ts">
@@ -44,21 +47,33 @@ export default {
 
 <script setup lang="ts">
 import { AnnouncementStatus } from '../../types/announcements';
+import ConfirmationDialog from '../util/ConfirmationDialog.vue';
 import ApiService from '../../services/apiService';
 import { useAnnouncementSearchStore } from '../../store/modules/announcementSearchStore';
 import { ref } from 'vue';
 
 const announcementSearchStore = useAnnouncementSearchStore();
+const confirmDialog = ref<typeof ConfirmationDialog>();
 const isDeleting = ref<boolean>(false);
 
 async function deleteAnnouncement(announcementId: string) {
-  isDeleting.value = true;
-  try {
-    await ApiService.deleteAnnouncements([announcementId]);
-    announcementSearchStore.repeatSearch();
-  } catch (e) {
-  } finally {
-    isDeleting.value = false;
+  const isConfirmed = await confirmDialog.value?.open(
+    'Confirm Deletion',
+    `Are you sure you want to delete the selected announcement?  This action cannot be undone.`,
+    {
+      titleBold: true,
+      resolveText: `Confirm`,
+    },
+  );
+  if (isConfirmed) {
+    isDeleting.value = true;
+    try {
+      await ApiService.deleteAnnouncements([announcementId]);
+      announcementSearchStore.repeatSearch();
+    } catch (e) {
+    } finally {
+      isDeleting.value = false;
+    }
   }
 }
 </script>

--- a/admin-frontend/src/components/announcements/AnnouncementActions.vue
+++ b/admin-frontend/src/components/announcements/AnnouncementActions.vue
@@ -1,0 +1,64 @@
+<template v-if="announcement">
+  <v-btn
+    aria-label="Actions"
+    density="compact"
+    variant="plain"
+    icon="mdi-dots-vertical"
+    color="black"
+    class="btn-actions"
+  >
+    <v-icon color="black"></v-icon>
+    <v-menu activator="parent">
+      <v-list>
+        <v-list-item>
+          <v-btn variant="text" prepend-icon="mdi-pencil">Edit</v-btn>
+        </v-list-item>
+        <v-list-item v-if="announcement.status == AnnouncementStatus.Draft">
+          <v-btn variant="text" prepend-icon="mdi-publish">Publish</v-btn>
+        </v-list-item>
+        <v-list-item v-if="announcement.status == AnnouncementStatus.Published">
+          <v-btn variant="text" prepend-icon="mdi-cancel">Unpublish</v-btn>
+        </v-list-item>
+        <v-list-item v-if="announcement.status != AnnouncementStatus.Deleted">
+          <v-btn
+            class="text-red"
+            variant="text"
+            prepend-icon="mdi-delete"
+            @click="deleteAnnouncement(announcement.announcement_id)"
+            :loading="isDeleting"
+            :disabled="isDeleting"
+            >Delete</v-btn
+          >
+        </v-list-item>
+      </v-list>
+    </v-menu>
+  </v-btn>
+</template>
+
+<script lang="ts">
+export default {
+  name: 'AnnouncementActions',
+  props: ['announcement'],
+};
+</script>
+
+<script setup lang="ts">
+import { AnnouncementStatus } from '../../types/announcements';
+import ApiService from '../../services/apiService';
+import { useAnnouncementSearchStore } from '../../store/modules/announcementSearchStore';
+import { ref } from 'vue';
+
+const announcementSearchStore = useAnnouncementSearchStore();
+const isDeleting = ref<boolean>(false);
+
+async function deleteAnnouncement(announcementId: string) {
+  isDeleting.value = true;
+  try {
+    await ApiService.deleteAnnouncements([announcementId]);
+    announcementSearchStore.repeatSearch();
+  } catch (e) {
+  } finally {
+    isDeleting.value = false;
+  }
+}
+</script>

--- a/admin-frontend/src/components/announcements/AnnouncementStatusChip.vue
+++ b/admin-frontend/src/components/announcements/AnnouncementStatusChip.vue
@@ -1,9 +1,13 @@
 <template>
   <v-chip
     :class="{
-      success: status == 'PUBLISHED',
-      warning: status == 'EXPIRED',
-      info: !['PUBLISHED', 'EXPIRED'].includes(status),
+      success: status == AnnouncementStatus.Published,
+      warning: status == AnnouncementStatus.Expired,
+      info: ![
+        AnnouncementStatus.Published,
+        AnnouncementStatus.Expired,
+      ].includes(status),
+      error: status == AnnouncementStatus.Deleted,
     }"
     size="small"
   >
@@ -17,4 +21,6 @@ export default {
 };
 </script>
 
-<script setup lang="ts"></script>
+<script setup lang="ts">
+import { AnnouncementStatus } from '../../types/announcements';
+</script>

--- a/admin-frontend/src/components/announcements/__tests__/AnnouncementActions.spec.ts
+++ b/admin-frontend/src/components/announcements/__tests__/AnnouncementActions.spec.ts
@@ -72,13 +72,38 @@ describe('AnnouncementActions', () => {
   });
 
   describe('deleteAnnouncement', async () => {
-    it('delegates to the ApiService', async () => {
-      const announcementId = '1';
-      const apiSpy = vi
-        .spyOn(ApiService, 'deleteAnnouncements')
-        .mockResolvedValue();
-      wrapper.vm.deleteAnnouncement(announcementId);
-      expect(apiSpy).toHaveBeenCalledWith([announcementId]);
+    describe('confirm delete', () => {
+      it('delegates to the ApiService', async () => {
+        const announcementId = '1';
+        const apiSpy = vi
+          .spyOn(ApiService, 'deleteAnnouncements')
+          .mockResolvedValue();
+
+        //mock the confirm delete dialog.
+        //simulate the user clicking the 'confirm' button
+        vi.spyOn(wrapper.vm.confirmDialog, 'open').mockResolvedValue(true);
+
+        await wrapper.vm.deleteAnnouncement(announcementId);
+
+        expect(apiSpy).toHaveBeenCalledWith([announcementId]);
+      });
+    });
+
+    describe('cancel delete', () => {
+      it('does nothing', async () => {
+        const announcementId = '1';
+        const apiSpy = vi
+          .spyOn(ApiService, 'deleteAnnouncements')
+          .mockResolvedValue();
+
+        //mock the confirm delete dialog.
+        //simulate the user clicking the 'cancel' button
+        vi.spyOn(wrapper.vm.confirmDialog, 'open').mockResolvedValue(false);
+
+        await wrapper.vm.deleteAnnouncement(announcementId);
+
+        expect(apiSpy).toHaveBeenCalledTimes(0);
+      });
     });
   });
 });

--- a/admin-frontend/src/components/announcements/__tests__/AnnouncementActions.spec.ts
+++ b/admin-frontend/src/components/announcements/__tests__/AnnouncementActions.spec.ts
@@ -1,0 +1,84 @@
+import { createTestingPinia } from '@pinia/testing';
+import { flushPromises, mount } from '@vue/test-utils';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createVuetify } from 'vuetify';
+import * as components from 'vuetify/components';
+import * as directives from 'vuetify/directives';
+import ApiService from '../../../services/apiService';
+import { IAnnouncement } from '../../../types/announcements';
+import AnnouncementActions from '../AnnouncementActions.vue';
+
+// Mock the ResizeObserver
+const ResizeObserverMock = vi.fn(() => ({
+  observe: vi.fn(),
+  unobserve: vi.fn(),
+  disconnect: vi.fn(),
+}));
+
+// Stub blobal objects needed for testing
+vi.stubGlobal('ResizeObserver', ResizeObserverMock);
+vi.stubGlobal('URL', { createObjectURL: vi.fn() });
+
+const mockDraftAnnouncement: IAnnouncement = {
+  announcement_id: '24b9455e-154b-46ce-91c7-5ec4474ad6fd',
+  title: 'Eum benigne',
+  description: 'Consectetur adstringo calculus talis',
+  created_date: '2024-08-06T18:56:35.825Z',
+  updated_date: '2024-08-06T18:56:35.825Z',
+  created_by: '7e53edd6-f50f-4002-be1a-06dc506c138a',
+  updated_by: '7e53edd6-f50f-4002-be1a-06dc506c138a',
+  published_on: '2024-07-30T18:56:35.825Z',
+  expires_on: '2024-10-29T18:56:35.825Z',
+  status: 'DRAFT',
+};
+
+describe('AnnouncementActions', () => {
+  let wrapper;
+  let pinia;
+
+  const initWrapper = async () => {
+    const vuetify = createVuetify({
+      components,
+      directives,
+    });
+
+    pinia = createTestingPinia({
+      initialState: {},
+    });
+    wrapper = mount(AnnouncementActions, {
+      props: {
+        announcement: mockDraftAnnouncement,
+      },
+      global: {
+        plugins: [vuetify, pinia],
+      },
+      stubs: {
+        transition: true,
+      },
+    });
+
+    //wait for the async component to load
+    await flushPromises();
+  };
+
+  beforeEach(async () => {
+    initWrapper();
+  });
+
+  afterEach(() => {
+    if (wrapper) {
+      wrapper.unmount();
+    }
+  });
+
+  describe('deleteAnnouncement', async () => {
+    it('delegates to the ApiService', async () => {
+      const announcementId = '1';
+      const apiSpy = vi
+        .spyOn(ApiService, 'deleteAnnouncements')
+        .mockResolvedValue();
+      wrapper.vm.deleteAnnouncement(announcementId);
+      expect(apiSpy).toHaveBeenCalledWith([announcementId]);
+    });
+  });
+});

--- a/admin-frontend/src/components/announcements/__tests__/AnnouncementSearchFilters.spec.ts
+++ b/admin-frontend/src/components/announcements/__tests__/AnnouncementSearchFilters.spec.ts
@@ -18,7 +18,7 @@ const ResizeObserverMock = vi.fn(() => ({
 vi.stubGlobal('ResizeObserver', ResizeObserverMock);
 vi.stubGlobal('URL', { createObjectURL: vi.fn() });
 
-describe('ReportSearchFilters', () => {
+describe('AnnouncementSearchFilters', () => {
   let wrapper;
   let pinia;
 

--- a/admin-frontend/src/services/__tests__/apiService.spec.ts
+++ b/admin-frontend/src/services/__tests__/apiService.spec.ts
@@ -1,8 +1,6 @@
 import { AxiosError } from 'axios';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import ApiService from '../apiService';
-import { de } from '@faker-js/faker';
-import { i } from 'vitest/dist/reporters-yx5ZTtEV.js';
 
 //Mock the interceptor used by the ApiService so it no longer depends on
 //HTTP calls to the backend.
@@ -197,7 +195,9 @@ describe('ApiService', () => {
           mockAxiosError,
         );
 
-        expect(ApiService.deleteUserInvite('1')).rejects.toEqual(mockAxiosError);
+        expect(ApiService.deleteUserInvite('1')).rejects.toEqual(
+          mockAxiosError,
+        );
       });
     });
   });
@@ -357,6 +357,49 @@ describe('ApiService', () => {
 
         const resp = await ApiService.getPdfReportAsBlob(mockReportId);
         expect(resp).toEqual(mockResponse.data);
+      });
+    });
+  });
+
+  describe('deleteAnnouncements', () => {
+    describe('when the API request to the backend is successful', () => {
+      it('returns a promise that eventually resolves', async () => {
+        const announcementIdsToDelete = ['1', '2'];
+        const mockResponse = {
+          data: {},
+          status: 201,
+        };
+        const patchSpy = vi
+          .spyOn(ApiService.apiAxios, 'patch')
+          .mockResolvedValueOnce(mockResponse);
+
+        await expect(ApiService.deleteAnnouncements(announcementIdsToDelete))
+          .resolves;
+
+        const expectedPatchBody = announcementIdsToDelete?.map((id) => {
+          return {
+            id: id,
+            status: 'DELETED',
+          };
+        });
+        expect(patchSpy).toHaveBeenCalledOnce();
+        expect(patchSpy.mock.calls[0][1]).toEqual(expectedPatchBody);
+      });
+    });
+    describe('when the API request to the backend is unsuccessful', () => {
+      it('returns a promise that eventually rejects', async () => {
+        const announcementIdsToDelete = ['1', '2'];
+        const mockResponse = {
+          data: {},
+          status: 400,
+        };
+        vi.spyOn(ApiService.apiAxios, 'patch').mockResolvedValueOnce(
+          mockResponse,
+        );
+
+        await expect(
+          ApiService.deleteAnnouncements(announcementIdsToDelete),
+        ).rejects.toThrow();
       });
     });
   });

--- a/admin-frontend/src/services/apiService.ts
+++ b/admin-frontend/src/services/apiService.ts
@@ -259,6 +259,25 @@ export default {
     }
   },
 
+  async deleteAnnouncements(announcementIds: string[]): Promise<void> {
+    try {
+      const body = announcementIds?.map((id) => {
+        return {
+          id: id,
+          status: 'DELETED',
+        };
+      });
+      const resp = await apiAxios.patch(`${ApiRoutes.ANNOUNCEMENTS}`, body);
+      if (resp?.status == 201) {
+        return;
+      }
+      throw new Error('Unexpected response from API.');
+    } catch (e) {
+      console.log(`Failed to delete announcements: ${e}`);
+      throw e;
+    }
+  },
+
   /**
    * Download a list of reports in csv format.  This method also causes
    * the browser to save the resulting file.

--- a/admin-frontend/src/types/announcements.ts
+++ b/admin-frontend/src/types/announcements.ts
@@ -1,5 +1,17 @@
+export interface IAnnouncement {
+  announcement_id: string;
+  title: string;
+  description: string;
+  created_date: string;
+  updated_date: string;
+  created_by: string;
+  updated_by: string;
+  published_on: string;
+  expires_on: string;
+  status: string;
+}
 export interface IAnnouncementSearchResult {
-  items: any[];
+  items: IAnnouncement[];
   total: number;
 }
 export interface IAnnouncementSearchUpdateParams {

--- a/backend/db/sample-data/generate_fake_announcements.sql
+++ b/backend/db/sample-data/generate_fake_announcements.sql
@@ -5,13 +5,15 @@ $$
 declare
 
 adminUserId uuid;
+announcementId uuid;
 
 begin
 
-	select admin_user_id into adminUserId from pay_transparency.admin_user limit 1;
- 
+  set search_path = pay_transparency;
 
-  insert into pay_transparency.announcement (title, description, published_on, expires_on, status, created_by, updated_by)
+  -- add 11 announcements.  some draft and some published.
+	select admin_user_id into adminUserId from pay_transparency.admin_user limit 1;
+  insert into announcement (title, description, published_on, expires_on, status, created_by, updated_by)
 	values 
 		('Fugiat credo', 'Aeternus conculco nihil desparatus varietas curatio soleo sublime valetudo. Ulciscor comitatus tego atque deputo soluta suadeo concido compello. Et anser bos acsi alias.', now(), now() + interval '12 week', 'PUBLISHED', adminUserId, adminUserId),
 	('Totidem ambitus', 'Depraedor adfectus vita ventito stabilis. Vorax numquam sustineo cetera brevis laborum vos ex testimonium. Stultus valeo peccatus comes abscido vilis crepusculum viscus volo.', now() - interval '1 week', now() + interval '12 week', 'DRAFT', adminUserId, adminUserId),
@@ -24,6 +26,12 @@ begin
     ('Numquam tenus', 'Bonus combibo crebro blanditiis acer abbas acidus. Subnecto charisma viduo sulum expedita una excepturi recusandae causa pecto. Arceo voco cursus similique tempus claudeo sono cultellus abundans decerno.', now() - interval '3 week', now() + interval '5 week', 'DRAFT', adminUserId, adminUserId),
 	('Appono itaque', 'Antiquus acervus at vinum spectaculum adulescens adstringo villa. Tergiversatio assumenda defendo conventus usque calculus aeternus abutor cernuus totus. Arcus titulus stabilis perspiciatis.', now() - interval '2 week', now() + interval '8 week', 'PUBLISHED', adminUserId, adminUserId),
     ('Alarte Ascendare', 'Adficio sum perspiciatis umerus cetera cribro absum. Cubitum curiositas utrimque numquam aggredior talis aedificium sortitus aperio. Cetera administratio corpus suscipit patrocinor color suppono.', now() - interval '7 week', now() + interval '13 week', 'DRAFT', adminUserId, adminUserId);
+
+  -- add a 'resource' associated with one of the announcements
+  select announcement_id into announcementId from pay_transparency.announcement limit 1;
+  insert into announcement_resource (announcement_id, resource_type, display_name, resource_url, created_by, updated_by) 
+  values 
+  (announcementId, 'LINK', 'Mock resource', 'Mock Url', adminUserId, adminUserId);
 
 end
 

--- a/backend/src/v1/services/announcements-service.ts
+++ b/backend/src/v1/services/announcements-service.ts
@@ -88,9 +88,14 @@ export const patchAnnouncements = async (
     });
 
     for (const announcement of announcements) {
+      //exclude the 'announcement_resource' attribute from
+      //the new announcement_history record
+      const announcement_history = { ...announcement };
+      delete announcement_history.announcement_resource;
+
       await tx.announcement_history.create({
         data: {
-          ...announcement,
+          ...announcement_history,
           announcement_resource_history: {
             createMany: {
               data: announcement.announcement_resource.map((resource) => ({


### PR DESCRIPTION
# Description

Support delete of multiple selected announcements (via the delete button at the bottom of the announcements page), and support delete of a single announcement from the 'action' button on each row of the data table.

Delete announcement support was added to the backend API in a previous PR. This PR is mainly for the frontend delete-related work (although it includes one minor bug fix to the API.)

Fixes # [GEO-1005](https://finrms.atlassian.net/browse/GEO-1005)

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

New unit tests

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have already been accepted and merged



---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://pay-transparency-pr-641-frontend.apps.silver.devops.gov.bc.ca)
- [Admin Frontend](https://pay-transparency-pr-641-admin-frontend.apps.silver.devops.gov.bc.ca)
- [Backend external API console](https://pay-transparency-pr-641-backend-external.apps.silver.devops.gov.bc.ca/api/V1/docs)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/fin-pay-transparency/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/fin-pay-transparency/actions/workflows/merge.yml)