### PR TITLE
fix: Update label from 'Publish On' to 'Active On' in AnnouncementsPage and Announcement Form

### DIFF
--- a/admin-frontend/src/components/AnnouncementsPage.vue
+++ b/admin-frontend/src/components/AnnouncementsPage.vue
@@ -202,7 +202,7 @@ const headers = ref<any>([
     key: AnnouncementKeys.TITLE,
   },
   {
-    title: 'Publish On',
+    title: 'Active On',
     align: 'start',
     sortable: true,
     key: AnnouncementKeys.PUBLISH_DATE,

--- a/admin-frontend/src/components/__tests__/AddAnnouncementPage.spec.ts
+++ b/admin-frontend/src/components/__tests__/AddAnnouncementPage.spec.ts
@@ -87,7 +87,7 @@ describe('AddAnnouncementPage', () => {
     expect(getByRole('button', { name: 'Save' })).toBeInTheDocument();
     expect(getByLabelText('Title')).toBeInTheDocument();
     expect(getByLabelText('Description')).toBeInTheDocument();
-    expect(getByLabelText('Publish On')).toBeInTheDocument();
+    expect(getByLabelText('Active On')).toBeInTheDocument();
     expect(getByLabelText('Expires On')).toBeInTheDocument();
     expect(getByRole('checkbox', { name: 'No expiry' })).toBeInTheDocument();
     expect(getByLabelText('Link URL')).toBeInTheDocument();
@@ -102,7 +102,7 @@ describe('AddAnnouncementPage', () => {
     const displayLinkAs = getByLabelText('Display URL As');
     await fireEvent.update(title, 'Test Title');
     await fireEvent.update(description, 'Test Description');
-    const publishOn = getByLabelText('Publish On');
+    const publishOn = getByLabelText('Active On');
     const publishDate = formatDate(LocalDate.now());
     await setDate(publishOn, () => {
       return getByLabelText(publishDate);
@@ -174,7 +174,7 @@ describe('AddAnnouncementPage', () => {
       await fireEvent.update(description, 'Test Description');
       await fireEvent.update(linkUrl, 'https://example.com');
       await fireEvent.update(displayLinkAs, 'Example.pdf');
-      const publishOn = getByLabelText('Publish On');
+      const publishOn = getByLabelText('Active On');
       const publishDate = formatDate(LocalDate.now());
       await setDate(publishOn, () => {
         return getByLabelText(publishDate);
@@ -197,7 +197,7 @@ describe('AddAnnouncementPage', () => {
     const displayLinkAs = getByLabelText('Display URL As');
     await fireEvent.update(title, 'Test Title');
     await fireEvent.update(description, 'Test Description');
-    const publishOn = getByLabelText('Publish On');
+    const publishOn = getByLabelText('Active On');
     const publishDate = formatDate(LocalDate.now());
     await setDate(publishOn, () => {
       return getByLabelText(publishDate);
@@ -298,7 +298,7 @@ describe('AddAnnouncementPage', () => {
         const linkUrl = getByLabelText('Link URL');
         await fireEvent.update(title, 'Test Title');
         await fireEvent.update(description, 'Test Description');
-        const publishOn = getByLabelText('Publish On');
+        const publishOn = getByLabelText('Active On');
         const publishDate = formatDate(LocalDate.now());
         await setDate(publishOn, () => {
           return getByLabelText(publishDate);
@@ -325,7 +325,7 @@ describe('AddAnnouncementPage', () => {
         const displayLinkAs = getByLabelText('Display URL As');
         await fireEvent.update(title, 'Test Title');
         await fireEvent.update(description, 'Test Description');
-        const publishOn = getByLabelText('Publish On');
+        const publishOn = getByLabelText('Active On');
         const publishDate = formatDate(LocalDate.now());
         await setDate(publishOn, () => {
           return getByLabelText(publishDate);
@@ -357,7 +357,7 @@ describe('AddAnnouncementPage', () => {
         const displayLinkAs = getByLabelText('Display URL As');
         await fireEvent.update(title, 'Test Title');
         await fireEvent.update(description, 'Test Description');
-        const publishOn = getByLabelText('Publish On');
+        const publishOn = getByLabelText('Active On');
         const publishDate = formatDate(LocalDate.now());
         await setDate(publishOn, () => {
           return getByLabelText(publishDate);
@@ -384,7 +384,7 @@ describe('AddAnnouncementPage', () => {
         const displayLinkAs = getByLabelText('Display URL As');
         await fireEvent.update(title, 'Test Title');
         await fireEvent.update(description, 'Test Description');
-        const publishOn = getByLabelText('Publish On');
+        const publishOn = getByLabelText('Active On');
         const publishDate = formatDate(LocalDate.now());
         await setDate(publishOn, () => {
           return getByLabelText(publishDate);
@@ -412,7 +412,7 @@ describe('AddAnnouncementPage', () => {
         const fileName = getByLabelText('Display File Link As');
         await fireEvent.update(title, 'Test Title');
         await fireEvent.update(description, 'Test Description');
-        const publishOn = getByLabelText('Publish On');
+        const publishOn = getByLabelText('Active On');
         const publishDate = formatDate(LocalDate.now());
         await setDate(publishOn, () => {
           return getByLabelText(publishDate);
@@ -440,7 +440,7 @@ describe('AddAnnouncementPage', () => {
         const displayLinkAs = getByLabelText('Display URL As');
         await fireEvent.update(title, 'Test Title');
         await fireEvent.update(description, 'Test Description');
-        const publishOn = getByLabelText('Publish On');
+        const publishOn = getByLabelText('Active On');
         const publishDate = formatDate(LocalDate.now());
         await setDate(publishOn, () => {
           return getByLabelText(publishDate);
@@ -531,7 +531,7 @@ describe('AddAnnouncementPage', () => {
       const displayLinkAs = getByLabelText('Display URL As');
       await fireEvent.update(title, 'Test Title');
       await fireEvent.update(description, 'Test Description');
-      const publishOn = getByLabelText('Publish On');
+      const publishOn = getByLabelText('Active On');
       const publishDate = formatDate(LocalDate.now());
       await setDate(publishOn, () => {
         return getByLabelText(publishDate);

--- a/admin-frontend/src/components/announcements/AnnouncementForm.vue
+++ b/admin-frontend/src/components/announcements/AnnouncementForm.vue
@@ -103,7 +103,7 @@
                         'text-error': errors.published_on != null,
                       }"
                     >
-                      Publish On
+                      Active On
                     </p>
                   </v-col>
                   <v-col cols="6">
@@ -114,7 +114,8 @@
                       :enable-time-picker="true"
                       arrow-navigation
                       auto-apply
-                      :aria-labels="{ input: 'Publish On' }"
+                      :disabled="announcement?.status === 'PUBLISHED'"
+                      :aria-labels="{ input: 'Active On' }"
                     >
                       <template #day="{ day, date }">
                         <span :aria-label="formatDate(date)">
@@ -489,6 +490,19 @@ const { handleSubmit, setErrors, errors, meta, values } = useForm({
     published_on(value) {
       if (!value && status.value === 'PUBLISHED') {
         return 'Publish date is required.';
+      }
+
+      return true;
+    },
+    expires_on(value) {
+      debugger
+      if (!value) {
+        return true;
+      }
+
+      const expiryDate = LocalDate.from(nativeJs(value));
+      if (expiryDate.isBefore(LocalDate.now())) {
+        return 'Expires On date cannot be in the past. Please choose another date.';
       }
 
       return true;


### PR DESCRIPTION

# Description

1. Change label from Publish On to Active On

1. Disable Active On when editing a published report

1. Expires On Date cannot be in the past

Fixes # ([issue](https://finrms.atlassian.net/browse/GEO-1113))

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)


## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have already been accepted and merged


## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://pay-transparency-pr-728-frontend.apps.silver.devops.gov.bc.ca)
- [Admin Frontend](https://pay-transparency-pr-728-admin-frontend.apps.silver.devops.gov.bc.ca)
- [Backend external API console](https://pay-transparency-pr-728-backend-external.apps.silver.devops.gov.bc.ca/api/V1/docs)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/fin-pay-transparency/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/fin-pay-transparency/actions/workflows/merge.yml)