### PR TITLE
fix: GEO-1096 - admin - display announcement dates in local timezone

### DIFF
--- a/admin-frontend/src/components/AnnouncementsPage.vue
+++ b/admin-frontend/src/components/AnnouncementsPage.vue
@@ -41,23 +41,23 @@
       "
       @update:options="updateSearch"
     >
-      <template v-slot:header.selection="{ column }">
+      <template #header.selection="{ column }">
         <v-checkbox
-          class="checkbox-no-details"
           v-model="isSelectedAnnouncementsHeaderChecked"
+          class="checkbox-no-details"
           @click="
             toggleSelectAllAnnouncements(!isSelectedAnnouncementsHeaderChecked)
           "
         ></v-checkbox>
       </template>
-      <template v-slot:item.selection="{ item }">
+      <template #item.selection="{ item }">
         <v-checkbox
-          class="checkbox-no-details"
           v-model="selectedAnnouncements[item.announcement_id]"
+          class="checkbox-no-details"
         >
         </v-checkbox>
       </template>
-      <template v-slot:item.title="{ item }">
+      <template #item.title="{ item }">
         <v-btn
           variant="text"
           class="btn-link no-min-width"
@@ -67,19 +67,31 @@
           {{ item.title }}
         </v-btn>
       </template>
-      <template v-slot:item.published_on="{ item }">
-        {{ item.published_on ? formatDate(item.published_on) : '-' }}
+      <template #item.published_on="{ item }">
+        <div v-if="item.published_on">
+          <div>{{ formatIsoDateTimeAsLocalDate(item.published_on) }}</div>
+          <small class="text-grey">{{
+            formatIsoDateTimeAsLocalTime(item.published_on)
+          }}</small>
+        </div>
+        <div v-else>-</div>
       </template>
-      <template v-slot:item.expires_on="{ item }">
-        {{ item.expires_on ? formatDate(item.expires_on) : '-' }}
+      <template #item.expires_on="{ item }">
+        <div v-if="item.expires_on">
+          <div>{{ formatIsoDateTimeAsLocalDate(item.expires_on) }}</div>
+          <small class="text-grey">{{
+            formatIsoDateTimeAsLocalTime(item.expires_on)
+          }}</small>
+        </div>
+        <div v-else>-</div>
       </template>
-      <template v-slot:item.status="{ item }">
+      <template #item.status="{ item }">
         <AnnouncementStatusChip :status="item.status"></AnnouncementStatusChip>
       </template>
-      <template v-slot:item.actions="{ item }">
+      <template #item.actions="{ item }">
         <AnnouncementActions :announcement="item"></AnnouncementActions>
       </template>
-      <template v-slot:footer.prepend="">
+      <template #footer.prepend="">
         <v-row class="d-flex justify-start">
           <v-col class="d-flex justify-start">
             <div class="mt-3 d-flex flex-column align-center">
@@ -87,8 +99,8 @@
                 class="btn-secondary"
                 :disabled="!selectedAnnouncementIds.length || isArchiving"
                 :loading="isArchiving"
-                @click="archiveAnnouncements(selectedAnnouncementIds)"
                 prepend-icon="mdi-archive"
+                @click="archiveAnnouncements(selectedAnnouncementIds)"
                 >Archive</v-btn
               >
               <small v-if="selectedAnnouncementIds.length">
@@ -134,7 +146,10 @@ import AnnouncementSearchFilters from './announcements/AnnouncementSearchFilters
 import AnnouncementStatusChip from './announcements/AnnouncementStatusChip.vue';
 import AnnouncementActions from './announcements/AnnouncementActions.vue';
 import { useAnnouncementSearchStore } from '../store/modules/announcementSearchStore';
-import { formatDate } from '../utils/date';
+import {
+  formatIsoDateTimeAsLocalDate,
+  formatIsoDateTimeAsLocalTime,
+} from '../utils/date';
 import { AnnouncementKeys } from '../types/announcements';
 import ApiService from '../services/apiService';
 import ConfirmationDialog from './util/ConfirmationDialog.vue';

--- a/admin-frontend/src/utils/__tests__/date.spec.ts
+++ b/admin-frontend/src/utils/__tests__/date.spec.ts
@@ -1,0 +1,69 @@
+import { DateTimeFormatter, ZonedDateTime, ZoneId } from '@js-joda/core';
+import { Locale } from '@js-joda/locale_en';
+import { describe, expect, it } from 'vitest';
+import {
+  formatDate,
+  formatIsoDateTimeAsLocalDate,
+  formatIsoDateTimeAsLocalTime,
+} from '../date';
+
+describe('formatDate', () => {
+  describe('given a datetime string in ISO 8601 format and UTC', () => {
+    it('converts into a string in the local timezone', () => {
+      const inDatetimeStr = '2024-09-05T18:15:00.000Z';
+      const inFormatter = DateTimeFormatter.ISO_DATE_TIME;
+      const outFormatter = DateTimeFormatter.ISO_INSTANT;
+
+      const expectedDate = ZonedDateTime.parse(
+        inDatetimeStr,
+        inFormatter,
+      ).withZoneSameInstant(ZoneId.systemDefault());
+
+      const outDatetimeStr = formatDate(
+        inDatetimeStr,
+        inFormatter,
+        outFormatter,
+      );
+
+      expect(outDatetimeStr).toBe(outFormatter.format(expectedDate));
+    });
+  });
+});
+
+describe('formatIsoDateTimeAsLocalDate', () => {
+  it('returns a date string in the expected format', () => {
+    const inDatetimeStr = '2024-09-05T18:15:00.000Z';
+    const inFormatter = DateTimeFormatter.ISO_DATE_TIME;
+    const outFormatter = DateTimeFormatter.ofPattern('MMM d, yyyy').withLocale(
+      Locale.CANADA,
+    );
+
+    const expectedDate = ZonedDateTime.parse(
+      inDatetimeStr,
+      inFormatter,
+    ).withZoneSameInstant(ZoneId.systemDefault());
+
+    const outDatetimeStr = formatIsoDateTimeAsLocalDate(inDatetimeStr);
+
+    expect(outDatetimeStr).toBe(outFormatter.format(expectedDate));
+  });
+});
+
+describe('formatIsoDateTimeAsLocalTime', () => {
+  it('returns a time string in the expected format', () => {
+    const inDatetimeStr = '2024-09-05T18:15:00.000Z';
+    const inFormatter = DateTimeFormatter.ISO_DATE_TIME;
+    const outFormatter = DateTimeFormatter.ofPattern('h:mm a').withLocale(
+      Locale.CANADA,
+    );
+
+    const expectedDate = ZonedDateTime.parse(
+      inDatetimeStr,
+      inFormatter,
+    ).withZoneSameInstant(ZoneId.systemDefault());
+
+    const outDatetimeStr = formatIsoDateTimeAsLocalTime(inDatetimeStr);
+
+    expect(outDatetimeStr).toBe(outFormatter.format(expectedDate));
+  });
+});

--- a/admin-frontend/src/utils/date.ts
+++ b/admin-frontend/src/utils/date.ts
@@ -1,20 +1,52 @@
-import { DateTimeFormatter, LocalDate } from '@js-joda/core';
+import { DateTimeFormatter, ZonedDateTime, ZoneId } from '@js-joda/core';
 import { Locale } from '@js-joda/locale_en';
 
-const DEFAULT_DISPLAY_FORMAT = DateTimeFormatter.ofPattern(
-  'MMM dd, yyyy',
+const DEFAULT_DATE_FORMAT = DateTimeFormatter.ofPattern(
+  'MMM d, yyyy',
 ).withLocale(Locale.CANADA);
 
+const DEFAULT_TIME_FORMAT = DateTimeFormatter.ofPattern('h:mm a').withLocale(
+  Locale.CANADA,
+);
+
 /*
-Converts a date/time string of one format into another format.
+Converts a datetime string of one format into another format.
+Always converts the timezone of the input into the local timezone.
 The incoming and outgoing formats can be specified with Joda
-DateTimeFormatter objects passed as parameters.
+DateTimeFormatter objects passed as parameters. By default, assumes the 
+incoming datetime string is in ISO 8601 format.
 */
 export function formatDate(
   inDateStr: string,
   inFormatter = DateTimeFormatter.ISO_DATE_TIME,
-  outFormatter = DEFAULT_DISPLAY_FORMAT,
+  outFormatter = DEFAULT_DATE_FORMAT,
 ) {
-  const jodaLocalDate = LocalDate.parse(inDateStr, inFormatter);
-  return outFormatter.format(jodaLocalDate);
+  const date = ZonedDateTime.parse(inDateStr, inFormatter);
+  const localTz = ZoneId.systemDefault();
+  const dateInLocalTz = date.withZoneSameInstant(localTz);
+  return outFormatter.format(dateInLocalTz);
+}
+
+/*
+Converts an ISO 8601 datetime string into a human-friendly date string 
+in the local tz (e.g. "Sep. 5, 2024")
+*/
+export function formatIsoDateTimeAsLocalDate(inDateStr: string) {
+  return formatDate(
+    inDateStr,
+    DateTimeFormatter.ISO_DATE_TIME,
+    DEFAULT_DATE_FORMAT,
+  );
+}
+
+/*
+Converts an ISO 8601 datetime string into a human-friendly time string 
+in the local tz (e.g. "9:45 a.m.")
+*/
+export function formatIsoDateTimeAsLocalTime(inDateStr: string) {
+  return formatDate(
+    inDateStr,
+    DateTimeFormatter.ISO_DATE_TIME,
+    DEFAULT_TIME_FORMAT,
+  );
 }

--- a/backend/db/migrations/V1.0.38__update_built_in_announcement.sql
+++ b/backend/db/migrations/V1.0.38__update_built_in_announcement.sql
@@ -1,5 +1,5 @@
 SET search_path TO pay_transparency;
 
 -- add a 'published_on' date to the built-in announcement
-update announcement set published_on = LOCALTIMESTAMP AT TIME ZONE 'UTC-7' 
+update announcement set published_on = LOCALTIMESTAMP AT TIME ZONE 'UTC' 
 where published_on is null and title = 'Guidance for preparing reports';

--- a/backend/db/migrations/V1.0.38__update_built_in_announcement.sql
+++ b/backend/db/migrations/V1.0.38__update_built_in_announcement.sql
@@ -1,5 +1,5 @@
 SET search_path TO pay_transparency;
 
 -- add a 'published_on' date to the built-in announcement
-update announcement set published_on = LOCALTIMESTAMP AT TIME ZONE 'UTC' 
+update announcement set published_on = LOCALTIMESTAMP AT TIME ZONE 'UTC-7' 
 where published_on is null and title = 'Guidance for preparing reports';

--- a/backend/db/migrations/V1.0.39__update_built_in_announcement.sql
+++ b/backend/db/migrations/V1.0.39__update_built_in_announcement.sql
@@ -1,0 +1,7 @@
+SET search_path TO pay_transparency;
+
+-- fix the 'published_on' date of the "build in" announcement that was incorrectly
+-- set in V1.0.38 to a time in the PDT timezone.  Add 7 hours to convert that
+-- time into the UTC timezone.
+update announcement set published_on = published_on + interval '7 hours' 
+where title = 'Guidance for preparing reports';


### PR DESCRIPTION
# Description

Admin announcements page: Updated the display of "Publish on" and "Expires on" dates to appear in the local timezone.  Also added the time which now appears below the dates.

Fixes # [GEO-1096](https://finrms.atlassian.net/browse/GEO-1096)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

New unit tests

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have already been accepted and merged

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://pay-transparency-pr-714-frontend.apps.silver.devops.gov.bc.ca)
- [Admin Frontend](https://pay-transparency-pr-714-admin-frontend.apps.silver.devops.gov.bc.ca)
- [Backend external API console](https://pay-transparency-pr-714-backend-external.apps.silver.devops.gov.bc.ca/api/V1/docs)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/fin-pay-transparency/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/fin-pay-transparency/actions/workflows/merge.yml)