### PR TITLE
fix: GEO-1098 datetime cleanups

### DIFF
--- a/backend/src/v1/services/admin-user-invites-service.ts
+++ b/backend/src/v1/services/admin-user-invites-service.ts
@@ -1,4 +1,4 @@
-import { convert, LocalDateTime, ZoneId } from '@js-joda/core';
+import { convert, ZonedDateTime, ZoneId } from '@js-joda/core';
 import { admin_user_onboarding } from '@prisma/client';
 import { config } from '../../config';
 import {
@@ -37,12 +37,12 @@ const createInvite = async (
     where: {
       email: email,
       is_onboarded: false,
-      expiry_date: { lte: convert(LocalDateTime.now(ZoneId.UTC)).toDate() },
+      expiry_date: { lte: convert(ZonedDateTime.now(ZoneId.UTC)).toDate() },
     },
   });
 
   const expiryDate = convert(
-    LocalDateTime.now(ZoneId.UTC).plusHours(
+    ZonedDateTime.now(ZoneId.UTC).plusHours(
       config.get('server:adminInvitationDurationInHours'),
     ),
   ).toDate();
@@ -93,7 +93,7 @@ const resendInvite = async (invitationId: string) => {
   );
 
   const expiryDate = convert(
-    LocalDateTime.now(ZoneId.UTC).plusHours(
+    ZonedDateTime.now(ZoneId.UTC).plusHours(
       config.get('server:adminInvitationDurationInHours'),
     ),
   ).toDate();

--- a/backend/src/v1/services/file-upload-service.spec.ts
+++ b/backend/src/v1/services/file-upload-service.spec.ts
@@ -7,13 +7,10 @@ import { SUBMISSION_ROW_COLUMNS } from './validate-service';
 import { createSampleRecord } from './validate-service.spec';
 const { mockRequest } = require('mock-req-res');
 
-const mockShouldPreventReportOverrides = jest.fn();
-
 jest.mock('./report-service', () => ({
   ...jest.requireActual('./report-service'),
   reportService: {
     ...jest.requireActual('./report-service').reportService,
-    shouldPreventReportOverrides: () => mockShouldPreventReportOverrides(),
   },
 }));
 
@@ -41,7 +38,7 @@ const mockValidSubmission = {
 
 jest.mock('./file-upload-service', () => {
   const actual = jest.requireActual('./file-upload-service');
-  const mocked = jest.genMockFromModule('./file-upload-service') as any;
+  const mocked = jest.createMockFromModule('./file-upload-service') as any;
 
   return {
     ...mocked,

--- a/backend/src/v1/services/report-service.spec.ts
+++ b/backend/src/v1/services/report-service.spec.ts
@@ -190,7 +190,7 @@ describe('getReportAndCalculations', () => {
         prisma.pay_transparency_calculated_data.findMany,
       ).toHaveBeenCalledTimes(1);
       expect(reportAndCalculations.report).toEqual(mockReportInDB);
-      expect(Object.keys(reportAndCalculations.calculations).length).toEqual(
+      expect(Object.keys(reportAndCalculations.calculations)).toHaveLength(
         mockCalculatedDatasInDB.length,
       );
     });
@@ -438,7 +438,7 @@ describe('getReportPdf', () => {
     });
   });
   describe('when an invalid report id and/or bceidBusinessGuid are provided', () => {
-    it('throws an error ', async () => {
+    it('throws an error', async () => {
       const mockReq = {
         session: {
           correlationID: 'mockCorrelationId',
@@ -1014,7 +1014,7 @@ describe('getReportById', () => {
         mockReportId,
         mockBceidBusinessGuid,
       );
-      expect(ret).toEqual(null);
+      expect(ret).toBeNull();
     });
   });
   describe('when an invalid reportId is passed, and bceidBusinessGuid is omitted', () => {
@@ -1023,7 +1023,7 @@ describe('getReportById', () => {
 
       mockReportFindFirst.mockResolvedValue(null);
       const ret = await reportService.getReportById(mockReportId);
-      expect(ret).toEqual(null);
+      expect(ret).toBeNull();
     });
   });
 });
@@ -1078,33 +1078,6 @@ describe('getReportFileName', () => {
         .spyOn(reportService, 'getReportById')
         .mockRejectedValueOnce(null);
       const invalidReportId = '66655fd3-22b7-4b9a-86de-2bfc0fcf2f2f';
-    });
-  });
-});
-
-describe('shouldPreventReportOverride', () => {
-  describe('when a published report exists for the same date period', () => {
-    it('should prevent override if the report is older than 30 days', async () => {
-      mockCompanyFindFirst.mockReturnValue({ company_id: '' });
-      mockReportFindFirst.mockReturnValue({ report_id: '' });
-      const result = await reportService.shouldPreventReportOverrides(
-        LocalDate.now(),
-        LocalDate.now(),
-        '',
-      );
-      expect(result).toBeTruthy();
-    });
-  });
-  describe('when a published report does not exist for the same date period', () => {
-    it('should not prevent override', async () => {
-      mockCompanyFindFirst.mockReturnValue({ company_id: '' });
-      mockReportFindFirst.mockReturnValue(undefined);
-      const result = await reportService.shouldPreventReportOverrides(
-        LocalDate.now(),
-        LocalDate.now(),
-        '',
-      );
-      expect(result).toBeFalsy();
     });
   });
 });

--- a/backend/src/v1/services/report-service.ts
+++ b/backend/src/v1/services/report-service.ts
@@ -15,7 +15,6 @@ import {
 } from '../../constants';
 import { logger } from '../../logger';
 import prisma from '../prisma/prisma-client';
-import { REPORT_STATUS } from './file-upload-service';
 import { CALCULATION_CODES, CalculatedAmount } from './report-calc-service';
 import { utils } from './utils-service';
 
@@ -1492,40 +1491,6 @@ const reportService = {
     } else {
       throw new Error(`No such report with reportId=${reportId}`);
     }
-  },
-
-  async shouldPreventReportOverrides(
-    startDate: LocalDate,
-    endDate: LocalDate,
-    bceidBusinessGuid: string,
-  ) {
-    const company = await prisma.pay_transparency_company.findFirst({
-      where: {
-        bceid_business_guid: bceidBusinessGuid,
-      },
-    });
-
-    const report = await prisma.pay_transparency_report.findFirst({
-      where: {
-        company_id: company.company_id,
-        report_status: REPORT_STATUS.PUBLISHED,
-        report_start_date: convert(startDate).toDate(),
-        report_end_date: convert(endDate).toDate(),
-        create_date: {
-          lt: convert(
-            LocalDate.now().minusDays(
-              config.get('server:reportEditDurationInDays'),
-            ),
-          ).toDate(),
-        },
-      },
-    });
-
-    if (report) {
-      return true;
-    }
-
-    return false;
   },
 };
 


### PR DESCRIPTION
# Description

- Fixed an timezone problem related to the expiry date of pending user invitations on the admin site.
- Removed a backend function in report-service that's no longer needed (it contained a suspicious datetime usage, but rather than fix the usage, it made more sense to remove the function).

Fixes # [GEO-1098](https://finrms.atlassian.net/browse/GEO-1098)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Existing unit tests

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have already been accepted and merged


---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://pay-transparency-pr-725-frontend.apps.silver.devops.gov.bc.ca)
- [Admin Frontend](https://pay-transparency-pr-725-admin-frontend.apps.silver.devops.gov.bc.ca)
- [Backend external API console](https://pay-transparency-pr-725-backend-external.apps.silver.devops.gov.bc.ca/api/V1/docs)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/fin-pay-transparency/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/fin-pay-transparency/actions/workflows/merge.yml)