### PR TITLE
feat: disable announcement expiry notifications in dev

### DIFF
--- a/charts/fin-pay-transparency/values-dev.yaml
+++ b/charts/fin-pay-transparency/values-dev.yaml
@@ -48,7 +48,7 @@ global:
     lock_report_cron_crontime: "15 0 * * *" # 12:15 AM PST/PDT
     expire_announcements_cron_crontime: "0 6,18 * * *" # 6am & 6pm daily
     email_expiring_announcements_cron_crontime: "0 7 * * *" # 7:00 AM PST/PDT
-    enable_email_expiring_announcements: true
+    enable_email_expiring_announcements: "false"
     reports_scheduler_cron_timezone: "America/Vancouver"
     first_year_with_prev_reporting_year_option: "2025"
     admin_invitation_duration_in_hours: "72"

--- a/charts/fin-pay-transparency/values-prod.yaml
+++ b/charts/fin-pay-transparency/values-prod.yaml
@@ -48,7 +48,7 @@ global:
     lock_report_cron_crontime: "15 0 * * *" # 12:15 AM PST/PDT
     expire_announcements_cron_crontime: "0 6,18 * * *" # 6am & 6pm daily
     email_expiring_announcements_cron_crontime: "0 7 * * *" # 7:00 AM PST/PDT
-    enable_email_expiring_announcements: true
+    enable_email_expiring_announcements: "true"
     reports_scheduler_cron_timezone: "America/Vancouver"
     first_year_with_prev_reporting_year_option: "2025"
     admin_invitation_duration_in_hours: "72"

--- a/charts/fin-pay-transparency/values-test.yaml
+++ b/charts/fin-pay-transparency/values-test.yaml
@@ -48,7 +48,7 @@ global:
     lock_report_cron_crontime: "15 0 * * *" # 12:15 AM PST/PDT
     expire_announcements_cron_crontime: "0 6,18 * * *" # 6am & 6pm daily
     email_expiring_announcements_cron_crontime: "0 7 * * *" # 7:00 AM PST/PDT
-    enable_email_expiring_announcements: true
+    enable_email_expiring_announcements: "true"
     reports_scheduler_cron_timezone: "America/Vancouver"
     first_year_with_prev_reporting_year_option: "2025"
     admin_invitation_duration_in_hours: "72"

--- a/charts/fin-pay-transparency/values.yaml
+++ b/charts/fin-pay-transparency/values.yaml
@@ -49,7 +49,7 @@ global:
     lock_report_cron_crontime: "15 0 * * *" # 12:15 AM PST/PDT
     expire_announcements_cron_crontime: "0 6,18 * * *" # 6am & 6pm daily
     email_expiring_announcements_cron_crontime: "0 7 * * *" # 7:00 AM PST/PDT
-    enable_email_expiring_announcements: true
+    enable_email_expiring_announcements: "true"
     reports_scheduler_cron_timezone: "America/Vancouver"
     first_year_with_prev_reporting_year_option: "2025"
     admin_invitation_duration_in_hours: "72"


### PR DESCRIPTION
Testing of this feature is done in Dev, so we don't need daily email spam.

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://pay-transparency-pr-750-frontend.apps.silver.devops.gov.bc.ca)
- [Admin Frontend](https://pay-transparency-pr-750-admin-frontend.apps.silver.devops.gov.bc.ca)
- [Backend external API console](https://pay-transparency-pr-750-backend-external.apps.silver.devops.gov.bc.ca/api/V1/docs)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/fin-pay-transparency/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/fin-pay-transparency/actions/workflows/merge.yml)