### PR TITLE
fix: geo 1086 implement display mode for file attachment on edit

### DIFF
--- a/admin-frontend/src/components/announcements/AnnouncementForm.vue
+++ b/admin-frontend/src/components/announcements/AnnouncementForm.vue
@@ -607,9 +607,10 @@ const handleSave = handleSubmit(async (values) => {
       return false;
     }
 
-    const publishDate = LocalDate.from(nativeJs(values.published_on));
-
-    if (publishDate.isBefore(LocalDate.now())) {
+    if (
+      values.published_on &&
+      LocalDate.from(nativeJs(values.published_on)).isBefore(LocalDate.now())
+    ) {
       setErrors({
         published_on:
           'Publish On date cannot be in the past. Please select a new date.',

--- a/admin-frontend/src/components/announcements/AnnouncementForm.vue
+++ b/admin-frontend/src/components/announcements/AnnouncementForm.vue
@@ -608,6 +608,7 @@ const handleSave = handleSubmit(async (values) => {
     }
 
     if (
+      announcement?.status !== 'PUBLISHED' &&
       values.published_on &&
       LocalDate.from(nativeJs(values.published_on)).isBefore(LocalDate.now())
     ) {

--- a/admin-frontend/src/components/announcements/AttachmentResource.vue
+++ b/admin-frontend/src/components/announcements/AttachmentResource.vue
@@ -1,0 +1,43 @@
+<template>
+  <div class="root">
+    <v-btn
+      variant="text"
+      color="primary"
+      append-icon="mdi-open-in-new"
+      @click="ApiService.downloadFile(id)"
+      >{{ name }}</v-btn
+    >
+    <v-btn
+      density="compact"
+      icon="mdi-pencil"
+      class="mr-2"
+      @click="emits('onEdit')"
+      aria-label="Edit file"
+    ></v-btn>
+    <v-btn
+      density="compact"
+      icon="mdi-delete-outline"
+      @click="emits('onDelete')"
+      aria-label="Delete file"
+    ></v-btn>
+  </div>
+</template>
+<script setup lang="ts">
+import { defineProps } from 'vue';
+import ApiService from '../../services/apiService';
+
+interface AttachmentResourceProps {
+  id: string;
+  name: string;
+}
+const { id, name } = defineProps<AttachmentResourceProps>();
+
+const emits = defineEmits(['onEdit', 'onDelete']);
+
+</script>
+<style scoped lang="scss">
+.root {
+  display: flex;
+  align-items: center;
+}
+</style>

--- a/admin-frontend/src/store/modules/announcementSelectionStore.ts
+++ b/admin-frontend/src/store/modules/announcementSelectionStore.ts
@@ -22,7 +22,7 @@ export const useAnnouncementSelectionStore = defineStore(
         (r) => r.resource_type === 'LINK',
       );
       const attachment = data.announcement_resource.find(
-        (r) => r.resource_type === 'ATTACHMENT',
+        (r) => r.resource_type === 'ATTACHMENT' && r.attachment_file_id,
       );
 
       announcement.value = {

--- a/backend/src/v1/routes/announcement-routes.ts
+++ b/backend/src/v1/routes/announcement-routes.ts
@@ -22,6 +22,7 @@ import {
   PatchAnnouncementsSchema,
   PatchAnnouncementsType,
 } from '../types/announcements';
+import { omit } from 'lodash';
 
 const router = Router();
 
@@ -124,7 +125,8 @@ router.put(
       // Create announcement
       const announcement = await updateAnnouncement(
         req.params.id,
-        data,
+        /* istanbul ignore next */
+        file ? data : omit(data, 'attachmentId'),
         user.admin_user_id,
       );
       return res.json(announcement);

--- a/backend/src/v1/services/announcements-service.spec.ts
+++ b/backend/src/v1/services/announcements-service.spec.ts
@@ -731,6 +731,42 @@ describe('AnnouncementsService', () => {
           }),
         );
       });
+
+      describe("and attachmentId is not provided in the input", () => {
+        it("should set attachment id to null", async () => {
+          const attachmentId = faker.string.uuid();
+          mockFindUniqueOrThrow.mockResolvedValue({
+            id: 'announcement-id',
+            announcement_resource: [
+              {
+                announcement_resource_id: attachmentId,
+                resource_type: 'ATTACHMENT',
+              },
+            ],
+          });
+          const announcementInput: AnnouncementDataType = {
+            title: faker.lorem.words(3),
+            description: faker.lorem.words(10),
+            expires_on: faker.date.recent().toISOString(),
+            published_on: faker.date.future().toISOString(),
+            status: 'PUBLISHED',
+          };
+          await updateAnnouncement(
+            'announcement-id',
+            announcementInput,
+            'user-id',
+          );
+          expect(mockHistoryCreate).toHaveBeenCalled();
+          expect(mockUpdateResource).toHaveBeenCalledWith({
+            where: { announcement_resource_id: attachmentId },
+            data: {
+              attachment_file_id: null,
+              updated_by: 'user-id',
+              update_date: expect.any(Date),
+            },
+          });
+        });
+      });
     });
 
     describe('without existing attachment resource', () => {

--- a/backend/src/v1/services/announcements-service.spec.ts
+++ b/backend/src/v1/services/announcements-service.spec.ts
@@ -8,6 +8,7 @@ import { UserInputError } from '../types/errors';
 import * as AnnouncementService from './announcements-service';
 import { utils } from './utils-service';
 import { LocalDateTime, ZonedDateTime, ZoneId } from '@js-joda/core';
+import { updateAnnouncement } from './announcements-service';
 
 const mockFindMany = jest.fn().mockResolvedValue([
   {

--- a/backend/src/v1/services/announcements-service.ts
+++ b/backend/src/v1/services/announcements-service.ts
@@ -350,11 +350,10 @@ export const updateAnnouncement = async (
       });
     }
 
+    const currentAttachment = announcementData?.announcement_resource.find(
+      (x) => x.resource_type === 'ATTACHMENT',
+    );
     if (input.attachmentId) {
-      const currentAttachment = announcementData?.announcement_resource.find(
-        (x) => x.resource_type === 'ATTACHMENT',
-      );
-
       if (currentAttachment) {
         await tx.announcement_resource.update({
           where: {
@@ -390,6 +389,17 @@ export const updateAnnouncement = async (
           },
         });
       }
+    } else if (currentAttachment && !input.attachmentId) {
+      await tx.announcement_resource.update({
+        where: {
+          announcement_resource_id: currentAttachment.announcement_resource_id,
+        },
+        data: {
+          attachment_file_id: null,
+          updated_by: currentUserId,
+          update_date: updateDate,
+        },
+      });
     }
 
     const data: Prisma.announcementUpdateInput = {

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -48,16 +48,6 @@ export default defineConfig({
       },
     },
     {
-      name: 'chromium',
-      use: {
-        ...devices['Desktop Chrome'],
-        baseURL: baseURL,
-        storageState: 'user.json',
-      },
-      dependencies: ['setup'],
-      teardown: 'teardown',
-    },
-    {
       name: 'Google Chrome',
       use: {
         ...devices['Desktop Chrome'],


### PR DESCRIPTION

# Description

Implement display mode for file attachment on announcement edit

Fixes # ([issue](https://finrms.atlassian.net/browse/GEO-1086))

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)


## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have already been accepted and merged


## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://pay-transparency-pr-710-frontend.apps.silver.devops.gov.bc.ca)
- [Admin Frontend](https://pay-transparency-pr-710-admin-frontend.apps.silver.devops.gov.bc.ca)
- [Backend external API console](https://pay-transparency-pr-710-backend-external.apps.silver.devops.gov.bc.ca/api/V1/docs)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/fin-pay-transparency/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/fin-pay-transparency/actions/workflows/merge.yml)