### PR TITLE
fix: GEO-1075 - admin app - renamed 'delete' action to 'archive'

### DIFF
--- a/admin-frontend/src/components/AnnouncementsPage.vue
+++ b/admin-frontend/src/components/AnnouncementsPage.vue
@@ -85,11 +85,11 @@
             <div class="mt-3 d-flex flex-column align-center">
               <v-btn
                 class="btn-secondary"
-                :disabled="!selectedAnnouncementIds.length || isDeleting"
-                :loading="isDeleting"
-                @click="deleteAnnouncements(selectedAnnouncementIds)"
-                prepend-icon="mdi-delete"
-                >Delete</v-btn
+                :disabled="!selectedAnnouncementIds.length || isArchiving"
+                :loading="isArchiving"
+                @click="archiveAnnouncements(selectedAnnouncementIds)"
+                prepend-icon="mdi-archive"
+                >Archive</v-btn
               >
               <small v-if="selectedAnnouncementIds.length">
                 {{ selectedAnnouncementIds.length }} selected
@@ -149,7 +149,7 @@ const confirmDialog = ref<typeof ConfirmationDialog>();
 const isAnnouncementDialogVisible = ref<boolean>(false);
 const isSelectedAnnouncementsHeaderChecked = ref<boolean>(false);
 const selectedAnnouncements = ref<object>({});
-const isDeleting = ref<boolean>(false);
+const isArchiving = ref<boolean>(false);
 const selectedAnnouncementIds = computed(() =>
   Object.entries(selectedAnnouncements.value)
     .filter(([_, value]) => value)
@@ -258,27 +258,27 @@ async function repeatSearch() {
   await announcementSearchStore.repeatSearch();
 }
 
-async function deleteAnnouncements(announcementIds: string[]) {
+async function archiveAnnouncements(announcementIds: string[]) {
   const isConfirmed = await confirmDialog.value?.open(
-    'Confirm Deletion',
-    `Are you sure you want to delete the selected announcement${announcementIds.length != 1 ? 's' : ''}?  This action cannot be undone.`,
+    'Confirm Archive',
+    `Are you sure you want to archive the selected announcement${announcementIds.length != 1 ? 's' : ''}?  This action cannot be undone.`,
     {
       titleBold: true,
       resolveText: `Confirm`,
     },
   );
   if (isConfirmed) {
-    isDeleting.value = true;
+    isArchiving.value = true;
     try {
       await ApiService.deleteAnnouncements(announcementIds);
       announcementSearchStore.repeatSearch();
       NotificationService.pushNotificationSuccess(
-        `Announcement${announcementIds.length != 1 ? 's' : ''} deleted successfully.`,
+        `Announcement${announcementIds.length != 1 ? 's' : ''} archived successfully.`,
         '',
       );
     } catch (e) {
     } finally {
-      isDeleting.value = false;
+      isArchiving.value = false;
     }
   }
 }

--- a/admin-frontend/src/components/__tests__/AnnouncementsPage.spec.ts
+++ b/admin-frontend/src/components/__tests__/AnnouncementsPage.spec.ts
@@ -215,8 +215,8 @@ describe('AnnouncementsPage', () => {
     });
   });
 
-  describe('deleteAnnouncement', async () => {
-    describe('confirm delete', () => {
+  describe('archiveAnnouncement', async () => {
+    describe('confirm archive', () => {
       it('delegates to the ApiService', async () => {
         const announcementIds = ['1', '2'];
         const repeatSearchSpy = vi.spyOn(
@@ -224,32 +224,32 @@ describe('AnnouncementsPage', () => {
           'repeatSearch',
         );
 
-        //mock the confirm delete dialog.
+        //mock the confirm dialog.
         //simulate the user clicking the 'confirm' button
         vi.spyOn(wrapper.vm.confirmDialog, 'open').mockResolvedValue(true);
 
-        const resp = await wrapper.vm.deleteAnnouncements(announcementIds);
+        const resp = await wrapper.vm.archiveAnnouncements(announcementIds);
         expect(mockDeleteAnnouncements).toHaveBeenCalledWith(announcementIds);
         expect(repeatSearchSpy).toHaveBeenCalledTimes(1);
-        expect(wrapper.vm.isDeleting).toBeFalsy();
+        expect(wrapper.vm.isArchiving).toBeFalsy();
       });
     });
-    describe('cancel delete', () => {
-      it("doesn't delete anything", async () => {
+    describe('cancel archive', () => {
+      it("doesn't archive anything", async () => {
         const announcementIds = ['1', '2'];
         const repeatSearchSpy = vi.spyOn(
           announcementSearchStore,
           'repeatSearch',
         );
 
-        //mock the confirm delete dialog.
+        //mock the confirm dialog.
         //simulate the user clicking the 'cancel' button
         vi.spyOn(wrapper.vm.confirmDialog, 'open').mockResolvedValue(false);
 
-        const resp = await wrapper.vm.deleteAnnouncements(announcementIds);
+        const resp = await wrapper.vm.archiveAnnouncements(announcementIds);
         expect(mockDeleteAnnouncements).toHaveBeenCalledTimes(0);
         expect(repeatSearchSpy).toHaveBeenCalledTimes(0);
-        expect(wrapper.vm.isDeleting).toBeFalsy();
+        expect(wrapper.vm.isArchiving).toBeFalsy();
       });
     });
   });

--- a/admin-frontend/src/components/announcements/AnnouncementActions.vue
+++ b/admin-frontend/src/components/announcements/AnnouncementActions.vue
@@ -30,11 +30,11 @@
           <v-btn
             class="text-red"
             variant="text"
-            prepend-icon="mdi-delete"
-            @click="deleteAnnouncement(announcement.announcement_id)"
-            :loading="isDeleting"
-            :disabled="isDeleting"
-            >Delete</v-btn
+            prepend-icon="mdi-archive"
+            @click="archiveAnnouncement(announcement.announcement_id)"
+            :loading="isArchiving"
+            :disabled="isArchiving"
+            >Archive</v-btn
           >
         </v-list-item>
       </v-list>
@@ -63,30 +63,30 @@ const { announcement } = defineProps<{
 
 const announcementSearchStore = useAnnouncementSearchStore();
 const confirmDialog = ref<typeof ConfirmationDialog>();
-const isDeleting = ref<boolean>(false);
+const isArchiving = ref<boolean>(false);
 const isUnpublishing = ref<boolean>(false);
 
-async function deleteAnnouncement(announcementId: string) {
+async function archiveAnnouncement(announcementId: string) {
   const isConfirmed = await confirmDialog.value?.open(
-    'Confirm Deletion',
-    `Are you sure you want to delete the selected announcement?  This action cannot be undone.`,
+    'Confirm Archive',
+    `Are you sure you want to archive the selected announcement?  This action cannot be undone.`,
     {
       titleBold: true,
       resolveText: `Confirm`,
     },
   );
   if (isConfirmed) {
-    isDeleting.value = true;
+    isArchiving.value = true;
     try {
       await ApiService.deleteAnnouncements([announcementId]);
       announcementSearchStore.repeatSearch();
       NotificationService.pushNotificationSuccess(
-        `Announcement deleted successfully.`,
+        `Announcement archived successfully.`,
         '',
       );
     } catch (e) {
     } finally {
-      isDeleting.value = false;
+      isArchiving.value = false;
     }
   }
 }

--- a/admin-frontend/src/components/announcements/__tests__/AnnouncementActions.spec.ts
+++ b/admin-frontend/src/components/announcements/__tests__/AnnouncementActions.spec.ts
@@ -72,36 +72,36 @@ describe('AnnouncementActions', () => {
     }
   });
 
-  describe('deleteAnnouncement', async () => {
-    describe('confirm delete', () => {
+  describe('archiveAnnouncement', async () => {
+    describe('confirm archive', () => {
       it('delegates to the ApiService', async () => {
         const announcementId = '1';
         const apiSpy = vi
           .spyOn(ApiService, 'deleteAnnouncements')
           .mockResolvedValue();
 
-        //mock the confirm delete dialog.
+        //mock the confirm dialog.
         //simulate the user clicking the 'confirm' button
         vi.spyOn(wrapper.vm.confirmDialog, 'open').mockResolvedValue(true);
 
-        await wrapper.vm.deleteAnnouncement(announcementId);
+        await wrapper.vm.archiveAnnouncement(announcementId);
 
         expect(apiSpy).toHaveBeenCalledWith([announcementId]);
       });
     });
 
-    describe('cancel delete', () => {
+    describe('cancel archive', () => {
       it('does nothing', async () => {
         const announcementId = '1';
         const apiSpy = vi
           .spyOn(ApiService, 'deleteAnnouncements')
           .mockResolvedValue();
 
-        //mock the confirm delete dialog.
+        //mock the confirm dialog.
         //simulate the user clicking the 'cancel' button
         vi.spyOn(wrapper.vm.confirmDialog, 'open').mockResolvedValue(false);
 
-        await wrapper.vm.deleteAnnouncement(announcementId);
+        await wrapper.vm.archiveAnnouncement(announcementId);
 
         expect(apiSpy).toHaveBeenCalledTimes(0);
       });


### PR DESCRIPTION
# Description

Fixes # [GEO-1075](https://finrms.atlassian.net/browse/GEO-1075)

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Updated unit tests

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have already been accepted and merged

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://pay-transparency-pr-699-frontend.apps.silver.devops.gov.bc.ca)
- [Admin Frontend](https://pay-transparency-pr-699-admin-frontend.apps.silver.devops.gov.bc.ca)
- [Backend external API console](https://pay-transparency-pr-699-backend-external.apps.silver.devops.gov.bc.ca/api/V1/docs)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/fin-pay-transparency/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/fin-pay-transparency/actions/workflows/merge.yml)