### PR TITLE
fix: GEO-888 Change announcement expiry email to 14 days (10 business days)

### DIFF
--- a/backend/src/v1/services/announcements-service.spec.ts
+++ b/backend/src/v1/services/announcements-service.spec.ts
@@ -734,8 +734,8 @@ describe('AnnouncementsService', () => {
         );
       });
 
-      describe("and attachmentId is not provided in the input", () => {
-        it("should set attachment id to null", async () => {
+      describe('and attachmentId is not provided in the input', () => {
+        it('should set attachment id to null', async () => {
           const attachmentId = faker.string.uuid();
           mockFindUniqueOrThrow.mockResolvedValue({
             id: 'announcement-id',
@@ -894,10 +894,10 @@ describe('AnnouncementsService', () => {
     it('should return only announcements that will expire', async () => {
       jest
         .spyOn(ZonedDateTime, 'now')
-        .mockImplementationOnce((zone) =>
+        .mockImplementationOnce((zone: ZoneId) =>
           ZonedDateTime.of(
             LocalDateTime.parse('2024-08-26T11:38:23.561'),
-            zone as ZoneId,
+            zone,
           ),
         );
       await AnnouncementService.getExpiringAnnouncements();
@@ -905,8 +905,8 @@ describe('AnnouncementsService', () => {
       expect(mockFindMany).toHaveBeenCalledWith({
         where: {
           expires_on: {
-            gte: new Date('2024-09-05T07:00:00.000Z'),
-            lt: new Date('2024-09-06T07:00:00.000Z'),
+            gte: new Date('2024-09-09T07:00:00.000Z'),
+            lt: new Date('2024-09-10T07:00:00.000Z'),
           },
           status: AnnouncementStatus.Published,
         },

--- a/backend/src/v1/services/announcements-service.ts
+++ b/backend/src/v1/services/announcements-service.ts
@@ -51,7 +51,7 @@ const buildAnnouncementWhereInput = (query: AnnouncementQueryType) => {
   const allFilters = [];
 
   if (query.filters) {
-    (query.filters as any[]).forEach((filter) => {
+    query.filters.forEach((filter) => {
       const attrFilter = {};
       switch (filter.key) {
         case 'active_on':
@@ -152,7 +152,9 @@ export const getAnnouncements = async (
  * @param id
  * @returns
  */
-export const getAnnouncementById = async (id: string): Promise<announcement> => {
+export const getAnnouncementById = async (
+  id: string,
+): Promise<announcement> => {
   return prisma.announcement.findUniqueOrThrow({
     where: {
       announcement_id: id,
@@ -161,7 +163,7 @@ export const getAnnouncementById = async (id: string): Promise<announcement> => 
       announcement_resource: true,
     },
   });
-}
+};
 
 /**
  * Patch announcements by ids.
@@ -425,9 +427,7 @@ export const updateAnnouncement = async (
       announcement_status: {
         connect: { code: input.status },
       },
-      active_on: !isEmpty(input.active_on)
-        ? input.active_on
-        : null,
+      active_on: !isEmpty(input.active_on) ? input.active_on : null,
       expires_on: !isEmpty(input.expires_on) ? input.expires_on : null,
       admin_user_announcement_updated_byToadmin_user: {
         connect: { admin_user_id: currentUserId },
@@ -479,7 +479,7 @@ export const expireAnnouncements = async () => {
 export const getExpiringAnnouncements = async (): Promise<announcement[]> => {
   const zone = ZoneId.of(config.get('server:schedulerTimeZone'));
   const targetDate = ZonedDateTime.now(zone)
-    .plusDays(10)
+    .plusDays(14)
     .withHour(0)
     .withMinute(0)
     .withSecond(0)


### PR DESCRIPTION
https://finrms.atlassian.net/browse/GEO-888

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://pay-transparency-pr-743-frontend.apps.silver.devops.gov.bc.ca)
- [Admin Frontend](https://pay-transparency-pr-743-admin-frontend.apps.silver.devops.gov.bc.ca)
- [Backend external API console](https://pay-transparency-pr-743-backend-external.apps.silver.devops.gov.bc.ca/api/V1/docs)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/fin-pay-transparency/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/fin-pay-transparency/actions/workflows/merge.yml)