### PR TITLE
feat: GEO-1105 Display limit for Url and other fields

### DIFF
--- a/admin-frontend/src/components/__tests__/AddAnnouncementPage.spec.ts
+++ b/admin-frontend/src/components/__tests__/AddAnnouncementPage.spec.ts
@@ -94,8 +94,7 @@ describe('AddAnnouncementPage', () => {
     expect(getByLabelText('Display URL As')).toBeInTheDocument();
   });
   it('should submit the form', async () => {
-    const { getByRole, getByLabelText } =
-      await wrappedRender();
+    const { getByRole, getByLabelText } = await wrappedRender();
     const saveButton = getByRole('button', { name: 'Save' });
     const title = getByLabelText('Title');
     const description = getByLabelText('Description');
@@ -312,6 +311,35 @@ describe('AddAnnouncementPage', () => {
         await waitFor(() => {
           expect(
             getByText('Link display name is required.'),
+          ).toBeInTheDocument();
+        });
+      });
+    });
+    describe('link link url is more than 255 characters', () => {
+      it('should show error message', async () => {
+        const { getByRole, getByLabelText, getByText } = await wrappedRender();
+        const saveButton = getByRole('button', { name: 'Save' });
+        const title = getByLabelText('Title');
+        const description = getByLabelText('Description');
+        const linkUrl = getByLabelText('Link URL');
+        const displayLinkAs = getByLabelText('Display URL As');
+        await fireEvent.update(title, 'Test Title');
+        await fireEvent.update(description, 'Test Description');
+        const publishOn = getByLabelText('Publish On');
+        const publishDate = formatDate(LocalDate.now());
+        await setDate(publishOn, () => {
+          return getByLabelText(publishDate);
+        });
+        const noExpiry = getByRole('checkbox', { name: 'No expiry' });
+        await fireEvent.update(linkUrl, 'https://' + 'x'.repeat(255));
+        await fireEvent.update(displayLinkAs, 'a');
+        await markAsPublish();
+        await fireEvent.click(saveButton);
+        await waitFor(() => {
+          expect(
+            getByText(
+              'URL max length is 255 characters. Please shorten the URL.',
+            ),
           ).toBeInTheDocument();
         });
       });

--- a/admin-frontend/src/components/announcements/AnnouncementForm.vue
+++ b/admin-frontend/src/components/announcements/AnnouncementForm.vue
@@ -197,8 +197,18 @@
                       placeholder="https://example.com"
                       label="https://example.com"
                       aria-label="Link URL"
+                      counter
                       :error-messages="errors.linkUrl"
-                    ></v-text-field>
+                    >
+                      <template #counter="{ value }">
+                        <span
+                          :class="{
+                            'text-error': linkUrlRef && !linkUrlRef?.isValid,
+                          }"
+                          >{{ value }}/255</span
+                        >
+                      </template>
+                    </v-text-field>
                   </v-col>
                   <v-col cols="12">
                     <span
@@ -217,6 +227,8 @@
                       placeholder="eg. Pay Transparency in B.C."
                       label="eg. Pay Transparency in B.C."
                       aria-label="Display URL As"
+                      counter
+                      maxlength="100"
                       :error-messages="errors.linkDisplayName"
                     ></v-text-field>
                   </v-col>
@@ -267,6 +279,8 @@
                       placeholder="eg. Updated Pay Transparency Guidance Document"
                       label="eg. Updated Pay Transparency Guidance Document"
                       aria-label="Display File Link As"
+                      counter
+                      maxlength="100"
                       :error-messages="errors.fileDisplayName"
                     ></v-text-field>
                   </v-col>
@@ -451,6 +465,9 @@ const { handleSubmit, setErrors, errors, meta, values } = useForm({
       if (value && !zod.string().url().safeParse(value).success) {
         return 'Invalid URL.';
       }
+
+      if (value.length > 255)
+        return 'URL max length is 255 characters. Please shorten the URL.';
 
       return true;
     },

--- a/admin-frontend/src/components/announcements/AnnouncementForm.vue
+++ b/admin-frontend/src/components/announcements/AnnouncementForm.vue
@@ -466,7 +466,7 @@ const { handleSubmit, setErrors, errors, meta, values } = useForm({
         return 'Invalid URL.';
       }
 
-      if (value.length > 255)
+      if (value && value.length > 255)
         return 'URL max length is 255 characters. Please shorten the URL.';
 
       return true;

--- a/admin-frontend/src/components/announcements/__tests__/AnnouncementForm.spec.ts
+++ b/admin-frontend/src/components/announcements/__tests__/AnnouncementForm.spec.ts
@@ -79,4 +79,13 @@ describe('AnnouncementItem - Vue Test Utils tests', () => {
       });
     });
   });
+
+  describe('Link Url', () => {
+    it('should display the length and max length even if it is too long', async () => {
+      const longUrl = 'http://' + 'x'.repeat(255);
+      const test = wrapper.findComponent({ ref: 'linkUrlRef' });
+      await test.setValue(longUrl);
+      expect(test.html()).toContain('>262/255<');
+    });
+  });
 });


### PR DESCRIPTION
https://finrms.atlassian.net/browse/GEO-1105

https://finrms.atlassian.net/browse/GEO-1110

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://pay-transparency-pr-718-frontend.apps.silver.devops.gov.bc.ca)
- [Admin Frontend](https://pay-transparency-pr-718-admin-frontend.apps.silver.devops.gov.bc.ca)
- [Backend external API console](https://pay-transparency-pr-718-backend-external.apps.silver.devops.gov.bc.ca/api/V1/docs)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/fin-pay-transparency/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/fin-pay-transparency/actions/workflows/merge.yml)