### PR TITLE
feat: GEO-1084 announcement resource link presentation

### DIFF
--- a/admin-frontend/src/components/announcements/AnnouncementForm.vue
+++ b/admin-frontend/src/components/announcements/AnnouncementForm.vue
@@ -283,6 +283,7 @@ import {
   AnnouncementFilterType,
   AnnouncementSortType,
   AnnouncementFormMode,
+  AnnouncementResourceType,
 } from '../../types/announcements';
 import { useField, useForm } from 'vee-validate';
 import * as zod from 'zod';
@@ -298,7 +299,7 @@ import ConfirmationDialog from '../util/ConfirmationDialog.vue';
 import { useRouter } from 'vue-router';
 import AnnouncementPager from './AnnouncementPager.vue';
 import ApiService from '../../services/apiService';
-import { v4 } from 'uuid'
+import { v4 } from 'uuid';
 
 type Props = {
   announcement: AnnouncementFormValue | null | undefined;
@@ -481,6 +482,7 @@ function buildAnnouncementToPreview() {
     previewAnnouncement.announcement_resource.push({
       display_name: linkDisplayName.value,
       resource_url: linkUrl.value,
+      resource_type: AnnouncementResourceType.LINK,
     });
   }
 
@@ -488,6 +490,7 @@ function buildAnnouncementToPreview() {
     previewAnnouncement.announcement_resource.push({
       display_name: fileDisplayName.value,
       announcement_resource_id: announcement?.file_resource_id,
+      resource_type: AnnouncementResourceType.ATTACHMENT,
     });
   }
   return previewAnnouncement;

--- a/admin-frontend/src/components/announcements/AnnouncementForm.vue
+++ b/admin-frontend/src/components/announcements/AnnouncementForm.vue
@@ -486,10 +486,10 @@ function buildAnnouncementToPreview() {
     });
   }
 
-  if (announcement?.file_resource_id && fileDisplayName.value) {
+  if (attachment.value && fileDisplayName.value) {
     previewAnnouncement.announcement_resource.push({
       display_name: fileDisplayName.value,
-      announcement_resource_id: announcement?.file_resource_id,
+      announcement_resource_file: attachment.value,
       resource_type: AnnouncementResourceType.ATTACHMENT,
     });
   }

--- a/admin-frontend/src/components/announcements/AnnouncementForm.vue
+++ b/admin-frontend/src/components/announcements/AnnouncementForm.vue
@@ -435,7 +435,7 @@ const handleCancel = async () => {
 /*
 Preview the current announcement alongside any other pre-existing (published)
 announcements.  The pre-existing announcements are fetched from the backend,
-and cached for quick subsequent access (because this function may be called 
+and cached for quick subsequent access (because this function may be called
 repeatedly).
 */
 async function preview() {
@@ -465,7 +465,7 @@ function closePreview() {
   announcementsToPreview.value = undefined;
 }
 
-/* 
+/*
 Create a new Announcement object using the current form values.
 The resulting Announcement object is principally used for preview
 its appearance, so some of the unnecessary attributes aren't populated
@@ -478,6 +478,8 @@ function buildAnnouncementToPreview() {
     description: announcementDescription.value,
     announcement_resource: [] as any[],
   };
+
+  //include resource with type LINK
   if (linkDisplayName.value && linkUrl.value) {
     previewAnnouncement.announcement_resource.push({
       display_name: linkDisplayName.value,
@@ -486,12 +488,25 @@ function buildAnnouncementToPreview() {
     });
   }
 
-  if (attachment.value && fileDisplayName.value) {
-    previewAnnouncement.announcement_resource.push({
+  //include resource with type ATTACHMENT
+  //we handle the attachment slightly differently depending on whether
+  //it is a pre-existing (already saved) file, or a not-yet-saved file.
+  if (
+    (attachment.value || announcement?.file_resource_id) &&
+    fileDisplayName.value
+  ) {
+    const resource: any = {
       display_name: fileDisplayName.value,
-      announcement_resource_file: attachment.value,
       resource_type: AnnouncementResourceType.ATTACHMENT,
-    });
+    };
+    //if there is a new, not-yet-saved attachment, include it in the
+    //preview in preference to the any pre-existing attachment
+    if (attachment.value) {
+      resource.announcement_resource_file = attachment.value;
+    } else if (announcement?.file_resource_id) {
+      resource.announcement_resource_id = announcement?.file_resource_id;
+    }
+    previewAnnouncement.announcement_resource.push(resource);
   }
   return previewAnnouncement;
 }
@@ -500,7 +515,7 @@ function buildAnnouncementToPreview() {
 Downloads from the backend a list of Announcements with status=PUBLISHED.
 Results are ordered by update date (most recently updated are first).
 Implementation note: The backend returns Announcements in "pages".  For
-simplicity here, this function assumes all the published announcements 
+simplicity here, this function assumes all the published announcements
 can be fetched in one large "page" (of 100).
 */
 async function getPublishedAnnouncements(): Promise<Announcement[]> {

--- a/admin-frontend/src/components/announcements/AnnouncementItem.vue
+++ b/admin-frontend/src/components/announcements/AnnouncementItem.vue
@@ -17,11 +17,7 @@
         >
         <a
           v-if="announcementResource.resource_type === 'ATTACHMENT'"
-          @click="
-            ApiService.downloadFile(
-              announcementResource.announcement_resource_id,
-            )
-          "
+          @click="downloadAnnouncementResource(announcementResource)"
           >{{ announcementResource.display_name }}</a
         >
       </div>
@@ -35,16 +31,31 @@ export default {
 </script>
 
 <script setup lang="ts">
-import { Announcement } from '../../types/announcements';
+import { Announcement, AnnouncementResource } from '../../types/announcements';
 import { sanitizeUrl } from '@braintree/sanitize-url';
 import ApiService from '../../services/apiService';
+import { saveAs } from 'file-saver';
 
 const props = defineProps<{
   announcement: Announcement;
 }>();
-</script>
-<style scoped lang="scss">
-.download-link {
-  color: #255a90;
+
+async function downloadAnnouncementResource(
+  announcementResource: AnnouncementResource,
+) {
+  if (announcementResource.announcement_resource_id) {
+    await ApiService.downloadFile(
+      announcementResource.announcement_resource_id,
+    );
+  } else if (announcementResource.announcement_resource_file) {
+    //When a resource with type ATTACHMENT hasn't yet been uploaded to the
+    //backend, it won't yet have an announcement_resource_id, so we
+    //cannot offer a download in the standard way.  In this case,
+    //check if the resource has the announcement_resource_file property, and
+    //if so, download that. The announcement_resource_file property is
+    //not known to the backend, but it is useful in the admin-frontend when
+    //displaying not-yet-saved resources.
+    await saveAs(announcementResource.announcement_resource_file);
+  }
 }
-</style>
+</script>

--- a/admin-frontend/src/components/announcements/AnnouncementItem.vue
+++ b/admin-frontend/src/components/announcements/AnnouncementItem.vue
@@ -2,27 +2,33 @@
   <div>
     <h3 class="mb-1">{{ announcement.title }}</h3>
     <p>{{ announcement.description }}</p>
-    <div
-      v-for="(announcementResource, i) in announcement.announcement_resource"
-      :key="i"
-      class="px-0 mt-2"
-    >
-      <a
-        v-if="announcementResource.resource_type === 'LINK'"
-        :href="sanitizeUrl(announcementResource.resource_url)"
-        target="_blank"
-        rel="noopener"
-        >{{ announcementResource.display_name }}</a
+    <div class="mt-2">
+      <div
+        v-for="(announcementResource, i) in announcement.announcement_resource"
+        :key="i"
+        class="px-0"
       >
-      <v-btn
-        v-else
-        class="download-link"
-        @click="
-          ApiService.downloadFile(announcementResource.announcement_resource_id)
-        "
-        variant="text"
-        >{{ announcementResource.display_name }}</v-btn
-      >
+        <a
+          v-if="announcementResource.resource_type === 'LINK'"
+          class="btn-link"
+          :href="sanitizeUrl(announcementResource.resource_url)"
+          target="_blank"
+          rel="noopener"
+          variant="text"
+          >{{ announcementResource.display_name }}</a
+        >
+        <a
+          v-if="announcementResource.resource_type === 'ATTACHMENT'"
+          class="btn-link"
+          @click="
+            ApiService.downloadFile(
+              announcementResource.announcement_resource_id,
+            )
+          "
+          variant="text"
+          >{{ announcementResource.display_name }}</a
+        >
+      </div>
     </div>
   </div>
 </template>

--- a/admin-frontend/src/components/announcements/AnnouncementItem.vue
+++ b/admin-frontend/src/components/announcements/AnnouncementItem.vue
@@ -10,22 +10,18 @@
       >
         <a
           v-if="announcementResource.resource_type === 'LINK'"
-          class="btn-link"
           :href="sanitizeUrl(announcementResource.resource_url)"
           target="_blank"
           rel="noopener"
-          variant="text"
           >{{ announcementResource.display_name }}</a
         >
         <a
           v-if="announcementResource.resource_type === 'ATTACHMENT'"
-          class="btn-link"
           @click="
             ApiService.downloadFile(
               announcementResource.announcement_resource_id,
             )
           "
-          variant="text"
           >{{ announcementResource.display_name }}</a
         >
       </div>

--- a/admin-frontend/src/components/announcements/__tests__/AnnouncementForm.spec.ts
+++ b/admin-frontend/src/components/announcements/__tests__/AnnouncementForm.spec.ts
@@ -1,6 +1,7 @@
 import { createTestingPinia } from '@pinia/testing';
 import { fireEvent, render, screen, waitFor } from '@testing-library/vue';
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { flushPromises, mount } from '@vue/test-utils';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { createVuetify } from 'vuetify';
 import * as components from 'vuetify/components';
 import * as directives from 'vuetify/directives';
@@ -39,7 +40,7 @@ const fillTitleAndDesc = async () => {
   await fireEvent.update(description, 'Test Description');
 };
 
-describe('AnnouncementForm', () => {
+describe('AnnouncementForm - Vue Testing Library tests', () => {
   afterEach(() => {
     vi.clearAllMocks();
   });
@@ -84,6 +85,65 @@ describe('AnnouncementForm', () => {
       expect(
         screen.queryByText('Preview Announcement'),
       ).not.toBeInTheDocument();
+    });
+  });
+});
+
+describe('AnnouncementItem - Vue Test Utils tests', () => {
+  let wrapper;
+  let pinia;
+
+  const initWrapper = async (options: any = {}) => {
+    const vuetify = createVuetify({
+      components,
+      directives,
+    });
+
+    pinia = createTestingPinia({
+      initialState: {},
+    });
+    wrapper = mount(AnnouncementForm, {
+      global: {
+        plugins: [vuetify, pinia],
+      },
+    });
+
+    //wait for the async component to load
+    await flushPromises();
+  };
+
+  beforeEach(async () => {
+    await initWrapper();
+  });
+
+  afterEach(() => {
+    if (wrapper) {
+      vi.clearAllMocks();
+      wrapper.unmount();
+    }
+  });
+
+  describe('buildAnnouncementToPreview', () => {
+    describe('when link and attachment details are provided', () => {
+      it('builds an announcement with resources', async () => {
+        wrapper.vm.announcementTitle = 'title';
+        wrapper.vm.announcementDescription = 'desc';
+        wrapper.vm.linkDisplayName = 'link name';
+        wrapper.vm.linkUrl = 'url';
+        wrapper.vm.attachment = 'attachment';
+        wrapper.vm.fileDisplayName = 'file display name';
+        const announcement = wrapper.vm.buildAnnouncementToPreview();
+        expect(
+          announcement.announcement_resource.find(
+            (r) => r.resource_type == 'LINK',
+          ),
+        ).toBeTruthy();
+        expect(
+          announcement.announcement_resource.find(
+            (r) => r.resource_type == 'ATTACHMENT',
+          ),
+        ).toBeTruthy();
+      });
     });
   });
 });

--- a/admin-frontend/src/components/announcements/__tests__/AnnouncementForm.spec.ts
+++ b/admin-frontend/src/components/announcements/__tests__/AnnouncementForm.spec.ts
@@ -11,11 +11,15 @@ const pinia = createTestingPinia();
 const vuetify = createVuetify({ components, directives });
 
 const mockGetAnnouncements = vi.fn().mockResolvedValue({ items: [] });
+const mockClamavScan = vi.fn();
 
 vi.mock('../../../services/apiService', () => ({
   default: {
     getAnnouncements: (...args) => {
       return mockGetAnnouncements(...args);
+    },
+    clamavScanFile: (...args) => {
+      return mockClamavScan;
     },
   },
 }));
@@ -63,6 +67,12 @@ describe('AnnouncementForm', () => {
     await waitFor(() => {
       expect(screen.queryByText('Preview Announcement')).toBeInTheDocument();
     });
+
+    //Fill in the link details
+    const linkDisplayName = screen.getByLabelText('Display Link As');
+    const linkUrl = screen.getByLabelText('Link URL');
+    await fireEvent.update(linkDisplayName, 'MockLinkName');
+    await fireEvent.update(linkUrl, 'MockUrl');
 
     const closePreviewButton = screen.getByRole('button', {
       name: 'Close preview',

--- a/admin-frontend/src/components/announcements/__tests__/AnnouncementItem.spec.ts
+++ b/admin-frontend/src/components/announcements/__tests__/AnnouncementItem.spec.ts
@@ -1,0 +1,106 @@
+import { createTestingPinia } from '@pinia/testing';
+import { flushPromises, mount } from '@vue/test-utils';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createVuetify } from 'vuetify';
+import * as components from 'vuetify/components';
+import * as directives from 'vuetify/directives';
+import { Announcement } from '../../../types/announcements';
+import { default as AnnouncementItem } from '../AnnouncementItem.vue';
+
+const mockDraftAnnouncement: Announcement = {
+  announcement_id: '24b9455e-154b-46ce-91c7-5ec4474ad6fd',
+  title: 'Eum benigne',
+  description: 'Consectetur adstringo calculus talis',
+  created_date: '2024-08-06T18:56:35.825Z',
+  updated_date: '2024-08-06T18:56:35.825Z',
+  created_by: '7e53edd6-f50f-4002-be1a-06dc506c138a',
+  updated_by: '7e53edd6-f50f-4002-be1a-06dc506c138a',
+  published_on: '2024-07-30T18:56:35.825Z',
+  expires_on: '2024-10-29T18:56:35.825Z',
+  status: 'DRAFT',
+  announcement_resource: [],
+};
+
+// Mock the ResizeObserver
+const ResizeObserverMock = vi.fn(() => ({
+  observe: vi.fn(),
+  unobserve: vi.fn(),
+  disconnect: vi.fn(),
+}));
+
+const mockDownloadFile = vi.fn();
+const mockSaveAs = vi.fn();
+
+vi.mock('../../../services/apiService', () => ({
+  default: {
+    downloadFile: (...args) => mockDownloadFile(...args),
+  },
+}));
+vi.mock('file-saver', () => ({
+  saveAs: (...args) => mockSaveAs(...args),
+}));
+
+// Stub blobal objects needed for testing
+vi.stubGlobal('ResizeObserver', ResizeObserverMock);
+vi.stubGlobal('URL', { createObjectURL: vi.fn() });
+
+describe('AnnouncementItem', () => {
+  let wrapper;
+  let pinia;
+
+  const initWrapper = async (options: any = {}) => {
+    const vuetify = createVuetify({
+      components,
+      directives,
+    });
+
+    pinia = createTestingPinia({
+      initialState: {},
+    });
+    wrapper = mount(AnnouncementItem, {
+      props: {
+        announcement: mockDraftAnnouncement,
+      },
+      global: {
+        plugins: [vuetify, pinia],
+      },
+    });
+
+    //wait for the async component to load
+    await flushPromises();
+  };
+
+  beforeEach(async () => {
+    await initWrapper();
+  });
+
+  afterEach(() => {
+    if (wrapper) {
+      vi.clearAllMocks();
+      wrapper.unmount();
+    }
+  });
+
+  describe('downloadAnnouncementResource', () => {
+    describe('when the resource has an announcement_resource_id', () => {
+      it('downloads the resource from the backend', async () => {
+        const mockAnnouncementResource = {
+          announcement_resource_id: '123',
+        };
+        await wrapper.vm.downloadAnnouncementResource(mockAnnouncementResource);
+        expect(mockDownloadFile).toHaveBeenCalled();
+        expect(mockSaveAs).not.toHaveBeenCalled();
+      });
+    });
+    describe("when the resource doesn't have an announcement_resource_id, but it does have an announcement_resource_file", () => {
+      it('downloads the resource from the frontend', async () => {
+        const mockAnnouncementResource = {
+          announcement_resource_file: 'mock file',
+        };
+        await wrapper.vm.downloadAnnouncementResource(mockAnnouncementResource);
+        expect(mockDownloadFile).not.toHaveBeenCalled();
+        expect(mockSaveAs).toHaveBeenCalled();
+      });
+    });
+  });
+});

--- a/admin-frontend/src/types/announcements.ts
+++ b/admin-frontend/src/types/announcements.ts
@@ -23,7 +23,11 @@ export type AnnouncementResource = {
   update_date: string;
   updated_by: string;
 };
-export type AnnouncementResourceType = 'LINK' | 'ATTACHMENT';
+
+export enum AnnouncementResourceType {
+  LINK = 'LINK',
+  ATTACHMENT = 'ATTACHMENT',
+}
 
 export interface IAnnouncementSearchResult {
   items: Announcement[];

--- a/admin-frontend/src/types/announcements.ts
+++ b/admin-frontend/src/types/announcements.ts
@@ -22,6 +22,12 @@ export type AnnouncementResource = {
   resource_url: string;
   update_date: string;
   updated_by: string;
+  //This property isn't supported on the backend, but is used in the frontend
+  //to support AnnouncementResources in which the file hasn't yet been uploaded
+  //to the backend.  In this case, the not-yet-uploaded file is saved directly
+  //to the announcement_resource_file property, and components
+  //that need to present a download link do so from the file saved here.
+  announcement_resource_file?: File;
 };
 
 export enum AnnouncementResourceType {

--- a/frontend/src/components/announcements/AnnouncementItem.vue
+++ b/frontend/src/components/announcements/AnnouncementItem.vue
@@ -2,27 +2,29 @@
   <div>
     <h3 class="mb-1">{{ announcement.title }}</h3>
     <p>{{ announcement.description }}</p>
-    <div
-      v-for="(announcementResource, i) in announcement.announcement_resource"
-      :key="i"
-      class="px-0 mt-2"
-    >
-      <a
-        :href="sanitizeUrl(announcementResource.resource_url)"
-        target="_blank"
-        rel="noopener"
-        v-if="announcementResource.resource_type === 'LINK'"
-        >{{ announcementResource.display_name }}</a
+    <div class="mt-2">
+      <div
+        v-for="(announcementResource, i) in announcement.announcement_resource"
+        :key="i"
+        class="px-0"
       >
-      <v-btn
-        variant="text"
-        class="download-link"
-        @click="
-          ApiService.downloadFile(announcementResource.announcement_resource_id)
-        "
-        v-else
-        >{{ announcementResource.display_name }}</v-btn
-      >
+        <a
+          v-if="announcementResource.resource_type === 'LINK'"
+          :href="sanitizeUrl(announcementResource.resource_url)"
+          target="_blank"
+          rel="noopener"
+          >{{ announcementResource.display_name }}</a
+        >
+        <a
+          v-if="announcementResource.resource_type === 'ATTACHMENT'"
+          @click="
+            ApiService.downloadFile(
+              announcementResource.announcement_resource_id,
+            )
+          "
+          >{{ announcementResource.display_name }}</a
+        >
+      </div>
     </div>
   </div>
 </template>

--- a/frontend/src/components/announcements/AnnouncementItem.vue
+++ b/frontend/src/components/announcements/AnnouncementItem.vue
@@ -17,11 +17,7 @@
         >
         <a
           v-if="announcementResource.resource_type === 'ATTACHMENT'"
-          @click="
-            ApiService.downloadFile(
-              announcementResource.announcement_resource_id,
-            )
-          "
+          @click="downloadAnnouncementResource(announcementResource)"
           >{{ announcementResource.display_name }}</a
         >
       </div>
@@ -35,17 +31,17 @@ export default {
 </script>
 
 <script setup lang="ts">
-import { Announcement } from '../../types/announcements';
+import { Announcement, AnnouncementResource } from '../../types/announcements';
 import { sanitizeUrl } from '@braintree/sanitize-url';
 import ApiService from '../../common/apiService';
 
 const props = defineProps<{
   announcement: Announcement;
 }>();
-</script>
-<style scoped lang="scss">
-.download-link {
-  padding-left: 0;
-  color: #255a90;
+
+async function downloadAnnouncementResource(
+  announcementResource: AnnouncementResource,
+) {
+  await ApiService.downloadFile(announcementResource.announcement_resource_id);
 }
-</style>
+</script>

--- a/frontend/src/components/announcements/__tests__/AnnouncementItem.spec.ts
+++ b/frontend/src/components/announcements/__tests__/AnnouncementItem.spec.ts
@@ -1,0 +1,93 @@
+import { createTestingPinia } from '@pinia/testing';
+import { flushPromises, mount } from '@vue/test-utils';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createVuetify } from 'vuetify';
+import * as components from 'vuetify/components';
+import * as directives from 'vuetify/directives';
+import { Announcement } from '../../../types/announcements';
+import { default as AnnouncementItem } from '../AnnouncementItem.vue';
+
+const mockDraftAnnouncement: Announcement = {
+  announcement_id: '24b9455e-154b-46ce-91c7-5ec4474ad6fd',
+  title: 'Eum benigne',
+  description: 'Consectetur adstringo calculus talis',
+  created_date: '2024-08-06T18:56:35.825Z',
+  updated_date: '2024-08-06T18:56:35.825Z',
+  created_by: '7e53edd6-f50f-4002-be1a-06dc506c138a',
+  updated_by: '7e53edd6-f50f-4002-be1a-06dc506c138a',
+  published_on: '2024-07-30T18:56:35.825Z',
+  expires_on: '2024-10-29T18:56:35.825Z',
+  status: 'DRAFT',
+  announcement_resource: [],
+};
+
+// Mock the ResizeObserver
+const ResizeObserverMock = vi.fn(() => ({
+  observe: vi.fn(),
+  unobserve: vi.fn(),
+  disconnect: vi.fn(),
+}));
+
+const mockDownloadFile = vi.fn();
+const mockSaveAs = vi.fn();
+
+vi.mock('../../../common/apiService', () => ({
+  default: {
+    downloadFile: (...args) => mockDownloadFile(...args),
+  },
+}));
+
+// Stub blobal objects needed for testing
+vi.stubGlobal('ResizeObserver', ResizeObserverMock);
+vi.stubGlobal('URL', { createObjectURL: vi.fn() });
+
+describe('AnnouncementItem', () => {
+  let wrapper;
+  let pinia;
+
+  const initWrapper = async (options: any = {}) => {
+    const vuetify = createVuetify({
+      components,
+      directives,
+    });
+
+    pinia = createTestingPinia({
+      initialState: {},
+    });
+    wrapper = mount(AnnouncementItem, {
+      props: {
+        announcement: mockDraftAnnouncement,
+      },
+      global: {
+        plugins: [vuetify, pinia],
+      },
+    });
+
+    //wait for the async component to load
+    await flushPromises();
+  };
+
+  beforeEach(async () => {
+    await initWrapper();
+  });
+
+  afterEach(() => {
+    if (wrapper) {
+      vi.clearAllMocks();
+      wrapper.unmount();
+    }
+  });
+
+  describe('downloadAnnouncementResource', () => {
+    describe('when the resource has an announcement_resource_id', () => {
+      it('downloads the resource from the backend', async () => {
+        const mockAnnouncementResource = {
+          announcement_resource_id: '123',
+        };
+        await wrapper.vm.downloadAnnouncementResource(mockAnnouncementResource);
+        expect(mockDownloadFile).toHaveBeenCalled();
+        expect(mockSaveAs).not.toHaveBeenCalled();
+      });
+    });
+  });
+});


### PR DESCRIPTION
# Description

Improved the presentation of resource ATTACHMENT links within admin _announcement preview_ and within updates shown on the public site _dashboard_.  ATTACHMENT resources are now presented the same as LINK resources.

Fixes # [GEO-1084](https://finrms.atlassian.net/browse/GEO-1084)

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

existing tests

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have already been accepted and merged


---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://pay-transparency-pr-711-frontend.apps.silver.devops.gov.bc.ca)
- [Admin Frontend](https://pay-transparency-pr-711-admin-frontend.apps.silver.devops.gov.bc.ca)
- [Backend external API console](https://pay-transparency-pr-711-backend-external.apps.silver.devops.gov.bc.ca/api/V1/docs)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/fin-pay-transparency/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/fin-pay-transparency/actions/workflows/merge.yml)