### PR TITLE
fix: Set No Expiry checkbox to true if it was previously published with no expiry date

### DIFF
--- a/admin-frontend/src/components/__tests__/EditAnnouncementPage.spec.ts
+++ b/admin-frontend/src/components/__tests__/EditAnnouncementPage.spec.ts
@@ -85,6 +85,19 @@ describe('EditAnnouncementPage', () => {
         expect(queryByLabelText('Draft')).toBeNull();
       });
     });
+    describe('when announcement was previously published and no expiry date', () => {
+      it('No expiry should be checked', async () => {
+        store.setAnnouncement({
+          title: 'title',
+          description: 'description',
+          status: 'PUBLISHED',
+          announcement_resource: [],
+        } as any);
+        const { getByRole } = await wrappedRender();
+        const noExpiry = getByRole('checkbox', { name: 'No expiry' });
+        expect(noExpiry).toBeChecked();
+      });
+    });
     describe('when announcement is draft', () => {
       it('should display DRAFT and PUBLISH radio buttons', async () => {
         store.setAnnouncement({

--- a/admin-frontend/src/components/__tests__/EditAnnouncementPage.spec.ts
+++ b/admin-frontend/src/components/__tests__/EditAnnouncementPage.spec.ts
@@ -193,8 +193,6 @@ describe('EditAnnouncementPage', () => {
         expect(getByLabelText('Title')).toHaveValue('title');
         expect(getByLabelText('Description')).toHaveValue('description');
 
-        const noExpiry = getByRole('checkbox', { name: 'No expiry' });
-        await fireEvent.click(noExpiry);
         const saveButton = getByRole('button', { name: 'Save' });
         await fireEvent.click(saveButton);
         await waitFor(async () => {
@@ -457,8 +455,7 @@ describe('EditAnnouncementPage', () => {
         } as any);
         mockUpdateAnnouncement.mockRejectedValueOnce(new Error('error'));
         const { getByRole } = await wrappedRender();
-        const noExpiry = getByRole('checkbox', { name: 'No expiry' });
-        await fireEvent.click(noExpiry);
+        
         const saveButton = getByRole('button', { name: 'Save' });
 
         await fireEvent.click(saveButton);

--- a/admin-frontend/src/components/announcements/AnnouncementForm.vue
+++ b/admin-frontend/src/components/announcements/AnnouncementForm.vue
@@ -170,7 +170,7 @@
                   <v-checkbox
                     v-model="noExpiry"
                     class="expiry-checkbox"
-                    label="No expiry"
+                    label="No expiry" 
                   ></v-checkbox>
                 </v-col>
               </v-row>
@@ -433,7 +433,7 @@ const { handleSubmit, setErrors, errors, meta, values } = useForm({
     expires_on: announcement?.expires_on
       ? new Date(announcement?.expires_on) //VueDatePicker is initialized with a Date()
       : undefined,
-    no_expiry: undefined,
+    no_expiry: !announcement?.expires_on && announcement?.status === 'PUBLISHED',
     linkUrl: announcement?.linkUrl || '',
     linkDisplayName: announcement?.linkDisplayName || '',
     fileDisplayName: announcement?.fileDisplayName || '',


### PR DESCRIPTION
# Description

Set No Expiry checkbox to true if it was previously published with no expiry date

Fixes # ([issue](https://finrms.atlassian.net/browse/GEO-1133))

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have already been accepted and merged


## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://pay-transparency-pr-745-frontend.apps.silver.devops.gov.bc.ca)
- [Admin Frontend](https://pay-transparency-pr-745-admin-frontend.apps.silver.devops.gov.bc.ca)
- [Backend external API console](https://pay-transparency-pr-745-backend-external.apps.silver.devops.gov.bc.ca/api/V1/docs)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/fin-pay-transparency/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/fin-pay-transparency/actions/workflows/merge.yml)