### PR TITLE
fix: update doc-gen-service to support puppeteer v23.x.x

### DIFF
--- a/backend/src/v1/services/report-service.ts
+++ b/backend/src/v1/services/report-service.ts
@@ -1214,6 +1214,7 @@ const reportService = {
             revision: true,
             is_unlocked: true,
             create_date: true,
+            update_date: true,
           },
           where: filters,
           orderBy: [

--- a/doc-gen-service/src/v1/services/doc-gen-service.spec.ts
+++ b/doc-gen-service/src/v1/services/doc-gen-service.spec.ts
@@ -120,6 +120,19 @@ describe('generateReport', () => {
       TEST_TIMEOUT_MS,
     );
   });
+  describe('when a pdf report is requested', () => {
+    it(
+      'returns a Buffer object',
+      async () => {
+        const report = await generateReport(
+          REPORT_FORMAT.PDF,
+          submittedReportData as any,
+        );
+        expect(report instanceof Buffer).toBeTruthy();
+      },
+      TEST_TIMEOUT_MS,
+    );
+  });
 });
 
 describe('buildEjsTemplate', () => {
@@ -250,8 +263,8 @@ describe('moveElementInto', () => {
         await puppeteerPage.close();
       }
 
-      expect(childrenOf1.length).toBe(0);
-      expect(childrenOf2.length).toBe(1);
+      expect(childrenOf1).toHaveLength(0);
+      expect(childrenOf2).toHaveLength(1);
     });
   });
 });

--- a/doc-gen-service/src/v1/services/doc-gen-service.ts
+++ b/doc-gen-service/src/v1/services/doc-gen-service.ts
@@ -321,7 +321,7 @@ const docGenServicePrivate = {
 
     // Organize all 'blocks' and their corresponding 'explanatory-notes'
     // into 'page' elements
-    for (let block of blocksToOrganize) {
+    for (const block of blocksToOrganize) {
       const isBlockEmpty = await docGenServicePrivate.isElementEmpty(
         puppeteerPage,
         block,
@@ -397,7 +397,7 @@ const docGenServicePrivate = {
       `.${docGenServicePrivate.STYLE_CLASSES.PAGE_CONTENT} .${docGenServicePrivate.STYLE_CLASSES.EXPLANATORY_NOTES}`,
     );
     if (allExplanatoryNotes?.length) {
-      for (let explanatoryNotes of allExplanatoryNotes) {
+      for (const explanatoryNotes of allExplanatoryNotes) {
         const blockExplanatoryNotes = await explanatoryNotes.$$(
           `.${docGenServicePrivate.STYLE_CLASSES.BLOCK_EXPLANATORY_NOTES}`,
         );
@@ -415,7 +415,7 @@ const docGenServicePrivate = {
       `.${docGenServicePrivate.STYLE_CLASSES.PAGE_CONTENT} .${docGenServicePrivate.STYLE_CLASSES.FOOTNOTES}`,
     );
     if (allFootnotes?.length) {
-      for (let footnotes of allFootnotes) {
+      for (const footnotes of allFootnotes) {
         const footnoteGroups = await footnotes.$$(
           `.${docGenServicePrivate.STYLE_CLASSES.FOOTNOTE_GROUP}`,
         );
@@ -911,8 +911,9 @@ async function generateReport(
         width: `${PDF_PAGE_SIZE_PIXELS.width}px`,
         height: `${PDF_PAGE_SIZE_PIXELS.height}px`,
       };
-      const pdf = await puppeteerPage.pdf(pdfOptions);
-      result = pdf;
+      const pdfAsByteArray = await puppeteerPage.pdf(pdfOptions);
+      const pdfAsBuffer = Buffer.from(pdfAsByteArray);
+      result = pdfAsBuffer;
     }
 
     if (!result) {

--- a/frontend/src/common/types/index.ts
+++ b/frontend/src/common/types/index.ts
@@ -10,6 +10,7 @@ export interface IReport {
   report_end_date: string;
   reporting_year: number;
   create_date: string;
+  update_date: string;
   is_unlocked: boolean;
   naics_code: string;
   report_status: string;

--- a/frontend/src/components/util/ReportsTable.vue
+++ b/frontend/src/components/util/ReportsTable.vue
@@ -9,13 +9,13 @@
     :loading="isLoading"
     loading-text="Loading reports..."
   >
-    <template v-slot:item="{ item }">
+    <template #item="{ item }">
       <tr>
         <td :data-testid="`reporting_year-${item.report_id}`">
           {{ item.reporting_year }}
         </td>
         <td :data-testid="`report_published_date-${item.report_id}`">
-          {{ formatDateTime(item.create_date) }}
+          {{ formatDateTime(item.update_date) }}
         </td>
         <td class="actions">
           <v-btn
@@ -66,7 +66,7 @@ const headers: any = [
   { title: 'Reporting Year', key: 'reporting_year', sortable: false },
   {
     title: 'Submission Date',
-    key: 'create_date',
+    key: 'update_date',
     sortable: false,
   },
   { title: 'Action', sortable: false, key: 'actions', align: 'end' },

--- a/frontend/src/components/util/__tests__/ReportsTable.spec.ts
+++ b/frontend/src/components/util/__tests__/ReportsTable.spec.ts
@@ -1,9 +1,9 @@
-import { expect, describe, it, vi, beforeEach } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { render, waitFor, fireEvent } from '@testing-library/vue';
-import { createTestingPinia } from '@pinia/testing';
 import { DateTimeFormatter, LocalDate } from '@js-joda/core';
 import { Locale } from '@js-joda/locale_en';
+import { createTestingPinia } from '@pinia/testing';
+import { fireEvent, render, waitFor } from '@testing-library/vue';
 import { createVuetify } from 'vuetify';
 import * as components from 'vuetify/components';
 import * as directives from 'vuetify/directives';
@@ -17,17 +17,17 @@ const vuetify = createVuetify({
 const pinia = createTestingPinia();
 const mockRouterPush = vi.fn();
 vi.mock('vue-router', () => ({
-    useRouter: () => ({
-        push: mockRouterPush
-    })
-}))
+  useRouter: () => ({
+    push: mockRouterPush,
+  }),
+}));
 
 global.ResizeObserver = require('resize-observer-polyfill');
 
 const wrappedRender = async () => {
   return render(ReportsTable, {
     global: {
-      plugins: [pinia, vuetify]
+      plugins: [pinia, vuetify],
     },
   });
 };
@@ -55,6 +55,7 @@ describe('ReportsTable', () => {
         report_end_date: '2023-02-01',
         reporting_year: 2023,
         create_date: new Date().toISOString(),
+        update_date: new Date().toISOString(),
       },
     ]);
     const { getByTestId } = await wrappedRender();
@@ -76,6 +77,7 @@ describe('ReportsTable', () => {
         report_start_date: '2023-01-01',
         report_end_date: '2023-02-01',
         create_date: new Date().toISOString(),
+        update_date: new Date().toISOString(),
       },
     ]);
     const { getByTestId } = await wrappedRender();
@@ -93,6 +95,7 @@ describe('ReportsTable', () => {
         report_start_date: '2023-01-01',
         report_end_date: '2023-02-01',
         create_date: new Date().toISOString(),
+        update_date: new Date().toISOString(),
         is_unlocked: true,
       },
     ]);


### PR DESCRIPTION
# Description

Two changes: 

1. A recent renovate PR upgraded puppeteer from v22.13.0 to v23.0.0.  The new puppeteer introduced a breaking change to the PDF export function.  It now returns a byte array instead of a Buffer.  This PR converts the byte array returned by Puppeteer back into the Buffer, which is expected by the pay transparency code.

2. The "submission date" shown for reports on the public site dashboard now comes from 'updated_date' (instead of 'created date)

Fixes # [GEO-1114](https://finrms.atlassian.net/browse/GEO-1114)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

new unit test

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have already been accepted and merged


---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://pay-transparency-pr-719-frontend.apps.silver.devops.gov.bc.ca)
- [Admin Frontend](https://pay-transparency-pr-719-admin-frontend.apps.silver.devops.gov.bc.ca)
- [Backend external API console](https://pay-transparency-pr-719-backend-external.apps.silver.devops.gov.bc.ca/api/V1/docs)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/fin-pay-transparency/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/fin-pay-transparency/actions/workflows/merge.yml)

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://pay-transparency-pr-719-frontend.apps.silver.devops.gov.bc.ca)
- [Admin Frontend](https://pay-transparency-pr-719-admin-frontend.apps.silver.devops.gov.bc.ca)
- [Backend external API console](https://pay-transparency-pr-719-backend-external.apps.silver.devops.gov.bc.ca/api/V1/docs)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/fin-pay-transparency/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/fin-pay-transparency/actions/workflows/merge.yml)

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://pay-transparency-pr-719-frontend.apps.silver.devops.gov.bc.ca)
- [Admin Frontend](https://pay-transparency-pr-719-admin-frontend.apps.silver.devops.gov.bc.ca)
- [Backend external API console](https://pay-transparency-pr-719-backend-external.apps.silver.devops.gov.bc.ca/api/V1/docs)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/fin-pay-transparency/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/fin-pay-transparency/actions/workflows/merge.yml)