### PR TITLE
fix: geo 1089 announcement link display and edit mode form

### DIFF
--- a/admin-frontend/src/components/__tests__/AddAnnouncementPage.spec.ts
+++ b/admin-frontend/src/components/__tests__/AddAnnouncementPage.spec.ts
@@ -91,16 +91,16 @@ describe('AddAnnouncementPage', () => {
     expect(getByLabelText('Expires On')).toBeInTheDocument();
     expect(getByRole('checkbox', { name: 'No expiry' })).toBeInTheDocument();
     expect(getByLabelText('Link URL')).toBeInTheDocument();
-    expect(getByLabelText('Display Link As')).toBeInTheDocument();
+    expect(getByLabelText('Display URL As')).toBeInTheDocument();
   });
   it('should submit the form', async () => {
-    const { getByRole, getByLabelText, queryAllByText, getAllByText } =
+    const { getByRole, getByLabelText } =
       await wrappedRender();
     const saveButton = getByRole('button', { name: 'Save' });
     const title = getByLabelText('Title');
     const description = getByLabelText('Description');
     const linkUrl = getByLabelText('Link URL');
-    const displayLinkAs = getByLabelText('Display Link As');
+    const displayLinkAs = getByLabelText('Display URL As');
     await fireEvent.update(title, 'Test Title');
     await fireEvent.update(description, 'Test Description');
     const publishOn = getByLabelText('Publish On');
@@ -142,7 +142,7 @@ describe('AddAnnouncementPage', () => {
     const title = getByLabelText('Title');
     const description = getByLabelText('Description');
     const linkUrl = getByLabelText('Link URL');
-    const displayLinkAs = getByLabelText('Display Link As');
+    const displayLinkAs = getByLabelText('Display URL As');
     await fireEvent.update(title, 'Test Title');
     await fireEvent.update(description, 'Test Description');
     await fireEvent.update(linkUrl, 'https://example.com');
@@ -170,7 +170,7 @@ describe('AddAnnouncementPage', () => {
       const title = getByLabelText('Title');
       const description = getByLabelText('Description');
       const linkUrl = getByLabelText('Link URL');
-      const displayLinkAs = getByLabelText('Display Link As');
+      const displayLinkAs = getByLabelText('Display URL As');
       await fireEvent.update(title, 'Test Title');
       await fireEvent.update(description, 'Test Description');
       await fireEvent.update(linkUrl, 'https://example.com');
@@ -195,7 +195,7 @@ describe('AddAnnouncementPage', () => {
     const title = getByLabelText('Title');
     const description = getByLabelText('Description');
     const linkUrl = getByLabelText('Link URL');
-    const displayLinkAs = getByLabelText('Display Link As');
+    const displayLinkAs = getByLabelText('Display URL As');
     await fireEvent.update(title, 'Test Title');
     await fireEvent.update(description, 'Test Description');
     const publishOn = getByLabelText('Publish On');
@@ -266,7 +266,7 @@ describe('AddAnnouncementPage', () => {
     const title = getByLabelText('Title');
     const description = getByLabelText('Description');
     const linkUrl = getByLabelText('Link URL');
-    const displayLinkAs = getByLabelText('Display Link As');
+    const displayLinkAs = getByLabelText('Display URL As');
     await fireEvent.update(title, 'Test Title');
     await fireEvent.update(description, 'Test Description');
     await fireEvent.update(linkUrl, 'https://example.com');
@@ -290,7 +290,7 @@ describe('AddAnnouncementPage', () => {
   });
 
   describe('when link url is not empty', () => {
-    describe('when display link as is empty', () => {
+    describe('when Display URL As is empty', () => {
       it('should show error message', async () => {
         const { getByRole, getByLabelText, getByText } = await wrappedRender();
         const saveButton = getByRole('button', { name: 'Save' });
@@ -326,7 +326,7 @@ describe('AddAnnouncementPage', () => {
         const title = getByLabelText('Title');
         const description = getByLabelText('Description');
         const linkUrl = getByLabelText('Link URL');
-        const displayLinkAs = getByLabelText('Display Link As');
+        const displayLinkAs = getByLabelText('Display URL As');
         await fireEvent.update(title, 'Test Title');
         await fireEvent.update(description, 'Test Description');
         const publishOn = getByLabelText('Publish On');
@@ -334,7 +334,6 @@ describe('AddAnnouncementPage', () => {
         await setDate(publishOn, () => {
           return getByLabelText(publishDate);
         });
-        const noExpiry = getByRole('checkbox', { name: 'No expiry' });
         await fireEvent.update(linkUrl, 'https://example.com');
         await fireEvent.update(displayLinkAs, 'a'.repeat(101));
         await markAsPublish();
@@ -354,7 +353,7 @@ describe('AddAnnouncementPage', () => {
         const saveButton = getByRole('button', { name: 'Save' });
         const title = getByLabelText('Title');
         const description = getByLabelText('Description');
-        const displayLinkAs = getByLabelText('Display Link As');
+        const displayLinkAs = getByLabelText('Display URL As');
         await fireEvent.update(title, 'Test Title');
         await fireEvent.update(description, 'Test Description');
         const publishOn = getByLabelText('Publish On');
@@ -381,8 +380,8 @@ describe('AddAnnouncementPage', () => {
         const title = getByLabelText('Title');
         const description = getByLabelText('Description');
         const linkUrl = getByLabelText('Link URL');
-        const displayLinkAs = getByLabelText('Display Link As');
-        const fileName = getByLabelText('File Name');
+        const displayLinkAs = getByLabelText('Display URL As');
+        const fileName = getByLabelText('Display File Link As');
         await fireEvent.update(title, 'Test Title');
         await fireEvent.update(description, 'Test Description');
         const publishOn = getByLabelText('Publish On');
@@ -410,7 +409,7 @@ describe('AddAnnouncementPage', () => {
         const saveButton = getByRole('button', { name: 'Save' });
         const title = getByLabelText('Title');
         const description = getByLabelText('Description');
-        const displayLinkAs = getByLabelText('Display Link As');
+        const displayLinkAs = getByLabelText('Display URL As');
         await fireEvent.update(title, 'Test Title');
         await fireEvent.update(description, 'Test Description');
         const publishOn = getByLabelText('Publish On');
@@ -501,7 +500,7 @@ describe('AddAnnouncementPage', () => {
       const title = getByLabelText('Title');
       const description = getByLabelText('Description');
       const linkUrl = getByLabelText('Link URL');
-      const displayLinkAs = getByLabelText('Display Link As');
+      const displayLinkAs = getByLabelText('Display URL As');
       await fireEvent.update(title, 'Test Title');
       await fireEvent.update(description, 'Test Description');
       const publishOn = getByLabelText('Publish On');

--- a/admin-frontend/src/components/__tests__/EditAnnouncementPage.spec.ts
+++ b/admin-frontend/src/components/__tests__/EditAnnouncementPage.spec.ts
@@ -7,12 +7,7 @@ import * as components from 'vuetify/components';
 import * as directives from 'vuetify/directives';
 import { useAnnouncementSelectionStore } from '../../store/modules/announcementSelectionStore';
 import EditAnnouncementPage from '../EditAnnouncementPage.vue';
-<<<<<<< HEAD
-=======
-import { faker } from '@faker-js/faker';
-import { a } from 'vitest/dist/chunks/suite.CcK46U-P.js';
 import { AnnouncementResourceType } from '../../types/announcements';
->>>>>>> b1464449 (create link display in announcement edit form)
 
 global.ResizeObserver = require('resize-observer-polyfill');
 

--- a/admin-frontend/src/components/__tests__/EditAnnouncementPage.spec.ts
+++ b/admin-frontend/src/components/__tests__/EditAnnouncementPage.spec.ts
@@ -7,6 +7,12 @@ import * as components from 'vuetify/components';
 import * as directives from 'vuetify/directives';
 import { useAnnouncementSelectionStore } from '../../store/modules/announcementSelectionStore';
 import EditAnnouncementPage from '../EditAnnouncementPage.vue';
+<<<<<<< HEAD
+=======
+import { faker } from '@faker-js/faker';
+import { a } from 'vitest/dist/chunks/suite.CcK46U-P.js';
+import { AnnouncementResourceType } from '../../types/announcements';
+>>>>>>> b1464449 (create link display in announcement edit form)
 
 global.ResizeObserver = require('resize-observer-polyfill');
 
@@ -143,8 +149,7 @@ describe('EditAnnouncementPage', () => {
         expect(getByLabelText('Publish')).toBeChecked();
         expect(getByLabelText('Title')).toHaveValue('title');
         expect(getByLabelText('Description')).toHaveValue('description');
-        expect(getByLabelText('Display Link As')).toHaveValue('link');
-        expect(getByLabelText('Link URL')).toHaveValue('https://example.com');
+        
         const noExpiry = getByRole('checkbox', { name: 'No expiry' });
         await fireEvent.click(noExpiry);
         const saveButton = getByRole('button', { name: 'Save' });
@@ -201,7 +206,7 @@ describe('EditAnnouncementPage', () => {
           const { getByRole, getByLabelText } = await wrappedRender();
           const deleteButton = getByRole('button', { name: 'Delete file' });
           await fireEvent.click(deleteButton);
-          const fileNameInput = getByLabelText('File Name');
+          const fileNameInput = getByLabelText('Display File Link As');
           await waitFor(() => {
             expect(fileNameInput).toHaveValue('');
           });
@@ -228,7 +233,7 @@ describe('EditAnnouncementPage', () => {
           const { getByRole, getByLabelText } = await wrappedRender();
           const editButton = getByRole('button', { name: 'Edit file' });
           await fireEvent.click(editButton);
-          const fileNameInput = getByLabelText('File Name');
+          const fileNameInput = getByLabelText('Display File Link As');
           await waitFor(() => {
             expect(fileNameInput).toHaveValue('file name');
           });
@@ -280,14 +285,109 @@ describe('EditAnnouncementPage', () => {
           status: 'PUBLISHED',
           announcement_resource: [],
         } as any);
-        const { getByRole, getByLabelText } = await wrappedRender();
-        const fileNameInput = getByLabelText('File Name');
+        const { getByLabelText } = await wrappedRender();
+        const fileNameInput = getByLabelText('Display File Link As');
         const fileInput = getByLabelText('Attachment');
         expect(fileNameInput).toHaveValue('');
         expect(fileInput).toBeInTheDocument();
       });
     });
 
+    describe('when announcement has a link', () => {
+      it('should display link', async () => {
+        store.setAnnouncement({
+          announcement_id: '1',
+          title: 'title',
+          description: 'description',
+          published_on: new Date().toDateString(),
+          status: 'PUBLISHED',
+          announcement_resource: [
+            {
+              announcement_resource_id: '1',
+              resource_type: AnnouncementResourceType.ATTACHMENT,
+              display_name: 'file name',
+              attachment_file_id: '1',
+              resource_url: '',
+            },
+            {
+              announcement_resource_id: '2',
+              resource_type: AnnouncementResourceType.LINK,
+              display_name: 'link display name',
+              resource_url: 'https://example.com',
+              attachment_file_id: '',
+            },
+          ],
+        } as any);
+        const { getByRole } = await wrappedRender();
+        expect(
+          getByRole('link', { name: 'link display name' }),
+        ).toBeInTheDocument();
+        expect(getByRole('button', { name: 'Edit link' })).toBeInTheDocument();
+        expect(
+          getByRole('button', { name: 'Delete link' }),
+        ).toBeInTheDocument();
+      });
+
+      describe('when link is deleted', () => {
+        it('should remove link', async () => {
+          store.setAnnouncement({
+            announcement_id: '1',
+            title: 'title',
+            description: 'description',
+            published_on: new Date(),
+            status: 'PUBLISHED',
+            announcement_resource: [
+              {
+                announcement_resource_id: '2',
+                resource_type: AnnouncementResourceType.LINK,
+                display_name: 'link display name',
+                resource_url: 'https://example.com',
+                attachment_file_id: '',
+              },
+            ],
+          } as any);
+          const { getByRole, getByLabelText } = await wrappedRender();
+          const deleteButton = getByRole('button', { name: 'Delete link' });
+          await fireEvent.click(deleteButton);
+          const linkNameInput = getByLabelText('Display URL As');
+          const linkUrlInput = getByLabelText('Link URL');
+          await waitFor(() => {
+            expect(linkNameInput).toHaveValue('');
+            expect(linkUrlInput).toHaveValue('');
+          });
+        });
+      });
+
+      describe('when link edit is clicked', () => {
+        it('should update link', async () => {
+          store.setAnnouncement({
+            announcement_id: '1',
+            title: 'title',
+            description: 'description',
+            published_on: new Date(),
+            status: 'PUBLISHED',
+            announcement_resource: [
+              {
+                announcement_resource_id: '2',
+                resource_type: AnnouncementResourceType.LINK,
+                display_name: 'link display name',
+                resource_url: 'https://example.com',
+                attachment_file_id: '',
+              },
+            ],
+          } as any);
+          const { getByRole, getByLabelText } = await wrappedRender();
+          const editButton = getByRole('button', { name: 'Edit link' });
+          await fireEvent.click(editButton);
+          const linkNameInput = getByLabelText('Display URL As');
+          const linkURLInput = getByLabelText('Link URL');
+          await waitFor(() => {
+            expect(linkNameInput).toHaveValue('link display name');
+            expect(linkURLInput).toHaveValue('https://example.com');
+          });
+        });
+      });
+    });
     describe('when announcement update fails', () => {
       it('should show error notification', async () => {
         store.setAnnouncement({

--- a/admin-frontend/src/components/announcements/AnnouncementForm.vue
+++ b/admin-frontend/src/components/announcements/AnnouncementForm.vue
@@ -180,7 +180,7 @@
               </v-col>
               <v-col cols="12">
                 <h5 class="mb-2">Link</h5>
-                <v-row dense class="ml-3 mt-2">
+                <v-row v-if="!linkDisplayOnly" dense class="ml-3 mt-2">
                   <v-col cols="12">
                     <span
                       class="attachment-label"
@@ -195,7 +195,8 @@
                       single-line
                       variant="outlined"
                       placeholder="https://example.com"
-                      label="Link URL"
+                      label="https://example.com"
+                      aria-label="Link URL"
                       :error-messages="errors.linkUrl"
                     ></v-text-field>
                   </v-col>
@@ -214,9 +215,20 @@
                       single-line
                       variant="filled"
                       placeholder="eg. Pay Transparency in B.C."
-                      label="Display Link As"
+                      label="eg. Pay Transparency in B.C."
+                      aria-label="Display URL As"
                       :error-messages="errors.linkDisplayName"
                     ></v-text-field>
+                  </v-col>
+                </v-row>
+                <v-row v-else dense class="ml-3 mt-2">
+                  <v-col cols="12">
+                    <LinkResource
+                      :url="linkUrl"
+                      :text="linkDisplayName"
+                      @on-edit="onEditLink"
+                      @on-delete="handleDeleteLink"
+                    ></LinkResource>
                   </v-col>
                 </v-row>
               </v-col>
@@ -245,15 +257,16 @@
                         'text-error':
                           fileDisplayNameRef && !fileDisplayNameRef?.isValid,
                       }"
-                      >File Name</span
+                      >Display File Link As</span
                     >
                     <v-text-field
                       ref="fileDisplayNameRef"
                       v-model="fileDisplayName"
                       single-line
                       variant="outlined"
-                      placeholder="eg. Pay Transparency in B.C."
-                      label="File Name"
+                      placeholder="eg. Updated Pay Transparency Guidance Document"
+                      label="eg. Updated Pay Transparency Guidance Document"
+                      aria-label="Display File Link As"
                       :error-messages="errors.fileDisplayName"
                     ></v-text-field>
                   </v-col>
@@ -285,8 +298,8 @@
                     <AttachmentResource
                       :id="announcement?.file_resource_id!"
                       :name="announcement?.fileDisplayName!"
-                      @on-edit="onEdit"
-                      @on-delete="handleDelete"
+                      @on-edit="onEditFile"
+                      @on-delete="handleDeleteFile"
                     ></AttachmentResource>
                   </v-col>
                 </v-row>
@@ -368,6 +381,7 @@ import ConfirmationDialog from '../util/ConfirmationDialog.vue';
 import { useRouter } from 'vue-router';
 import AnnouncementPager from './AnnouncementPager.vue';
 import AttachmentResource from './AttachmentResource.vue';
+import LinkResource from './LinkResource.vue';
 import ApiService from '../../services/apiService';
 import { v4 } from 'uuid';
 import AnnouncementStatusChip from './AnnouncementStatusChip.vue';
@@ -397,6 +411,9 @@ const confirmDialog = ref<typeof ConfirmationDialog>();
 const publishConfirmationDialog = ref<typeof ConfirmationDialog>();
 const { announcement, mode } = defineProps<Props>();
 const fileDisplayOnly = ref(!!announcement?.file_resource_id);
+const linkDisplayOnly = ref(
+  !isEmpty(announcement?.linkUrl) && !isEmpty(announcement?.linkDisplayName),
+);
 const isConfirmDialogVisible = ref(false);
 
 const { handleSubmit, setErrors, errors, meta, values } = useForm({
@@ -481,6 +498,9 @@ const { value: linkUrl } = useField('linkUrl') as any;
 const { value: linkDisplayName } = useField('linkDisplayName') as any;
 const { value: fileDisplayName } = useField('fileDisplayName') as any;
 const { value: attachment } = useField('attachment') as any;
+watch(linkUrl, () => {
+  console.log('xxxx', linkUrl.value);
+});
 
 watch(noExpiry, () => {
   if (noExpiry.value) {
@@ -505,11 +525,21 @@ const formatDate = (date: Date) => {
   );
 };
 
-const onEdit = () => {
+const onEditFile = () => {
   fileDisplayOnly.value = false;
 };
 
-const handleDelete = () => {
+const onEditLink = () => {
+  linkDisplayOnly.value = false;
+};
+
+const handleDeleteLink = () => {
+  linkDisplayOnly.value = false;
+  linkDisplayName.value = undefined;
+  linkUrl.value = undefined;
+};
+
+const handleDeleteFile = () => {
   fileDisplayName.value = undefined;
   fileDisplayOnly.value = false;
 };

--- a/admin-frontend/src/components/announcements/AnnouncementForm.vue
+++ b/admin-frontend/src/components/announcements/AnnouncementForm.vue
@@ -498,9 +498,6 @@ const { value: linkUrl } = useField('linkUrl') as any;
 const { value: linkDisplayName } = useField('linkDisplayName') as any;
 const { value: fileDisplayName } = useField('fileDisplayName') as any;
 const { value: attachment } = useField('attachment') as any;
-watch(linkUrl, () => {
-  console.log('xxxx', linkUrl.value);
-});
 
 watch(noExpiry, () => {
   if (noExpiry.value) {

--- a/admin-frontend/src/components/announcements/LinkResource.vue
+++ b/admin-frontend/src/components/announcements/LinkResource.vue
@@ -4,7 +4,7 @@
       variant="text"
       color="primary"
       append-icon="mdi-open-in-new"
-      :href="props.url"
+      :href="sanitizeUrl(props.url)"
       target="_blank"
       >{{ props.text }}</v-btn
     >
@@ -24,7 +24,9 @@
   </div>
 </template>
 <script setup lang="ts">
-import { defineProps, watch } from 'vue';
+import { defineProps } from 'vue';
+import { sanitizeUrl } from '@braintree/sanitize-url';
+
 
 type LinkResourceProps = {
   text: string;
@@ -32,9 +34,6 @@ type LinkResourceProps = {
 };
 
 const props = defineProps<LinkResourceProps>();
-watch(props, () => {
-  console.log(props);
-});
 const emits = defineEmits(['onEdit', 'onDelete']);
 </script>
 <style scoped></style>

--- a/admin-frontend/src/components/announcements/LinkResource.vue
+++ b/admin-frontend/src/components/announcements/LinkResource.vue
@@ -27,7 +27,6 @@
 import { defineProps } from 'vue';
 import { sanitizeUrl } from '@braintree/sanitize-url';
 
-
 type LinkResourceProps = {
   text: string;
   url: string;

--- a/admin-frontend/src/components/announcements/LinkResource.vue
+++ b/admin-frontend/src/components/announcements/LinkResource.vue
@@ -35,4 +35,3 @@ type LinkResourceProps = {
 const props = defineProps<LinkResourceProps>();
 const emits = defineEmits(['onEdit', 'onDelete']);
 </script>
-<style scoped></style>

--- a/admin-frontend/src/components/announcements/LinkResource.vue
+++ b/admin-frontend/src/components/announcements/LinkResource.vue
@@ -1,0 +1,40 @@
+<template>
+  <div class="root">
+    <v-btn
+      variant="text"
+      color="primary"
+      append-icon="mdi-open-in-new"
+      :href="props.url"
+      target="_blank"
+      >{{ props.text }}</v-btn
+    >
+    <v-btn
+      density="compact"
+      icon="mdi-pencil"
+      class="mr-2"
+      aria-label="Edit link"
+      @click="emits('onEdit')"
+    ></v-btn>
+    <v-btn
+      density="compact"
+      icon="mdi-delete-outline"
+      aria-label="Delete link"
+      @click="emits('onDelete')"
+    ></v-btn>
+  </div>
+</template>
+<script setup lang="ts">
+import { defineProps, watch } from 'vue';
+
+type LinkResourceProps = {
+  text: string;
+  url: string;
+};
+
+const props = defineProps<LinkResourceProps>();
+watch(props, () => {
+  console.log(props);
+});
+const emits = defineEmits(['onEdit', 'onDelete']);
+</script>
+<style scoped></style>

--- a/admin-frontend/src/types/announcements.ts
+++ b/admin-frontend/src/types/announcements.ts
@@ -12,16 +12,16 @@ export type Announcement = {
   announcement_resource: AnnouncementResource[];
 };
 export type AnnouncementResource = {
-  announcement_id: string;
+  announcement_id?: string;
   announcement_resource_id: string;
-  created_by: string;
-  created_date: string;
+  created_by?: string;
+  created_date?: string;
   display_name: string;
-  attachment_file_id: string;
+  attachment_file_id?: string;
   resource_type: AnnouncementResourceType;
-  resource_url: string;
-  update_date: string;
-  updated_by: string;
+  resource_url?: string;
+  update_date?: string;
+  updated_by?: string;
   //This property isn't supported on the backend, but is used in the frontend
   //to support AnnouncementResources in which the file hasn't yet been uploaded
   //to the backend.  In this case, the not-yet-uploaded file is saved directly


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description

Create a link display in the announcement edit form

Fixes # ([issue](https://finrms.atlassian.net/browse/GEO-1089))

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)


## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have already been accepted and merged


## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://pay-transparency-pr-717-frontend.apps.silver.devops.gov.bc.ca)
- [Admin Frontend](https://pay-transparency-pr-717-admin-frontend.apps.silver.devops.gov.bc.ca)
- [Backend external API console](https://pay-transparency-pr-717-backend-external.apps.silver.devops.gov.bc.ca/api/V1/docs)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/fin-pay-transparency/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/fin-pay-transparency/actions/workflows/merge.yml)