### PR TITLE
feat: geo 1049 dashboard public announcements panel

### DIFF
--- a/admin-frontend/src/components/DashboardPage.vue
+++ b/admin-frontend/src/components/DashboardPage.vue
@@ -57,9 +57,18 @@
       <RecentlyViewedReports ref="recentlyViewedReports" />
     </v-col>
     <v-col sm="12" md="12" lg="5" xl="4">
-      <h4 class="mb-4">
+      <h4 class="mb-4 d-flex align-center">
         <v-icon icon="mdi-bullhorn"></v-icon>
         Public Announcements
+        <span class="flex-fill"></span>
+        <v-btn
+          variant="plain"
+          to="/announcements"
+          class="btn-link d-flex align-center text-subtitle-1"
+          size="x-small"
+          append-icon="mdi-chevron-right"
+          >Go to edit
+        </v-btn>
       </h4>
       <PublicAnnouncements ref="publicAnnouncements"></PublicAnnouncements>
     </v-col>

--- a/admin-frontend/src/components/DashboardPage.vue
+++ b/admin-frontend/src/components/DashboardPage.vue
@@ -61,7 +61,7 @@
         <v-icon icon="mdi-bullhorn"></v-icon>
         Public Announcements
       </h4>
-      <PublicAnnouncements></PublicAnnouncements>
+      <PublicAnnouncements ref="publicAnnouncements"></PublicAnnouncements>
     </v-col>
   </v-row>
 </template>
@@ -82,6 +82,7 @@ const isDashboardAvailable =
 const recentlySubmittedReports = ref<typeof RecentlySubmittedReports>();
 const recentlyViewedReports = ref<typeof RecentlyViewedReports>();
 const numSubmissionsInYear = ref<typeof NumSubmissionsInYear>();
+const publicAnnouncements = ref<typeof PublicAnnouncements>();
 
 onMounted(() => {
   //Periodically refresh the widgets
@@ -94,5 +95,6 @@ async function refresh() {
   await recentlySubmittedReports.value?.refresh();
   await recentlyViewedReports.value?.refresh();
   await numSubmissionsInYear.value?.refresh();
+  await publicAnnouncements.value?.refresh();
 }
 </script>

--- a/admin-frontend/src/components/dashboard/PublicAnnouncements.vue
+++ b/admin-frontend/src/components/dashboard/PublicAnnouncements.vue
@@ -2,15 +2,15 @@
   <v-card class="ptap-widget">
     <v-card-text class="h-100 d-flex flex-column">
       <div class="widget-header flex-grow-0 flex-shrink-0">
-        There are {{ announcementsMetrics?.published.count }} published
-        announcements and {{ announcementsMetrics?.draft.count }} draft
+        There are {{ announcementsMetrics?.published?.count || 0 }} published
+        announcements and {{ announcementsMetrics?.draft?.count || 0 }} draft
         announcements
       </div>
       <div class="d-flex">
         <div
           class="d-flex flex-column justify-center align-center widget-value text-primary flex-grow-1 flex-shrink-0"
         >
-          {{ announcementsMetrics?.published.count }}
+          {{ announcementsMetrics?.published?.count || 0 }}
           <AnnouncementStatusChip
             :status="AnnouncementStatus.Published"
             class="ms-2"
@@ -19,7 +19,7 @@
         <div
           class="d-flex flex-column justify-center align-center widget-value text-primary flex-grow-1 flex-shrink-0"
         >
-          {{ announcementsMetrics?.draft.count }}
+          {{ announcementsMetrics?.draft?.count || 0 }}
           <AnnouncementStatusChip
             :status="AnnouncementStatus.Draft"
             class="ms-2"

--- a/admin-frontend/src/components/dashboard/PublicAnnouncements.vue
+++ b/admin-frontend/src/components/dashboard/PublicAnnouncements.vue
@@ -2,13 +2,15 @@
   <v-card class="ptap-widget">
     <v-card-text class="h-100 d-flex flex-column">
       <div class="widget-header flex-grow-0 flex-shrink-0">
-        There are 0 published announcements and 0 draft announcements
+        There are {{ announcementsMetrics?.published.count }} published
+        announcements and {{ announcementsMetrics?.draft.count }} draft
+        announcements
       </div>
       <div class="d-flex">
         <div
           class="d-flex flex-column justify-center align-center widget-value text-primary flex-grow-1 flex-shrink-0"
         >
-          0
+          {{ announcementsMetrics?.published.count }}
           <AnnouncementStatusChip
             :status="AnnouncementStatus.Published"
             class="ms-2"
@@ -17,7 +19,7 @@
         <div
           class="d-flex flex-column justify-center align-center widget-value text-primary flex-grow-1 flex-shrink-0"
         >
-          0
+          {{ announcementsMetrics?.draft.count }}
           <AnnouncementStatusChip
             :status="AnnouncementStatus.Draft"
             class="ms-2"
@@ -30,6 +32,15 @@
 <script setup lang="ts">
 import AnnouncementStatusChip from '../announcements/AnnouncementStatusChip.vue';
 import { AnnouncementStatus } from '../../types/announcements';
+import useDashboardMetrics from '../../store/modules/dashboardMetricsStore';
+import { storeToRefs } from 'pinia';
+import { onBeforeMount } from 'vue';
+const dashboardMetrics = useDashboardMetrics();
+const { announcementsMetrics } = storeToRefs(dashboardMetrics);
+
+onBeforeMount(async () => {
+  await dashboardMetrics.getAnnouncementMetrics();
+});
 </script>
 
 <style lang="scss">

--- a/admin-frontend/src/components/dashboard/PublicAnnouncements.vue
+++ b/admin-frontend/src/components/dashboard/PublicAnnouncements.vue
@@ -34,9 +34,17 @@ import AnnouncementStatusChip from '../announcements/AnnouncementStatusChip.vue'
 import { AnnouncementStatus } from '../../types/announcements';
 import useDashboardMetrics from '../../store/modules/dashboardMetricsStore';
 import { storeToRefs } from 'pinia';
-import { onBeforeMount } from 'vue';
+import { onBeforeMount, defineExpose } from 'vue';
 const dashboardMetrics = useDashboardMetrics();
 const { announcementsMetrics } = storeToRefs(dashboardMetrics);
+
+const refresh = async () => {
+  await dashboardMetrics.getAnnouncementMetrics();
+};
+
+defineExpose({
+  refresh,
+});
 
 onBeforeMount(async () => {
   await dashboardMetrics.getAnnouncementMetrics();

--- a/admin-frontend/src/components/dashboard/__tests__/PublicAnnouncements.spec.ts
+++ b/admin-frontend/src/components/dashboard/__tests__/PublicAnnouncements.spec.ts
@@ -1,0 +1,46 @@
+import { render } from '@testing-library/vue';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import PublicAnnouncements from '../PublicAnnouncements.vue';
+import { createTestingPinia } from '@pinia/testing';
+import { createVuetify } from 'vuetify';
+import * as components from 'vuetify/components';
+import * as directives from 'vuetify/directives';
+import dashboardMetricsStore from '../../../store/modules/dashboardMetricsStore';
+
+const getAnnouncementsMetricsMock = vi.fn();
+vi.mock('../../../services/apiService', () => ({
+  default: {
+    getAnnouncementsMetrics: () => {
+      return getAnnouncementsMetricsMock();
+    },
+  },
+}));
+
+global.ResizeObserver = require('resize-observer-polyfill');
+const pinia = createTestingPinia();
+const vuetify = createVuetify({ components, directives });
+
+const wrappedRender = () => {
+  return render(PublicAnnouncements, {
+    global: {
+      plugins: [pinia, vuetify],
+    },
+  });
+};
+
+describe('PublicAnnouncements', () => {
+  let store;
+  beforeEach(() => {
+    vi.clearAllMocks();
+    store = dashboardMetricsStore();
+  });
+  it('should render the component', async () => {
+    store.announcementsMetrics = {
+      published: { count: 0 },
+      draft: { count: 0 },
+    };
+    const { getByText } = await wrappedRender();
+    expect(store.getAnnouncementMetrics).toHaveBeenCalled();
+    expect(getByText('There are 0 published announcements and 0 draft announcements')).not.toBeNull();
+  });
+});

--- a/admin-frontend/src/services/__tests__/apiService.spec.ts
+++ b/admin-frontend/src/services/__tests__/apiService.spec.ts
@@ -649,4 +649,32 @@ describe('ApiService', () => {
       });
     });
   });
+
+  describe('getAnnouncementsMetrics', () => {
+    it('returns an announcement metrics', async () => {
+      const mockBackendResponse = { draft: { count: 1 }, published: { count: 2 } };
+      const mockAxiosResponse = {
+        data: mockBackendResponse,
+      };
+      vi.spyOn(ApiService.apiAxios, 'get').mockResolvedValueOnce(
+        mockAxiosResponse,
+      );
+
+      const resp = await ApiService.getAnnouncementsMetrics();
+      expect(resp).toEqual(mockBackendResponse);
+    });
+
+    describe('when the data are not successfully retrieved from the backend', () => {
+      it('returns a rejected promise', async () => {
+        const mockAxiosError = new AxiosError();
+        vi.spyOn(ApiService.apiAxios, 'get').mockRejectedValueOnce(
+          mockAxiosError,
+        );
+
+        await expect(ApiService.getAnnouncementsMetrics()).rejects.toEqual(
+          mockAxiosError,
+        );
+      });
+    });
+  });
 });

--- a/admin-frontend/src/services/apiService.ts
+++ b/admin-frontend/src/services/apiService.ts
@@ -506,6 +506,15 @@ export default {
       throw error;
     }
   },
+  async getAnnouncementsMetrics() {
+    try {
+      const { data } = await apiAxios.get(ApiRoutes.ANNOUNCEMENTS_METRICS);
+      return data;
+    } catch (e) {
+      console.log(`Failed to get announcements metrics from API - ${e}`);
+      throw e;
+    }
+  },
 };
 
 const buildFormData = (data: AnnouncementFormValue) => {

--- a/admin-frontend/src/store/modules/__tests__/dashboardMetricsStore.spec.ts
+++ b/admin-frontend/src/store/modules/__tests__/dashboardMetricsStore.spec.ts
@@ -1,0 +1,61 @@
+import { describe, vi, it, beforeEach, expect } from 'vitest';
+
+import { setActivePinia, createPinia } from 'pinia';
+import useDashboardMetricsStore from '../dashboardMetricsStore';
+
+const getAnnouncementsMetricsMock = vi.fn();
+vi.mock('../../../services/apiService', () => ({
+  default: {
+    getAnnouncementsMetrics: () => {
+      return getAnnouncementsMetricsMock();
+    },
+  },
+}));
+describe('dashboardMetricsStore', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+  });
+
+  describe('announcements metrics', () => {
+    it('should return the initial state', () => {
+      const store = useDashboardMetricsStore();
+      expect(store.announcementMetricsLoading).toBe(false);
+      expect(store.announcementsMetrics).toBe(undefined);
+    });
+  });
+
+  describe('getAnnouncementMetrics', () => {
+    it('should get announcements metrics', async () => {
+      const store = useDashboardMetricsStore();
+      getAnnouncementsMetricsMock.mockResolvedValueOnce({
+        draft: { count: 1 },
+        published: { count: 2 },
+      });
+      await store.getAnnouncementMetrics();
+      expect(getAnnouncementsMetricsMock).toHaveBeenCalled();
+    });
+
+    describe('when getAnnouncementMetrics fails', () => {
+      it('should set announcementMetricsLoading to false', async () => {
+        const store = useDashboardMetricsStore();
+        getAnnouncementsMetricsMock.mockRejectedValueOnce('error');
+        await store.getAnnouncementMetrics();
+        expect(store.announcementMetricsLoading).toBe(false);
+      });
+    });
+  });
+
+  describe('reset', () => {
+    it('should reset the store', () => {
+      const store = useDashboardMetricsStore();
+      store.announcementMetricsLoading = true;
+      store.announcementsMetrics = {
+        draft: { count: 1 },
+        published: { count: 2 },
+      };
+      store.reset();
+      expect(store.announcementMetricsLoading).toBe(false);
+      expect(store.announcementsMetrics).toBe(undefined);
+    });
+  });
+});

--- a/admin-frontend/src/store/modules/dashboardMetricsStore.ts
+++ b/admin-frontend/src/store/modules/dashboardMetricsStore.ts
@@ -1,0 +1,41 @@
+import { defineStore } from 'pinia';
+import { ref } from 'vue';
+import ApiService from '../../services/apiService';
+
+interface AnnouncementMetrics {
+  draft: { count: number };
+  published: { count: number };
+}
+
+const useDashboardMetricsStore = defineStore('dashboardMetrics', () => {
+  const announcementMetricsLoading = ref<boolean>(false);
+  const announcementsMetrics = ref<AnnouncementMetrics | undefined>(undefined);
+
+  const getAnnouncementMetrics = async () => {
+    try {
+      announcementMetricsLoading.value = true;
+      const data = await ApiService.getAnnouncementsMetrics();
+      announcementsMetrics.value = data;
+    } catch (err) {
+      console.log(`get announcements metrics failed: ${err}`);
+    } finally {
+      announcementMetricsLoading.value = false;
+    }
+  };
+
+  const reset = () => {
+    announcementMetricsLoading.value = false;
+    announcementsMetrics.value = undefined;
+  };
+
+  return {
+    //state
+    announcementMetricsLoading,
+    announcementsMetrics,
+    //actions
+    getAnnouncementMetrics,
+    reset,
+  };
+});
+
+export default useDashboardMetricsStore;

--- a/admin-frontend/src/utils/constant.js
+++ b/admin-frontend/src/utils/constant.js
@@ -28,6 +28,7 @@ export const ApiRoutes = Object.freeze({
   USERS: `${baseRoot}/v1/users`,
   USER_INVITES: `${baseRoot}/v1/user-invites`,
   ANNOUNCEMENTS: `${baseRoot}/v1/announcements`,
+  ANNOUNCEMENTS_METRICS: `${baseRoot}/v1/dashboard/announcement-metrics`,
   CLAMAV_SCAN: `${clamavBaseRoot}/`,
   RESOURCES: `${baseRoot}/v1/resources`,
   REPORT_METRICS: `${baseRoot}/v1/dashboard/reports-metrics`,

--- a/backend/src/v1/services/code-service.ts
+++ b/backend/src/v1/services/code-service.ts
@@ -17,7 +17,6 @@ const codeService = {
   the full list of all values. */
   async getAllEmployeeCountRanges() {
     const now = LocalDateTime.now();
-
     if (
       employeeCountRangeCacheExpiryDate &&
       now.isAfter(employeeCountRangeCacheExpiryDate)


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description

Integrate announcement metrics API with dashboard panel

Fixes # ([issue](https://finrms.atlassian.net/browse/GEO-1049))

## Type of change

- [ ] New feature (non-breaking change which adds functionality)


## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have already been accepted and merged


## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://pay-transparency-pr-773-frontend.apps.silver.devops.gov.bc.ca)
- [Admin Frontend](https://pay-transparency-pr-773-admin-frontend.apps.silver.devops.gov.bc.ca)
- [Backend external API console](https://pay-transparency-pr-773-backend-external.apps.silver.devops.gov.bc.ca/api/V1/docs)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/fin-pay-transparency/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/fin-pay-transparency/actions/workflows/merge.yml)