### PR TITLE
fix: Fetch announcement with the edit button is clicked

### DIFF
--- a/admin-frontend/src/components/announcements/AnnouncementActions.vue
+++ b/admin-frontend/src/components/announcements/AnnouncementActions.vue
@@ -53,12 +53,13 @@ import { useAnnouncementSelectionStore } from '../../store/modules/announcementS
 import { ref } from 'vue';
 import { NotificationService } from '../../services/notificationService';
 import { useRouter } from 'vue-router';
+import { Announcement } from '../../types/announcements';
 
 const router = useRouter();
 
 const announcementSelectionStore = useAnnouncementSelectionStore();
-const { announcement } = defineProps<{
-  announcement: any;
+const props = defineProps<{
+  announcement: Announcement;
 }>();
 
 const announcementSearchStore = useAnnouncementSearchStore();
@@ -116,8 +117,18 @@ async function unpublishAnnouncement(announcementId: string) {
   }
 }
 
-const editAnnouncement = () => {
-  announcementSelectionStore.setAnnouncement(announcement);
-  router.push('/edit-announcement');
+const editAnnouncement = async () => {
+  const { announcement_id } = props.announcement;
+  try {
+    const announcement = await ApiService.getAnnouncement(announcement_id);
+    announcementSelectionStore.setAnnouncement(announcement);
+    router.push(`/edit-announcement`);
+  } catch (e) {
+    console.error(e);
+    NotificationService.pushNotificationError(
+      'Error',
+      'An error occurred while trying to load the announcement.',
+    );
+  }
 };
 </script>

--- a/admin-frontend/src/components/announcements/__tests__/AnnouncementActions.spec.ts
+++ b/admin-frontend/src/components/announcements/__tests__/AnnouncementActions.spec.ts
@@ -5,6 +5,7 @@ import { createVuetify } from 'vuetify';
 import * as components from 'vuetify/components';
 import * as directives from 'vuetify/directives';
 import ApiService from '../../../services/apiService';
+import { NotificationService } from '../../../services/notificationService';
 import { Announcement } from '../../../types/announcements';
 import AnnouncementActions from '../AnnouncementActions.vue';
 
@@ -140,6 +141,38 @@ describe('AnnouncementActions', () => {
         await wrapper.vm.unpublishAnnouncement(announcementId);
 
         expect(apiSpy).toHaveBeenCalledTimes(0);
+      });
+    });
+  });
+
+  describe('edit announcement', () => {
+    it('sets the announcement to edit mode', async () => {
+      const apiSpy = vi
+        .spyOn(ApiService, 'getAnnouncement')
+        .mockImplementation(() => {
+          return Promise.resolve(mockDraftAnnouncement as any);
+        });
+      await wrapper.vm.editAnnouncement();
+
+      expect(apiSpy).toHaveBeenCalledWith(
+        mockDraftAnnouncement.announcement_id,
+      );
+    });
+
+    describe('when the announcement is not successfully retrieved', () => {
+      it('shows an error message', async () => {
+        vi.spyOn(ApiService, 'getAnnouncement').mockImplementation(() => {
+          return Promise.reject();
+        });
+
+        const errorSnackbarSpy = vi.spyOn(
+          NotificationService,
+          'pushNotificationError',
+        );
+
+        await wrapper.vm.editAnnouncement();
+
+        expect(errorSnackbarSpy).toHaveBeenCalled();
       });
     });
   });

--- a/admin-frontend/src/services/__tests__/apiService.spec.ts
+++ b/admin-frontend/src/services/__tests__/apiService.spec.ts
@@ -527,6 +527,34 @@ describe('ApiService', () => {
     });
   });
 
+  describe('getAnnouncement', () => {
+    it('returns an announcement', async () => {
+      const mockBackendResponse = { title: 'test' };
+      const mockAxiosResponse = {
+        data: mockBackendResponse,
+      };
+      vi.spyOn(ApiService.apiAxios, 'get').mockResolvedValueOnce(
+        mockAxiosResponse,
+      );
+
+      const resp = await ApiService.getAnnouncement('1');
+      expect(resp).toEqual(mockBackendResponse);
+    });
+
+    describe('when the data are not successfully retrieved from the backend', () => {
+      it('returns a rejected promise', async () => {
+        const mockAxiosError = new AxiosError();
+        vi.spyOn(ApiService.apiAxios, 'get').mockRejectedValueOnce(
+          mockAxiosError,
+        );
+
+        await expect(ApiService.getAnnouncement('1')).rejects.toEqual(
+          mockAxiosError,
+        );
+      });
+    });
+  });
+
   describe('clamavScanFile', () => {
     describe('when the given file is valid', () => {
       it('returns a response', async () => {

--- a/admin-frontend/src/services/apiService.ts
+++ b/admin-frontend/src/services/apiService.ts
@@ -7,6 +7,7 @@ import {
   UserInvite,
 } from '../types';
 import {
+  Announcement,
   AnnouncementFilterType,
   AnnouncementFormValue,
   AnnouncementSortType,
@@ -333,6 +334,25 @@ export default {
       throw new Error('Unexpected response from API.');
     } catch (e) {
       console.log(`Failed to unpublish announcement: ${e}`);
+      throw e;
+    }
+  },
+
+  async getAnnouncement(id: string) {
+    try {
+      const { data } = await apiAxios.get<
+        Announcement & {
+          announcement_resource: {
+            resource_type: string;
+            display_name: string;
+            resource_url: string;
+            attachment_file_id: string;
+          }[];
+        }
+      >(`${ApiRoutes.ANNOUNCEMENTS}/${id}`);
+      return data;
+    } catch (e) {
+      console.log(`Failed to get announcement from API - ${e}`);
       throw e;
     }
   },

--- a/backend/src/v1/routes/announcement-routes.spec.ts
+++ b/backend/src/v1/routes/announcement-routes.spec.ts
@@ -14,6 +14,7 @@ const mockGetAnnouncements = jest.fn().mockResolvedValue({
 const mockPatchAnnouncements = jest.fn();
 const mockCreateAnnouncement = jest.fn();
 const mockUpdateAnnouncement = jest.fn();
+const mockGetAnnouncementById = jest.fn();
 jest.mock('../services/announcements-service', () => ({
   getAnnouncements: (...args) => {
     return mockGetAnnouncements(...args);
@@ -21,6 +22,7 @@ jest.mock('../services/announcements-service', () => ({
   patchAnnouncements: (...args) => mockPatchAnnouncements(...args),
   createAnnouncement: (...args) => mockCreateAnnouncement(...args),
   updateAnnouncement: (...args) => mockUpdateAnnouncement(...args),
+  getAnnouncementById: (...args) => mockGetAnnouncementById(...args),
 }));
 
 jest.mock('../middlewares/authorization/authenticate-admin', () => ({
@@ -431,4 +433,22 @@ describe('announcement-routes', () => {
       });
     });
   });
+
+  describe('GET /:id - get announcement by id', () => {
+    it('should return 200', async () => {
+      const response = await request(app).get('/123');
+      expect(response.status).toBe(200);
+      expect(mockGetAnnouncementById).toHaveBeenCalledWith("123");
+    });
+
+    describe('when service throws error', () => {
+      it('should return 400', async () => {
+        mockGetAnnouncementById.mockRejectedValue(new Error('Invalid request'));
+        const response = await request(app).get('/123');
+
+        expect(response.status).toBe(400);
+        expect(response.body.error).toBeDefined();
+      });
+    });
+  })
 });

--- a/backend/src/v1/routes/announcement-routes.ts
+++ b/backend/src/v1/routes/announcement-routes.ts
@@ -1,4 +1,4 @@
-import { Router } from 'express';
+import { Request, Router } from 'express';
 import formData from 'express-form-data';
 import os from 'os';
 import { APP_ANNOUNCEMENTS_FOLDER } from '../../constants/admin';
@@ -9,6 +9,7 @@ import { useUpload } from '../middlewares/storage/upload';
 import { useValidate } from '../middlewares/validations';
 import {
   createAnnouncement,
+  getAnnouncementById,
   getAnnouncements,
   patchAnnouncements,
   updateAnnouncement,
@@ -136,5 +137,15 @@ router.put(
     }
   },
 );
+
+router.get('/:id', authenticateAdmin(), async (req: Request, res) => {
+  try {
+    const announcement = await getAnnouncementById(req.params.id);
+    return res.json(announcement);
+  } catch (error) {
+    logger.error(error);
+    res.status(400).json({ message: 'Invalid request', error });
+  }
+});
 
 export default router;

--- a/backend/src/v1/services/announcements-service.spec.ts
+++ b/backend/src/v1/services/announcements-service.spec.ts
@@ -45,6 +45,7 @@ jest.mock('../prisma/prisma-client', () => ({
       count: jest.fn().mockResolvedValue(2),
       updateMany: (...args) => mockUpdateMany(...args),
       create: (...args) => mockCreateAnnouncement(...args),
+      findUniqueOrThrow: (...args) => mockFindUniqueOrThrow(...args),
     },
     announcement_history: {
       create: (...args) => mockHistoryCreate(...args),
@@ -832,7 +833,7 @@ describe('AnnouncementsService', () => {
       });
     });
 
-    it('should default to undefined dates', async () => {
+    it('should default to null dates', async () => {
       mockFindUniqueOrThrow.mockResolvedValue({
         id: 'announcement-id',
         announcement_resource: [],
@@ -855,8 +856,8 @@ describe('AnnouncementsService', () => {
         expect.objectContaining({
           where: { announcement_id: 'announcement-id' },
           data: expect.objectContaining({
-            expires_on: undefined,
-            published_on: undefined,
+            expires_on: null,
+            published_on: null,
           }),
         }),
       );
@@ -909,6 +910,16 @@ describe('AnnouncementsService', () => {
           },
           status: AnnouncementStatus.Published,
         },
+      });
+    });
+  });
+
+  describe('getAnnouncementById', () => {
+    it('should return announcement by id', async () => {
+      await AnnouncementService.getAnnouncementById('1');
+      expect(mockFindUniqueOrThrow).toHaveBeenCalledWith({
+        where: { announcement_id: '1' },
+        include: { announcement_resource: true },
       });
     });
   });

--- a/backend/src/v1/services/announcements-service.ts
+++ b/backend/src/v1/services/announcements-service.ts
@@ -148,6 +148,22 @@ export const getAnnouncements = async (
 };
 
 /**
+ * Get announcement by id
+ * @param id
+ * @returns
+ */
+export const getAnnouncementById = async (id: string): Promise<announcement> => {
+  return prisma.announcement.findUniqueOrThrow({
+    where: {
+      announcement_id: id,
+    },
+    include: {
+      announcement_resource: true,
+    },
+  });
+}
+
+/**
  * Patch announcements by ids.
  * This method also copies the original record into the announcement history table.
  * @param data - array of objects with format:
@@ -411,8 +427,8 @@ export const updateAnnouncement = async (
       },
       published_on: !isEmpty(input.published_on)
         ? input.published_on
-        : undefined,
-      expires_on: !isEmpty(input.expires_on) ? input.expires_on : undefined,
+        : null,
+      expires_on: !isEmpty(input.expires_on) ? input.expires_on : null,
       admin_user_announcement_updated_byToadmin_user: {
         connect: { admin_user_id: currentUserId },
       },


### PR DESCRIPTION



# Description

The code changes in this commit add error handling for the case when the retrieval of an announcement fails. When the `editAnnouncement` function is called, it now makes an API request to retrieve the announcement using the `getAnnouncement` method from the `ApiService`. If the retrieval is successful, the announcement is set in the `announcementSelectionStore` and the user is redirected to the edit announcement page. However, if the retrieval fails, an error message is displayed using the `NotificationService`.

Fixes # ([issue](https://finrms.atlassian.net/browse/GEO-1085))

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)



## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have already been accepted and merged


## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://pay-transparency-pr-724-frontend.apps.silver.devops.gov.bc.ca)
- [Admin Frontend](https://pay-transparency-pr-724-admin-frontend.apps.silver.devops.gov.bc.ca)
- [Backend external API console](https://pay-transparency-pr-724-backend-external.apps.silver.devops.gov.bc.ca/api/V1/docs)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/fin-pay-transparency/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/fin-pay-transparency/actions/workflows/merge.yml)