### PR TITLE
feat: GEO-1095 - admin announcement preview always visible

### DIFF
--- a/admin-frontend/src/components/__tests__/AddAnnouncementPage.spec.ts
+++ b/admin-frontend/src/components/__tests__/AddAnnouncementPage.spec.ts
@@ -1,13 +1,13 @@
-import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { DateTimeFormatter, LocalDate } from '@js-joda/core';
+import { Locale } from '@js-joda/locale_en';
 import { createTestingPinia } from '@pinia/testing';
-import { render, screen, fireEvent, waitFor } from '@testing-library/vue';
 import { userEvent } from '@testing-library/user-event';
+import { fireEvent, render, screen, waitFor } from '@testing-library/vue';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { createVuetify } from 'vuetify';
 import * as components from 'vuetify/components';
 import * as directives from 'vuetify/directives';
 import AddAnnouncementPage from '../AddAnnouncementPage.vue';
-import { DateTimeFormatter, LocalDate } from '@js-joda/core';
-import { Locale } from '@js-joda/locale_en';
 
 global.ResizeObserver = require('resize-observer-polyfill');
 const pinia = createTestingPinia();
@@ -22,12 +22,15 @@ const wrappedRender = async () => {
 };
 
 const mockAddAnnouncement = vi.fn();
+const mockGetAnnouncement = vi.fn();
 const mockClamavScanFile = vi.fn();
 vi.mock('../../services/apiService', () => ({
   default: {
     addAnnouncement: (...args) => {
-      console.log('mockAddAnnouncement.....', args);
       mockAddAnnouncement(...args);
+    },
+    getAnnouncements: (...args) => {
+      mockGetAnnouncement(...args);
     },
     clamavScanFile: (...args) => {
       return mockClamavScanFile(...args);
@@ -62,7 +65,6 @@ const formatDate = (date: LocalDate) => {
 const setDate = async (field: HTMLElement, getDateCell: () => HTMLElement) => {
   await fireEvent.click(field);
   await waitFor(() => {
-    
     const dateCell = getDateCell();
     expect(dateCell).toBeInTheDocument();
     fireEvent.click(dateCell!);
@@ -104,7 +106,7 @@ describe('AddAnnouncementPage', () => {
     const publishOn = getByLabelText('Publish On');
     const publishDate = formatDate(LocalDate.now());
     await setDate(publishOn, () => {
-      return getByLabelText(publishDate)
+      return getByLabelText(publishDate);
     });
     const noExpiry = getByRole('checkbox', { name: 'No expiry' });
     await fireEvent.click(noExpiry);

--- a/admin-frontend/src/components/__tests__/EditAnnouncementPage.spec.ts
+++ b/admin-frontend/src/components/__tests__/EditAnnouncementPage.spec.ts
@@ -79,8 +79,8 @@ describe('EditAnnouncementPage', () => {
           status: 'PUBLISHED',
           announcement_resource: [],
         } as any);
-        const { queryByRole } = await wrappedRender();
-        expect(queryByRole('radio', { name: 'Draft' })).toBeNull();
+        const { queryByLabelText } = await wrappedRender();
+        expect(queryByLabelText('Draft')).toBeNull();
       });
     });
     describe('when announcement is draft', () => {
@@ -91,9 +91,9 @@ describe('EditAnnouncementPage', () => {
           status: 'DRAFT',
           announcement_resource: [],
         } as any);
-        const { getByRole } = await wrappedRender();
-        expect(getByRole('radio', { name: 'Draft' })).toBeInTheDocument();
-        expect(getByRole('radio', { name: 'Publish' })).toBeInTheDocument();
+        const { getByLabelText } = await wrappedRender();
+        expect(getByLabelText('Draft')).toBeInTheDocument();
+        expect(getByLabelText('Publish')).toBeInTheDocument();
       });
 
       describe('when publishing announcement', () => {
@@ -105,9 +105,10 @@ describe('EditAnnouncementPage', () => {
             status: 'DRAFT',
             announcement_resource: [],
           } as any);
-          const { getByRole, getByText } = await wrappedRender();
-          const publishButton = getByRole('radio', { name: 'Publish' });
-          expect(getByRole('radio', { name: 'Publish' })).toBeInTheDocument();
+          const { getByRole, getByText, getByLabelText } =
+            await wrappedRender();
+          const publishButton = getByLabelText('Publish');
+          expect(publishButton).toBeInTheDocument();
           await fireEvent.click(publishButton);
           const saveButton = getByRole('button', { name: 'Save' });
           await fireEvent.click(saveButton);
@@ -139,7 +140,7 @@ describe('EditAnnouncementPage', () => {
           ],
         } as any);
         const { getByRole, getByLabelText } = await wrappedRender();
-        expect(getByRole('radio', { name: 'Publish' })).toBeChecked();
+        expect(getByLabelText('Publish')).toBeChecked();
         expect(getByLabelText('Title')).toHaveValue('title');
         expect(getByLabelText('Description')).toHaveValue('description');
         expect(getByLabelText('Display Link As')).toHaveValue('link');

--- a/admin-frontend/src/components/__tests__/EditAnnouncementPage.spec.ts
+++ b/admin-frontend/src/components/__tests__/EditAnnouncementPage.spec.ts
@@ -1,3 +1,4 @@
+import { faker } from '@faker-js/faker';
 import { fireEvent, render, waitFor } from '@testing-library/vue';
 import { createPinia, setActivePinia } from 'pinia';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
@@ -6,7 +7,6 @@ import * as components from 'vuetify/components';
 import * as directives from 'vuetify/directives';
 import { useAnnouncementSelectionStore } from '../../store/modules/announcementSelectionStore';
 import EditAnnouncementPage from '../EditAnnouncementPage.vue';
-import { faker } from '@faker-js/faker';
 
 global.ResizeObserver = require('resize-observer-polyfill');
 
@@ -39,9 +39,11 @@ const wrappedRender = () => {
 
 const mockUpdateAnnouncement = vi.fn();
 const mockDownloadFile = vi.fn();
+const mockGetAnnouncement = vi.fn();
 vi.mock('../../services/apiService', () => ({
   default: {
     updateAnnouncement: (...args) => mockUpdateAnnouncement(...args),
+    getAnnouncements: (...args) => mockGetAnnouncement(...args),
     downloadFile: (...args) => mockDownloadFile(...args),
   },
 }));

--- a/admin-frontend/src/components/announcements/AnnouncementForm.vue
+++ b/admin-frontend/src/components/announcements/AnnouncementForm.vue
@@ -59,10 +59,7 @@
                   Title *
                 </h5>
                 <v-text-field
-ref="announcementTitleRef" <<<<<<<
-                  HEAD
-=======
->>>>>>> main
+                  ref="announcementTitleRef"
                   v-model="announcementTitle"
                   single-line
                   label="Title"
@@ -84,10 +81,7 @@ ref="announcementTitleRef" <<<<<<<
                   Description *
                 </h5>
                 <v-textarea
-ref="announcementDescriptionRef" <<<<<<<
-                  HEAD
-=======
->>>>>>> main
+                  ref="announcementDescriptionRef"
                   v-model="announcementDescription"
                   single-line
                   variant="outlined"
@@ -115,18 +109,11 @@ ref="announcementDescriptionRef" <<<<<<<
                   <v-col cols="6">
                     <VueDatePicker
                       v-model="publishedOn"
-<<<<<<< HEAD
-=======
                       :state="errors.published_on == null ? undefined : false"
->>>>>>> main
                       format="yyyy-MM-dd hh:mm a"
                       :enable-time-picker="true"
                       arrow-navigation
                       auto-apply
-<<<<<<< HEAD
-                      prevent-min-max-navigation
-=======
->>>>>>> main
                       :aria-labels="{ input: 'Publish On' }"
                     >
                       <template #day="{ day, date }">
@@ -203,10 +190,7 @@ ref="announcementDescriptionRef" <<<<<<<
                       >Link URL</span
                     >
                     <v-text-field
-ref="linkUrlRef" <<<<<<<
-                      HEAD
-=======
->>>>>>> main
+                      ref="linkUrlRef"
                       v-model="linkUrl"
                       single-line
                       variant="outlined"
@@ -225,10 +209,7 @@ ref="linkUrlRef" <<<<<<<
                       >Display Link As</span
                     >
                     <v-text-field
-ref="linkDisplayNameRef" <<<<<<<
-                      HEAD
-=======
->>>>>>> main
+                      ref="linkDisplayNameRef"
                       v-model="linkDisplayName"
                       single-line
                       variant="filled"
@@ -267,10 +248,7 @@ ref="linkDisplayNameRef" <<<<<<<
                       >File Name</span
                     >
                     <v-text-field
-ref="fileDisplayNameRef" <<<<<<<
-                      HEAD
-=======
->>>>>>> main
+                      ref="fileDisplayNameRef"
                       v-model="fileDisplayName"
                       single-line
                       variant="outlined"

--- a/admin-frontend/src/components/announcements/AnnouncementForm.vue
+++ b/admin-frontend/src/components/announcements/AnnouncementForm.vue
@@ -23,6 +23,7 @@
                   announcement?.status === 'PUBLISHED'
                 )
               "
+              label="Draft"
               value="DRAFT"
               class="mr-2"
             >
@@ -32,7 +33,7 @@
                 ></AnnouncementStatusChip>
               </template>
             </v-radio>
-            <v-radio value="PUBLISHED">
+            <v-radio value="PUBLISHED" label="Publish">
               <template #label>
                 <AnnouncementStatusChip
                   :status="AnnouncementStatus.Published"
@@ -480,7 +481,7 @@ async function refreshPreview() {
   const publishedAnnouncementsFiltered =
     mode == AnnouncementFormMode.CREATE
       ? publishedAnnouncements
-      : publishedAnnouncements.filter(
+      : publishedAnnouncements?.filter(
           (a) => a.announcement_id != announcement?.announcement_id,
         );
   currentAnnouncement.value = buildAnnouncementToPreview();
@@ -496,7 +497,9 @@ async function refreshPreview() {
   if (!isCurrentAnnouncementEmpty) {
     announcements.push(currentAnnouncement.value);
   }
-  announcements.push(...publishedAnnouncementsFiltered);
+  if (publishedAnnouncementsFiltered?.length) {
+    announcements.push(...publishedAnnouncementsFiltered);
+  }
   announcementsToPreview.value = announcements;
 }
 

--- a/admin-frontend/src/components/announcements/AnnouncementForm.vue
+++ b/admin-frontend/src/components/announcements/AnnouncementForm.vue
@@ -15,7 +15,7 @@
 
         <div class="d-flex flex-row align-center">
           <div class="mr-2">Save as:</div>
-          <v-radio-group inline v-model="status" class="status-options mr-2">
+          <v-radio-group v-model="status" inline class="status-options mr-2">
             <v-radio
               v-if="
                 !(
@@ -23,19 +23,24 @@
                   announcement?.status === 'PUBLISHED'
                 )
               "
-              label="Draft"
               value="DRAFT"
               class="mr-2"
-            ></v-radio>
-            <v-radio label="Publish" value="PUBLISHED"></v-radio>
+            >
+              <template #label>
+                <AnnouncementStatusChip
+                  :status="AnnouncementStatus.Draft"
+                ></AnnouncementStatusChip>
+              </template>
+            </v-radio>
+            <v-radio value="PUBLISHED">
+              <template #label>
+                <AnnouncementStatusChip
+                  :status="AnnouncementStatus.Published"
+                ></AnnouncementStatusChip>
+              </template>
+            </v-radio>
           </v-radio-group>
-          <v-btn
-            color="primary"
-            class="ml-2"
-            @click="handleSave()"
-            :disabled="!isPreviewVisible"
-            >Save</v-btn
-          >
+          <v-btn color="primary" class="ml-2" @click="handleSave()">Save</v-btn>
         </div>
       </div>
 
@@ -46,19 +51,20 @@
               <v-col cols="12" md="12" sm="12">
                 <h5>Title *</h5>
                 <v-text-field
+                  v-model="announcementTitle"
                   single-line
                   label="Title"
                   placeholder="Title"
                   variant="outlined"
                   counter
                   maxlength="100"
-                  v-model="announcementTitle"
                   :error-messages="errors.title"
                 ></v-text-field>
               </v-col>
               <v-col cols="12" md="12" sm="12">
                 <h5>Description *</h5>
                 <v-textarea
+                  v-model="announcementDescription"
                   single-line
                   variant="outlined"
                   label="Description"
@@ -66,7 +72,6 @@
                   maxlength="2000"
                   counter
                   rows="3"
-                  v-model="announcementDescription"
                   :error-messages="errors.description"
                 ></v-textarea>
               </v-col>
@@ -78,12 +83,12 @@
                   </v-col>
                   <v-col cols="6">
                     <VueDatePicker
+                      v-model="publishedOn"
                       format="yyyy-MM-dd hh:mm a"
                       :enable-time-picker="true"
                       arrow-navigation
                       auto-apply
                       prevent-min-max-navigation
-                      v-model="publishedOn"
                       :aria-labels="{ input: 'Publish On' }"
                     >
                       <template #day="{ day, date }">
@@ -107,13 +112,13 @@
                   </v-col>
                   <v-col cols="6" class="d-flex align-center">
                     <VueDatePicker
+                      v-model="expiresOn"
                       :aria-labels="{ input: 'Expires On' }"
                       format="yyyy-MM-dd hh:mm a"
                       :enable-time-picker="true"
                       arrow-navigation
                       auto-apply
                       prevent-min-max-navigation
-                      v-model="expiresOn"
                       :disabled="noExpiry"
                     >
                       <template #day="{ day, date }">
@@ -147,10 +152,10 @@
                   <v-col cols="12">
                     <span class="attachment-label">Link URL</span>
                     <v-text-field
+                      v-model="linkUrl"
                       single-line
                       variant="outlined"
                       placeholder="https://example.com"
-                      v-model="linkUrl"
                       label="Link URL"
                       :error-messages="errors.linkUrl"
                     ></v-text-field>
@@ -158,11 +163,11 @@
                   <v-col cols="12">
                     <span class="attachment-label">Display Link As</span>
                     <v-text-field
+                      v-model="linkDisplayName"
                       single-line
                       variant="filled"
                       placeholder="eg. Pay Transparency in B.C."
                       label="Display Link As"
-                      v-model="linkDisplayName"
                       :error-messages="errors.linkDisplayName"
                     ></v-text-field>
                   </v-col>
@@ -179,9 +184,9 @@
                       announcement?.fileDisplayName
                     "
                     variant="text"
-                    @click="cancelEdit"
                     class="ml-2"
                     aria-label="Edit file"
+                    @click="cancelEdit"
                     >Cancel edit file</v-btn
                   >
                 </div>
@@ -189,20 +194,20 @@
                   <v-col cols="12">
                     <span class="attachment-label">File Name</span>
                     <v-text-field
+                      v-model="fileDisplayName"
                       single-line
                       variant="outlined"
                       placeholder="eg. Pay Transparency in B.C."
                       label="File Name"
-                      v-model="fileDisplayName"
                       :error-messages="errors.fileDisplayName"
                     ></v-text-field>
                   </v-col>
                   <v-col cols="12">
                     <span class="attachment-label">Attachment</span>
                     <v-file-input
+                      v-model="attachment"
                       single-line
                       label="Attachment"
-                      v-model="attachment"
                       class="attachment"
                       variant="outlined"
                       :error-messages="errors.attachment"
@@ -225,75 +230,51 @@
                 </v-row>
               </v-col>
             </v-row>
-            <v-row>
-              <v-col class="d-flex justify-end">
-                <v-btn
-                  v-if="!announcementsToPreview?.length"
-                  class="btn-primary"
-                  prepend-icon="mdi-eye"
-                  @click="preview()"
-                  :disabled="!isPreviewAvailable"
-                  >Preview</v-btn
-                >
-              </v-col>
-            </v-row>
           </div>
         </v-col>
-        <Transition name="slide-fade">
-          <v-col
-            sm="6"
-            md="5"
-            lg="5"
-            xl="4"
-            class="px-0 py-0 d-flex justify-end"
-            v-if="isPreviewVisible"
-          >
-            <div class="previewPanel bg-previewPanel w-100 h-100 px-6 py-6">
-              <v-row dense>
-                <v-col>
-                  <h3>Preview Announcement</h3>
-                </v-col>
-                <v-col cols="2" class="d-flex justify-end">
-                  <v-btn
-                    aria-label="Close preview"
-                    density="compact"
-                    variant="plain"
-                    icon="mdi-close"
-                    @click="closePreview()"
-                  ></v-btn>
-                </v-col>
-              </v-row>
+        <v-col
+          sm="6"
+          md="5"
+          lg="5"
+          xl="4"
+          class="px-0 py-0 d-flex justify-end extend-to-bottom"
+        >
+          <div class="previewPanel bg-previewPanel w-100 h-100 px-6 py-6">
+            <v-row dense>
+              <v-col>
+                <h3>Preview Announcement</h3>
+              </v-col>
+            </v-row>
 
-              <v-row dense class="mb-2">
-                <v-col>
-                  <v-icon icon="mdi-information"></v-icon>
-                  This is how the announcement will appear to the public.
-                </v-col>
-              </v-row>
-              <v-row dense>
-                <v-col class="announcements">
-                  <AnnouncementPager
-                    :announcements="announcementsToPreview"
-                    :pageSize="2"
-                    class="h-100"
-                  ></AnnouncementPager> </v-col
-              ></v-row>
-            </div>
-          </v-col>
-        </Transition>
+            <v-row dense class="mb-2">
+              <v-col>
+                <v-icon icon="mdi-information"></v-icon>
+                This is how the announcement will appear to the public.
+              </v-col>
+            </v-row>
+            <v-row dense>
+              <v-col class="announcements">
+                <AnnouncementPager
+                  :announcements="announcementsToPreview"
+                  :page-size="2"
+                  class="h-100"
+                ></AnnouncementPager> </v-col
+            ></v-row>
+          </div>
+        </v-col>
       </v-row>
     </v-col>
   </v-row>
 
   <ConfirmationDialog ref="confirmDialog">
-    <template v-slot:message>
+    <template #message>
       <p>
         Are you sure want to cancel this changes. This process cannot be undone.
       </p>
     </template>
   </ConfirmationDialog>
   <ConfirmationDialog ref="publishConfirmationDialog">
-    <template v-slot:message>
+    <template #message>
       <p>Are you sure you want to publish this announcement?</p>
     </template>
   </ConfirmationDialog>
@@ -301,7 +282,7 @@
 
 <script lang="ts" setup>
 import VueDatePicker from '@vuepic/vue-datepicker';
-import { defineProps, defineEmits, watch, ref, computed } from 'vue';
+import { defineProps, defineEmits, watch, ref } from 'vue';
 import {
   AnnouncementFormValue,
   Announcement,
@@ -309,6 +290,7 @@ import {
   AnnouncementSortType,
   AnnouncementFormMode,
   AnnouncementResourceType,
+  AnnouncementStatus,
 } from '../../types/announcements';
 import { useField, useForm } from 'vee-validate';
 import * as zod from 'zod';
@@ -326,6 +308,7 @@ import AnnouncementPager from './AnnouncementPager.vue';
 import AttachmentResource from './AttachmentResource.vue';
 import ApiService from '../../services/apiService';
 import { v4 } from 'uuid';
+import AnnouncementStatusChip from './AnnouncementStatusChip.vue';
 
 type Props = {
   announcement: AnnouncementFormValue | null | undefined;
@@ -334,6 +317,7 @@ type Props = {
 };
 
 let publishedAnnouncements: Announcement[] | undefined = undefined;
+const currentAnnouncement = ref<any>(null);
 const announcementsToPreview = ref<Announcement[]>();
 
 const router = useRouter();
@@ -342,8 +326,6 @@ const confirmDialog = ref<typeof ConfirmationDialog>();
 const publishConfirmationDialog = ref<typeof ConfirmationDialog>();
 const { announcement, mode } = defineProps<Props>();
 const fileDisplayOnly = ref(!!announcement?.file_resource_id);
-const isPreviewAvailable = computed(() => values.title && values.description);
-const isPreviewVisible = computed(() => announcementsToPreview.value?.length);
 const isConfirmDialogVisible = ref(false);
 
 const { handleSubmit, setErrors, errors, meta, values } = useForm({
@@ -438,11 +420,13 @@ watch(noExpiry, () => {
 //Watch for changes to any form field.
 //If the 'preview' mode is active when the form changes
 //then refresh the preview
-watch(values, () => {
-  if (announcementsToPreview.value) {
-    preview();
-  }
-});
+watch(
+  values,
+  () => {
+    refreshPreview();
+  },
+  { immediate: true },
+);
 
 const formatDate = (date: Date) => {
   return LocalDate.from(nativeJs(date)).format(
@@ -487,7 +471,7 @@ announcements.  The pre-existing announcements are fetched from the backend,
 and cached for quick subsequent access (because this function may be called
 repeatedly).
 */
-async function preview() {
+async function refreshPreview() {
   if (!publishedAnnouncements) {
     publishedAnnouncements = await getPublishedAnnouncements();
   }
@@ -499,19 +483,21 @@ async function preview() {
       : publishedAnnouncements.filter(
           (a) => a.announcement_id != announcement?.announcement_id,
         );
-  const currentAnnouncement = buildAnnouncementToPreview();
-  announcementsToPreview.value = [
-    currentAnnouncement as any,
-    ...publishedAnnouncementsFiltered,
-  ];
-}
+  currentAnnouncement.value = buildAnnouncementToPreview();
 
-/*
-Clears the 'announcementsToPreview' ref which triggers the
-preview panel to disappear.
-*/
-function closePreview() {
-  announcementsToPreview.value = undefined;
+  //combine the currentAnnouncement with a list of already-published
+  //announcements
+  const announcements: any[] = [];
+  const isCurrentAnnouncementEmpty =
+    !currentAnnouncement.value.announcement_id &&
+    !currentAnnouncement.value.title &&
+    !currentAnnouncement.value.description &&
+    !currentAnnouncement.value.announcement_resource.length;
+  if (!isCurrentAnnouncementEmpty) {
+    announcements.push(currentAnnouncement.value);
+  }
+  announcements.push(...publishedAnnouncementsFiltered);
+  announcementsToPreview.value = announcements;
 }
 
 /*
@@ -522,7 +508,7 @@ its appearance, so some of the unnecessary attributes aren't populated
 */
 function buildAnnouncementToPreview() {
   const previewAnnouncement = {
-    announcement_id: null,
+    announcement_id: announcement?.announcement_id,
     title: announcementTitle.value,
     description: announcementDescription.value,
     announcement_resource: [] as any[],
@@ -557,6 +543,7 @@ function buildAnnouncementToPreview() {
     }
     previewAnnouncement.announcement_resource.push(resource);
   }
+
   return previewAnnouncement;
 }
 
@@ -729,6 +716,9 @@ const handleSave = handleSubmit(async (values) => {
 }
 .extend-to-right-edge {
   margin-right: -40px !important;
+}
+.extend-to-bottom {
+  margin-bottom: -36px;
 }
 .status-options {
   height: 40px;

--- a/admin-frontend/src/components/announcements/__tests__/AnnouncementForm.spec.ts
+++ b/admin-frontend/src/components/announcements/__tests__/AnnouncementForm.spec.ts
@@ -1,5 +1,4 @@
 import { createTestingPinia } from '@pinia/testing';
-import { fireEvent, render, screen, waitFor } from '@testing-library/vue';
 import { flushPromises, mount } from '@vue/test-utils';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { createVuetify } from 'vuetify';
@@ -8,8 +7,6 @@ import * as directives from 'vuetify/directives';
 import AnnouncementForm from '../AnnouncementForm.vue';
 
 global.ResizeObserver = require('resize-observer-polyfill');
-const pinia = createTestingPinia();
-const vuetify = createVuetify({ components, directives });
 
 const mockGetAnnouncements = vi.fn().mockResolvedValue({ items: [] });
 const mockClamavScan = vi.fn();
@@ -24,70 +21,6 @@ vi.mock('../../../services/apiService', () => ({
     },
   },
 }));
-
-const wrappedRender = async () => {
-  return render(AnnouncementForm, {
-    global: {
-      plugins: [pinia, vuetify],
-    },
-  });
-};
-
-const fillTitleAndDesc = async () => {
-  const title = screen.getByLabelText('Title');
-  const description = screen.getByLabelText('Description');
-  await fireEvent.update(title, 'Test Title');
-  await fireEvent.update(description, 'Test Description');
-};
-
-describe('AnnouncementForm - Vue Testing Library tests', () => {
-  afterEach(() => {
-    vi.clearAllMocks();
-  });
-
-  it('preview button becomes enabled when title and desc are provided', async () => {
-    const { getByRole, getByLabelText } = await wrappedRender();
-    const previewButton = getByRole('button', { name: 'Preview' });
-    const title = getByLabelText('Title');
-    const description = getByLabelText('Description');
-    expect(previewButton).not.toBeEnabled();
-    await fireEvent.update(title, 'Test Title');
-    expect(previewButton).not.toBeEnabled();
-    await fireEvent.update(description, 'Test Description');
-    expect(previewButton).toBeEnabled();
-  });
-
-  it('preview panel appears when preview button is clicked, and disappear when close is clicked', async () => {
-    await wrappedRender();
-    await fillTitleAndDesc();
-    const previewButton = screen.getByRole('button', { name: 'Preview' });
-    expect(previewButton).toBeEnabled();
-    await fireEvent.click(previewButton);
-
-    //check that preview panel appeared
-    await waitFor(() => {
-      expect(screen.queryByText('Preview Announcement')).toBeInTheDocument();
-    });
-
-    //Fill in the link details
-    const linkDisplayName = screen.getByLabelText('Display Link As');
-    const linkUrl = screen.getByLabelText('Link URL');
-    await fireEvent.update(linkDisplayName, 'MockLinkName');
-    await fireEvent.update(linkUrl, 'MockUrl');
-
-    const closePreviewButton = screen.getByRole('button', {
-      name: 'Close preview',
-    });
-    await fireEvent.click(closePreviewButton);
-
-    //check that preview panel disappeared
-    await waitFor(() => {
-      expect(
-        screen.queryByText('Preview Announcement'),
-      ).not.toBeInTheDocument();
-    });
-  });
-});
 
 describe('AnnouncementItem - Vue Test Utils tests', () => {
   let wrapper;

--- a/admin-frontend/src/components/announcements/__tests__/AnnouncementForm.spec.ts
+++ b/admin-frontend/src/components/announcements/__tests__/AnnouncementForm.spec.ts
@@ -20,7 +20,7 @@ vi.mock('../../../services/apiService', () => ({
       return mockGetAnnouncements(...args);
     },
     clamavScanFile: (...args) => {
-      return mockClamavScan;
+      return mockClamavScan(...args);
     },
   },
 }));


### PR DESCRIPTION
In the admin app:
- Add/edit announcement now makes the "preview" panel always visible.  No need to click a "preview" button to see it.
- Replace the "Draft" and "Published" radio button labels with "chips" for visual consistency with the main Announcements page.

Fixes # [GEO-1095](https://finrms.atlassian.net/browse/GEO-1095), [GEO-1102](https://finrms.atlassian.net/browse/GEO-1102)

## Type of change

- [ ] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Updated existing unit tests

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have already been accepted and merged

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://pay-transparency-pr-716-frontend.apps.silver.devops.gov.bc.ca)
- [Admin Frontend](https://pay-transparency-pr-716-admin-frontend.apps.silver.devops.gov.bc.ca)
- [Backend external API console](https://pay-transparency-pr-716-backend-external.apps.silver.devops.gov.bc.ca/api/V1/docs)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/fin-pay-transparency/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/fin-pay-transparency/actions/workflows/merge.yml)

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://pay-transparency-pr-716-frontend.apps.silver.devops.gov.bc.ca)
- [Admin Frontend](https://pay-transparency-pr-716-admin-frontend.apps.silver.devops.gov.bc.ca)
- [Backend external API console](https://pay-transparency-pr-716-backend-external.apps.silver.devops.gov.bc.ca/api/V1/docs)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/fin-pay-transparency/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/fin-pay-transparency/actions/workflows/merge.yml)