### PR TITLE
fix: GEO 1072 ensure newly added announcement is selectable

### DIFF
--- a/admin-frontend/src/components/AddAnnouncementPage.vue
+++ b/admin-frontend/src/components/AddAnnouncementPage.vue
@@ -14,10 +14,14 @@ import {
 } from '../types/announcements';
 import { useRouter } from 'vue-router';
 import AnnouncementForm from './announcements/AnnouncementForm.vue';
+import { useAnnouncementSelectionStore } from '../store/modules/announcementSelectionStore';
+import { useAnnouncementSearchStore } from '../store/modules/announcementSearchStore';
 import { NotificationService } from '../services/notificationService';
 import ApiService from '../services/apiService';
 
 const router = useRouter();
+const selectionStore = useAnnouncementSelectionStore();
+const announcementSearch = useAnnouncementSearchStore();
 
 const submit = async (data: AnnouncementFormValue) => {
   try {
@@ -25,6 +29,8 @@ const submit = async (data: AnnouncementFormValue) => {
     NotificationService.pushNotificationSuccess(
       'Announcement saved successfully',
     );
+    selectionStore.reset();
+    await announcementSearch.repeatSearch();
     router.push('/announcements');
   } catch (error) {
     console.error('Failed to save announcement', error);

--- a/backend/src/v1/prisma/schema.prisma
+++ b/backend/src/v1/prisma/schema.prisma
@@ -342,7 +342,6 @@ model announcement_resource {
   updated_by                                              String?                         @db.Uuid
   resource_type                                           String                          @db.VarChar(20)
   attachment_file_id                                      String?                         @db.Uuid
-  attachment_path                                         String?                         @db.VarChar(255)
   admin_user_announcement_resource_created_byToadmin_user admin_user?                     @relation("announcement_resource_created_byToadmin_user", fields: [created_by], references: [admin_user_id], onDelete: NoAction, onUpdate: NoAction, map: "announcement_resource_created_by_fk")
   announcement                                            announcement                    @relation(fields: [announcement_id], references: [announcement_id], onDelete: NoAction, onUpdate: NoAction, map: "announcement_resource_fk")
   announcement_resource_type                              announcement_resource_type      @relation(fields: [resource_type], references: [code], onDelete: NoAction, onUpdate: NoAction, map: "announcement_resource_type_fk")
@@ -365,7 +364,6 @@ model announcement_resource_history {
   resource_type                                                   String                     @db.VarChar(20)
   announcement_history_id                                         String                     @db.Uuid
   attachment_file_id                                              String?                    @db.Uuid
-  attachment_path                                                 String?                    @db.VarChar(255)
   announcement                                                    announcement               @relation(fields: [announcement_id], references: [announcement_id], onDelete: NoAction, onUpdate: NoAction, map: "announcement_resource_history_announcement_fk")
   announcement_history                                            announcement_history       @relation(fields: [announcement_history_id], references: [announcement_history_id], onDelete: NoAction, onUpdate: NoAction)
   announcement_resource                                           announcement_resource?     @relation(fields: [announcement_resource_id], references: [announcement_resource_id], onDelete: NoAction, onUpdate: NoAction, map: "announcement_resource_history_announcement_resource_fk")


### PR DESCRIPTION
# Description

Ensure announcement is selectable after add

Fixes # ([issue](https://finrms.atlassian.net/browse/GEO-1072))

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)


## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have already been accepted and merged


## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://pay-transparency-pr-698-frontend.apps.silver.devops.gov.bc.ca)
- [Admin Frontend](https://pay-transparency-pr-698-admin-frontend.apps.silver.devops.gov.bc.ca)
- [Backend external API console](https://pay-transparency-pr-698-backend-external.apps.silver.devops.gov.bc.ca/api/V1/docs)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/fin-pay-transparency/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/fin-pay-transparency/actions/workflows/merge.yml)