### PR TITLE
feat: admin announcement preview updates

### DIFF
--- a/admin-frontend/src/components/AddAnnouncementPage.vue
+++ b/admin-frontend/src/components/AddAnnouncementPage.vue
@@ -3,12 +3,15 @@
     :announcement="null"
     title="Add Announcement"
     @save="submit"
-    mode="create"
+    :mode="AnnouncementFormMode.CREATE"
   ></AnnouncementForm>
 </template>
 
 <script lang="ts" setup>
-import { AnnouncementFormValue } from '../types/announcements';
+import {
+  AnnouncementFormValue,
+  AnnouncementFormMode,
+} from '../types/announcements';
 import { useRouter } from 'vue-router';
 import AnnouncementForm from './announcements/AnnouncementForm.vue';
 import { NotificationService } from '../services/notificationService';

--- a/admin-frontend/src/components/EditAnnouncementPage.vue
+++ b/admin-frontend/src/components/EditAnnouncementPage.vue
@@ -3,14 +3,17 @@
     :announcement="announcement"
     title="Edit Announcement"
     @save="submit"
-    mode="edit"
+    :mode="AnnouncementFormMode.EDIT"
   ></AnnouncementForm>
 </template>
 
 <script lang="ts" setup>
 import { onBeforeMount } from 'vue';
 import { storeToRefs } from 'pinia';
-import { AnnouncementFormValue } from '../types/announcements';
+import {
+  AnnouncementFormValue,
+  AnnouncementFormMode,
+} from '../types/announcements';
 import AnnouncementForm from './announcements/AnnouncementForm.vue';
 import { NotificationService } from '../services/notificationService';
 import { useAnnouncementSelectionStore } from '../store/modules/announcementSelectionStore';

--- a/admin-frontend/src/components/__tests__/EditAnnouncementPage.spec.ts
+++ b/admin-frontend/src/components/__tests__/EditAnnouncementPage.spec.ts
@@ -1,12 +1,11 @@
-import { beforeEach, describe, it, vi, expect } from 'vitest';
-import EditAnnouncementPage from '../EditAnnouncementPage.vue';
 import { fireEvent, render, waitFor } from '@testing-library/vue';
+import { createPinia, setActivePinia } from 'pinia';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createVuetify } from 'vuetify';
 import * as components from 'vuetify/components';
 import * as directives from 'vuetify/directives';
-import { createVuetify } from 'vuetify';
-import { createTestingPinia } from '@pinia/testing';
-import { createPinia, setActivePinia } from 'pinia';
 import { useAnnouncementSelectionStore } from '../../store/modules/announcementSelectionStore';
+import EditAnnouncementPage from '../EditAnnouncementPage.vue';
 
 global.ResizeObserver = require('resize-observer-polyfill');
 
@@ -96,6 +95,7 @@ describe('EditAnnouncementPage', () => {
     describe('when announcement is updated', () => {
       it('should show success notification', async () => {
         store.setAnnouncement({
+          announcement_id: '1',
           title: 'title',
           description: 'description',
           published_on: new Date(),
@@ -126,6 +126,7 @@ describe('EditAnnouncementPage', () => {
     describe('when announcement update fails', () => {
       it('should show error notification', async () => {
         store.setAnnouncement({
+          announcement_id: '1',
           title: 'title',
           description: 'description',
           published_on: new Date(),

--- a/admin-frontend/src/store/modules/__tests__/announcementSelectionStore.spec.ts
+++ b/admin-frontend/src/store/modules/__tests__/announcementSelectionStore.spec.ts
@@ -1,5 +1,5 @@
+import { createPinia, setActivePinia } from 'pinia';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { setActivePinia, createPinia } from 'pinia';
 import { useAnnouncementSelectionStore } from '../announcementSelectionStore';
 
 const mockUpdateAnnouncement = vi.fn();
@@ -48,7 +48,7 @@ describe('announcementSelectionStore', () => {
         expect(store.announcement).toEqual(
           expect.objectContaining({
             title: 'title',
-            id: '1',
+            announcement_id: '1',
             description: 'description',
             published_on: expect.any(Date),
             expires_on: expect.any(Date),
@@ -65,7 +65,7 @@ describe('announcementSelectionStore', () => {
       it('should reset announcement', () => {
         const store = useAnnouncementSelectionStore();
         store.announcement = {
-          id: '1',
+          announcement_id: '1',
           title: 'title',
           description: 'description',
           published_on: 'published_on',
@@ -84,7 +84,7 @@ describe('announcementSelectionStore', () => {
       it('should save changes', async () => {
         const store = useAnnouncementSelectionStore();
         store.announcement = {
-          id: '1',
+          announcement_id: '1',
           title: 'title',
           description: 'description',
           published_on: 'published_on',

--- a/admin-frontend/src/store/modules/announcementSelectionStore.ts
+++ b/admin-frontend/src/store/modules/announcementSelectionStore.ts
@@ -44,7 +44,7 @@ export const useAnnouncementSelectionStore = defineStore(
     const saveChanges = async (data: AnnouncementFormValue) => {
       if (announcement.value!?.announcement_id) {
         await ApiService.updateAnnouncement(
-          announcement.value!.announcement_id,
+          announcement.value.announcement_id,
           data,
         );
       }

--- a/admin-frontend/src/store/modules/announcementSelectionStore.ts
+++ b/admin-frontend/src/store/modules/announcementSelectionStore.ts
@@ -42,7 +42,7 @@ export const useAnnouncementSelectionStore = defineStore(
     };
 
     const saveChanges = async (data: AnnouncementFormValue) => {
-      if (announcement.value!.announcement_id) {
+      if (announcement.value!?.announcement_id) {
         await ApiService.updateAnnouncement(
           announcement.value!.announcement_id,
           data,

--- a/admin-frontend/src/store/modules/announcementSelectionStore.ts
+++ b/admin-frontend/src/store/modules/announcementSelectionStore.ts
@@ -1,20 +1,15 @@
 import { defineStore } from 'pinia';
 import { ref } from 'vue';
-import {
-  AnnouncementFormValue,
-  IAnnouncement,
-} from '../../types/announcements';
 import ApiService from '../../services/apiService';
+import { Announcement, AnnouncementFormValue } from '../../types/announcements';
 
 export const useAnnouncementSelectionStore = defineStore(
   'announcementSelection',
   () => {
-    const announcement = ref<
-      (AnnouncementFormValue & { id: string }) | undefined
-    >(undefined);
+    const announcement = ref<AnnouncementFormValue | undefined>(undefined);
 
     const setAnnouncement = (
-      data: IAnnouncement & {
+      data: Announcement & {
         announcement_resource: {
           resource_type: string;
           display_name: string;
@@ -26,7 +21,7 @@ export const useAnnouncementSelectionStore = defineStore(
         (r) => r.resource_type === 'LINK',
       );
       announcement.value = {
-        id: data.announcement_id,
+        announcement_id: data.announcement_id,
         title: data.title,
         description: data.description,
         published_on: data.published_on
@@ -47,7 +42,12 @@ export const useAnnouncementSelectionStore = defineStore(
     };
 
     const saveChanges = async (data: AnnouncementFormValue) => {
-      await ApiService.updateAnnouncement(announcement.value!.id, data);
+      if (announcement.value!.announcement_id) {
+        await ApiService.updateAnnouncement(
+          announcement.value!.announcement_id,
+          data,
+        );
+      }
     };
 
     return {

--- a/admin-frontend/src/types/announcements.ts
+++ b/admin-frontend/src/types/announcements.ts
@@ -92,7 +92,13 @@ export type AnnouncementFormValue = Pick<
   Announcement,
   'title' | 'description' | 'published_on' | 'expires_on' | 'status'
 > & {
+  announcement_id?: string;
   no_expiry?: boolean;
   linkUrl?: string;
   linkDisplayName?: string;
 };
+
+export enum AnnouncementFormMode {
+  CREATE = 'create',
+  EDIT = 'edit',
+}


### PR DESCRIPTION
# Description

Admin app - Add/Edit announcement - Save button is disabled until preview is activated.  Also fixed a bug that caused edited announcements to show up twice in the preview area.

Fixes # [GEO-869](https://finrms.atlassian.net/browse/GEO-869)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

updated existing unit tests

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have already been accepted and merged

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://pay-transparency-pr-656-frontend.apps.silver.devops.gov.bc.ca)
- [Admin Frontend](https://pay-transparency-pr-656-admin-frontend.apps.silver.devops.gov.bc.ca)
- [Backend external API console](https://pay-transparency-pr-656-backend-external.apps.silver.devops.gov.bc.ca/api/V1/docs)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/fin-pay-transparency/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/fin-pay-transparency/actions/workflows/merge.yml)