### PR TITLE
fix: fix for frontend announcement having access to ALL states

### DIFF
--- a/admin-frontend/src/components/announcements/AnnouncementForm.vue
+++ b/admin-frontend/src/components/announcements/AnnouncementForm.vue
@@ -108,22 +108,28 @@
                   >
                     Active On
                   </span>
-                  <VueDatePicker
-                    v-model="activeOn"
-                    :state="errors.active_on == null ? undefined : false"
-                    format="yyyy-MM-dd hh:mm a"
-                    :enable-time-picker="true"
-                    arrow-navigation
-                    auto-apply
-                    :disabled="announcement?.status === 'PUBLISHED'"
-                    :aria-labels="{ input: 'Active On' }"
+                  <v-input
+                    variant="outlined"
+                    label="Active On"
+                    placeholder="Active On"
                   >
-                    <template #day="{ day, date }">
-                      <span :aria-label="formatDate(date)">
-                        {{ day }}
-                      </span>
-                    </template>
-                  </VueDatePicker>
+                    <VueDatePicker
+                      v-model="activeOn"
+                      :state="errors.active_on == null ? undefined : false"
+                      format="yyyy-MM-dd hh:mm a"
+                      :enable-time-picker="true"
+                      arrow-navigation
+                      auto-apply
+                      :disabled="announcement?.status === 'PUBLISHED'"
+                      :aria-labels="{ input: 'Active On' }"
+                    >
+                      <template #day="{ day, date }">
+                        <span :aria-label="formatDate(date)">
+                          {{ day }}
+                        </span>
+                      </template>
+                    </VueDatePicker>
+                  </v-input>
                 </v-col>
               </v-row>
               <v-row dense class="mt-0">
@@ -170,7 +176,7 @@
                   <v-checkbox
                     v-model="noExpiry"
                     class="expiry-checkbox"
-                    label="No expiry" 
+                    label="No expiry"
                   ></v-checkbox>
                 </v-col>
               </v-row>
@@ -437,7 +443,8 @@ const { handleSubmit, setErrors, errors, meta, values } = useForm({
     expires_on: announcement?.expires_on
       ? new Date(announcement?.expires_on) //VueDatePicker is initialized with a Date()
       : undefined,
-    no_expiry: !announcement?.expires_on && announcement?.status === 'PUBLISHED',
+    no_expiry:
+      !announcement?.expires_on && announcement?.status === 'PUBLISHED',
     linkUrl: announcement?.linkUrl || '',
     linkDisplayName: announcement?.linkDisplayName || '',
     fileDisplayName: announcement?.fileDisplayName || '',

--- a/backend/src/v1/middlewares/authorization/authenticate-admin.spec.ts
+++ b/backend/src/v1/middlewares/authorization/authenticate-admin.spec.ts
@@ -97,7 +97,7 @@ describe('authenticateAdmin', () => {
           preferred_username: 'username',
         },
       });
-      mockFindFirst.mockResolvedValue({});
+      mockFindFirst.mockResolvedValue(null);
       await middleware(req, res, next);
       expect(req.user?.admin_user_id).toBeFalsy();
       expect(next).toHaveBeenCalled();

--- a/backend/src/v1/middlewares/authorization/authenticate-admin.spec.ts
+++ b/backend/src/v1/middlewares/authorization/authenticate-admin.spec.ts
@@ -18,7 +18,7 @@ describe('authenticateAdmin', () => {
   let next: any;
 
   beforeEach(() => {
-    jest.clearAllMocks
+    jest.clearAllMocks;
     jest.resetModules();
     req = {};
     res = {
@@ -30,7 +30,7 @@ describe('authenticateAdmin', () => {
 
   it('should return 401 if no session data', async () => {
     const middleware = await authenticateAdmin();
-    middleware(req, res, next);
+    await middleware(req, res, next);
     expect(res.status).toHaveBeenCalledWith(401);
     expect(res.json).toHaveBeenCalledWith({
       message: 'No session data',
@@ -75,5 +75,32 @@ describe('authenticateAdmin', () => {
       },
     });
     expect(next).toHaveBeenCalled();
+  });
+
+  describe('strict is false', () => {
+    it('should not set req.user if no session data', async () => {
+      const middleware = await authenticateAdmin(false);
+      mockGetSessionUser.mockReturnValue({});
+      mockFindFirst.mockResolvedValue({
+        admin_user_id: 1,
+      });
+      await middleware(req, res, next);
+      expect(req.user).toBeFalsy();
+      expect(next).toHaveBeenCalled();
+    });
+
+    it('should not set req.user.admin_user_id if not in admin table', async () => {
+      const middleware = await authenticateAdmin(false);
+      mockGetSessionUser.mockReturnValue({
+        jwt: 'jwt',
+        _json: {
+          preferred_username: 'username',
+        },
+      });
+      mockFindFirst.mockResolvedValue({});
+      await middleware(req, res, next);
+      expect(req.user?.admin_user_id).toBeFalsy();
+      expect(next).toHaveBeenCalled();
+    });
   });
 });

--- a/backend/src/v1/middlewares/authorization/authenticate-admin.ts
+++ b/backend/src/v1/middlewares/authorization/authenticate-admin.ts
@@ -6,7 +6,7 @@ import prisma from '../../prisma/prisma-client';
 
 /**
  * Middleware to authenticate admin users
- * @param strict If strict is false, the function continues the middleware chane.
+ * @param strict If strict is false, then it is okay to continue even if the user isn't an admin.
  * @returns
  */
 export const authenticateAdmin = (strict: boolean = true) => {

--- a/backend/src/v1/middlewares/validations/index.ts
+++ b/backend/src/v1/middlewares/validations/index.ts
@@ -11,10 +11,9 @@ export const useValidate = ({ mode, schema }: UseValidateOptions) => {
   return async (req: Request, res: Response, next: NextFunction) => {
     try {
       const data = req[mode];
-      console.log(data);
       const results = await schema.parseAsync(data);
       req[mode] = results;
-      next()
+      next();
     } catch (error) {
       logger.error(error);
       return next(error);

--- a/backend/src/v1/routes/announcement-routes.ts
+++ b/backend/src/v1/routes/announcement-routes.ts
@@ -36,6 +36,8 @@ router.get(
   async (req: SsoRequest, res, next) => {
     if (!req?.user?.admin_user_id) {
       // If this is not an admin user, then it is a public user and they are strictly limited to what they can do
+      req.query = {}; // remove all existing query params
+      req.params = {}; // remove all url params (shouldn't be any anyways)
       const now = ZonedDateTime.now().format(DateTimeFormatter.ISO_DATE_TIME);
       req.query.filters = [
         {
@@ -55,6 +57,8 @@ router.get(
         },
       ];
       req.query.sort = [{ field: 'updated_date', order: 'desc' }];
+      req.query.offset = 0;
+      req.query.limit = 100;
     }
     next();
   },

--- a/backend/src/v1/routes/announcement-routes.ts
+++ b/backend/src/v1/routes/announcement-routes.ts
@@ -24,11 +24,40 @@ import {
   PatchAnnouncementsType,
 } from '../types/announcements';
 import { omit } from 'lodash';
+import { DateTimeFormatter, ZonedDateTime } from '@js-joda/core';
 
 const router = Router();
 
+type SsoRequest = ExtendedRequest & { query: AnnouncementQueryType };
+
 router.get(
   '',
+  authenticateAdmin(false),
+  async (req: SsoRequest, res, next) => {
+    if (!req?.user?.admin_user_id) {
+      // If this is not an admin user, then it is a public user and they are strictly limited to what they can do
+      const now = ZonedDateTime.now().format(DateTimeFormatter.ISO_DATE_TIME);
+      req.query.filters = [
+        {
+          key: 'status',
+          operation: 'in',
+          value: ['PUBLISHED'],
+        },
+        {
+          key: 'active_on',
+          operation: 'lte',
+          value: now,
+        },
+        {
+          key: 'expires_on',
+          operation: 'gt',
+          value: now,
+        },
+      ];
+      req.query.sort = [{ field: 'updated_date', order: 'desc' }];
+    }
+    next();
+  },
   useValidate({ mode: 'query', schema: AnnouncementQuerySchema }),
   async (req, res) => {
     try {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -2339,17 +2339,6 @@
         "cldr-data-downloader": "bin/download.sh"
       }
     },
-    "node_modules/cldr-data-downloader/node_modules/axios": {
-      "version": "1.7.6",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.6.tgz",
-      "integrity": "sha512-Ekur6XDwhnJ5RgOCaxFnXyqlPALI3rVeukZMwOdfghW7/wGz784BYKiQq+QD8NPcr91KRo30KfHOchyijwWw7g==",
-      "peer": true,
-      "dependencies": {
-        "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.0",
-        "proxy-from-env": "^1.1.0"
-      }
-    },
     "node_modules/cldrjs": {
       "version": "0.5.5",
       "resolved": "https://registry.npmjs.org/cldrjs/-/cldrjs-0.5.5.tgz",

--- a/frontend/src/common/__tests__/apiService.spec.ts
+++ b/frontend/src/common/__tests__/apiService.spec.ts
@@ -448,15 +448,10 @@ describe('ApiService', () => {
         const mockAxiosResponse = {
           data: mockBackendResponse,
         };
-        const axiosGetSpy = vi
-          .spyOn(ApiService.apiAxios, 'get')
-          .mockResolvedValueOnce(mockAxiosResponse);
-        const offset = 1;
-        const limit = 2;
-        const resp = await ApiService.getAnnouncements(offset, limit);
-        const queryParamsToBackend: any = axiosGetSpy.mock.calls[0][1];
-        expect(queryParamsToBackend.params.offset).toBe(offset);
-        expect(queryParamsToBackend.params.limit).toBe(limit);
+        vi.spyOn(ApiService.apiAxios, 'get').mockResolvedValueOnce(
+          mockAxiosResponse,
+        );
+        const resp = await ApiService.getAnnouncements();
         expect(resp).toEqual(mockBackendResponse);
       });
     });
@@ -466,9 +461,7 @@ describe('ApiService', () => {
         vi.spyOn(ApiService.apiAxios, 'get').mockRejectedValueOnce(
           mockAxiosError,
         );
-        expect(ApiService.getAnnouncements(1, 2)).rejects.toEqual(
-          mockAxiosError,
-        );
+        expect(ApiService.getAnnouncements()).rejects.toEqual(mockAxiosError);
       });
     });
   });

--- a/frontend/src/common/__tests__/apiService.spec.ts
+++ b/frontend/src/common/__tests__/apiService.spec.ts
@@ -453,17 +453,8 @@ describe('ApiService', () => {
           .mockResolvedValueOnce(mockAxiosResponse);
         const offset = 1;
         const limit = 2;
-        const filter = [];
-        const sort = [];
-        const resp = await ApiService.getAnnouncements(
-          offset,
-          limit,
-          filter,
-          sort,
-        );
+        const resp = await ApiService.getAnnouncements(offset, limit);
         const queryParamsToBackend: any = axiosGetSpy.mock.calls[0][1];
-        expect(queryParamsToBackend.params.sort).toBe(sort);
-        expect(queryParamsToBackend.params.filters).toBe(filter);
         expect(queryParamsToBackend.params.offset).toBe(offset);
         expect(queryParamsToBackend.params.limit).toBe(limit);
         expect(resp).toEqual(mockBackendResponse);
@@ -475,49 +466,9 @@ describe('ApiService', () => {
         vi.spyOn(ApiService.apiAxios, 'get').mockRejectedValueOnce(
           mockAxiosError,
         );
-        expect(ApiService.getAnnouncements(1, 2, [], [])).rejects.toEqual(
+        expect(ApiService.getAnnouncements(1, 2)).rejects.toEqual(
           mockAxiosError,
         );
-      });
-    });
-  });
-
-  describe('getPublishedAnnouncements', () => {
-    it('request filters by status, active_on and expired_on', async () => {
-      const mockTimeNow = '1234';
-      const dateSpy = vi
-        .spyOn(ApiServicePrivate, 'dateToApiDateTimeString')
-        .mockReturnValue(mockTimeNow);
-      const getAnnouncementsSpy = vi
-        .spyOn(ApiService, 'getAnnouncements')
-        .mockResolvedValue({ items: [], total: 0 });
-      await ApiService.getPublishedAnnouncements();
-
-      const filter = getAnnouncementsSpy.mock.calls[0][2];
-      const statusFilter = filter?.filter((f) => f.key == 'status');
-      const activeOnFilter: any = filter?.filter(
-        (f) => f.key == 'active_on',
-      )[0];
-      const expiresOnFilter: any = filter?.filter(
-        (f) => f.key == 'expires_on',
-      )[0];
-      expect(dateSpy).toHaveBeenCalled();
-      expect(statusFilter).toStrictEqual([
-        {
-          key: 'status',
-          operation: 'in',
-          value: [AnnouncementStatus.Published],
-        },
-      ]);
-      expect(activeOnFilter).toStrictEqual({
-        key: 'active_on',
-        operation: 'lte',
-        value: mockTimeNow,
-      });
-      expect(expiresOnFilter).toStrictEqual({
-        key: 'expires_on',
-        operation: 'gt',
-        value: mockTimeNow,
       });
     });
   });

--- a/frontend/src/common/apiService.ts
+++ b/frontend/src/common/apiService.ts
@@ -280,24 +280,14 @@ export default {
   },
 
   async getPublishedAnnouncements(): Promise<Announcement[]> {
-    const result = await this.getAnnouncements(0, 100);
+    const result = await this.getAnnouncements();
     return result?.items;
   },
 
-  async getAnnouncements(
-    offset: number = 0,
-    limit: number = 20,
-  ): Promise<IAnnouncementSearchResult> {
+  async getAnnouncements(): Promise<IAnnouncementSearchResult> {
     try {
-      const params = {
-        offset: offset,
-        limit: limit,
-      };
       const resp = await apiAxios.get<IAnnouncementSearchResult>(
         ApiRoutes.ANNOUNCEMENTS,
-        {
-          params: params,
-        },
       );
       if (resp?.data) {
         return resp.data;

--- a/frontend/src/common/apiService.ts
+++ b/frontend/src/common/apiService.ts
@@ -3,8 +3,6 @@ import axios from 'axios';
 import { saveAs } from 'file-saver';
 import {
   Announcement,
-  AnnouncementFilterType,
-  AnnouncementSortType,
   IAnnouncementSearchResult,
 } from '../types/announcements';
 import { ApiRoutes } from '../utils/constant';
@@ -282,49 +280,18 @@ export default {
   },
 
   async getPublishedAnnouncements(): Promise<Announcement[]> {
-    const now: string = ApiServicePrivate.dateToApiDateTimeString(new Date());
-    const filters: AnnouncementFilterType = [
-      {
-        key: 'status',
-        operation: 'in',
-        value: ['PUBLISHED'],
-      },
-      {
-        key: 'active_on',
-        operation: 'lte',
-        value: now,
-      },
-      {
-        key: 'expires_on',
-        operation: 'gt',
-        value: now,
-      },
-    ];
-    const sort: AnnouncementSortType = [
-      { field: 'updated_date', order: 'desc' },
-    ];
-    const result = await this.getAnnouncements(0, 100, filters, sort);
+    const result = await this.getAnnouncements(0, 100);
     return result?.items;
   },
 
   async getAnnouncements(
     offset: number = 0,
     limit: number = 20,
-    filter: AnnouncementFilterType | null = null,
-    sort: AnnouncementSortType | null = null,
   ): Promise<IAnnouncementSearchResult> {
     try {
-      if (!filter) {
-        filter = [];
-      }
-      if (!sort) {
-        sort = [{ field: 'active_on', order: 'asc' }];
-      }
       const params = {
         offset: offset,
         limit: limit,
-        filters: filter,
-        sort: sort,
       };
       const resp = await apiAxios.get<IAnnouncementSearchResult>(
         ApiRoutes.ANNOUNCEMENTS,
@@ -341,6 +308,7 @@ export default {
       throw e;
     }
   },
+
   async downloadFile(fileId: string) {
     try {
       const { data, headers } = await apiAxios.get(
@@ -349,10 +317,10 @@ export default {
           responseType: 'blob',
         },
       );
-      let name = headers['content-disposition']
+      const name = headers['content-disposition']
         .split('filename="')[1]
         .split('.')[0];
-      let extension = headers['content-disposition']
+      const extension = headers['content-disposition']
         .split('.')[1]
         .split('"')[0];
 

--- a/frontend/src/types/announcements.ts
+++ b/frontend/src/types/announcements.ts
@@ -36,8 +36,6 @@ export interface IAnnouncementSearchUpdateParams {
 export interface IAnnouncementSearchParams {
   page?: number;
   itemsPerPage?: number;
-  filter?: AnnouncementFilterType;
-  sort?: AnnouncementSortType;
 }
 
 export enum AnnouncementKeys {

--- a/frontend/src/types/announcements.ts
+++ b/frontend/src/types/announcements.ts
@@ -36,6 +36,8 @@ export interface IAnnouncementSearchUpdateParams {
 export interface IAnnouncementSearchParams {
   page?: number;
   itemsPerPage?: number;
+  filter?: AnnouncementFilterType;
+  sort?: AnnouncementSortType;
 }
 
 export enum AnnouncementKeys {


### PR DESCRIPTION
Problem: The frontend (frontend/src/common/apiService.ts) has the ability to query any status from the announcement table. Currently it specifies that only published results should be shown, but a malicious user could inject some JavaScript in this page to show expired, deleted, or draft statuses. This is because the frontend and admin-frontend share the same route (backend/src/v1/routes/announcement-routes.ts) so anything that the admin-frontend can do, so can the frontend.

Solution: I added some logic in the backend route that if the request is coming from the public site, then it will overwrite the 'filters' and 'sort' part of the query preventing public users from having access to those.

Alternative: an alternative way of handling this would be to create a new announcement-route just for the frontend instead of both the frontend and admin-frontend sharing the same route.

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://pay-transparency-pr-754-frontend.apps.silver.devops.gov.bc.ca)
- [Admin Frontend](https://pay-transparency-pr-754-admin-frontend.apps.silver.devops.gov.bc.ca)
- [Backend external API console](https://pay-transparency-pr-754-backend-external.apps.silver.devops.gov.bc.ca/api/V1/docs)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/fin-pay-transparency/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/fin-pay-transparency/actions/workflows/merge.yml)