### PR TITLE
fix: GEO 1088 display error snackbar when download file fails

### DIFF
--- a/admin-frontend/src/components/announcements/AnnouncementItem.vue
+++ b/admin-frontend/src/components/announcements/AnnouncementItem.vue
@@ -68,7 +68,7 @@ async function downloadAnnouncementResource(
     } catch (error) {
       console.error(error);
       NotificationService.pushNotificationError(
-        'There is a problem with this link/file, please try again later. If the problem persists please contact the Gender Equity Office; paytransparency@gov.bc.ca',
+        'There is a problem with this link/file, please try again later or contact the helpdesk.',
         '',
         30000,
       );

--- a/admin-frontend/src/components/announcements/AnnouncementItem.vue
+++ b/admin-frontend/src/components/announcements/AnnouncementItem.vue
@@ -51,8 +51,9 @@ import { Announcement, AnnouncementResource } from '../../types/announcements';
 import { sanitizeUrl } from '@braintree/sanitize-url';
 import ApiService from '../../services/apiService';
 import { saveAs } from 'file-saver';
+import { NotificationService } from '../../services/notificationService';
 
-const props = defineProps<{
+defineProps<{
   announcement: Announcement;
 }>();
 
@@ -60,9 +61,18 @@ async function downloadAnnouncementResource(
   announcementResource: AnnouncementResource,
 ) {
   if (announcementResource.announcement_resource_id) {
-    await ApiService.downloadFile(
-      announcementResource.announcement_resource_id,
-    );
+    try {
+      await ApiService.downloadFile(
+        announcementResource.announcement_resource_id,
+      );
+    } catch (error) {
+      console.error(error);
+      NotificationService.pushNotificationError(
+        'There is a problem with this link/file, please try again later. If the problem persists please contact the Gender Equity Office; paytransparency@gov.bc.ca',
+        '',
+        30000,
+      );
+    }
   } else if (announcementResource.announcement_resource_file) {
     //When a resource with type ATTACHMENT hasn't yet been uploaded to the
     //backend, it won't yet have an announcement_resource_id, so we

--- a/admin-frontend/src/components/announcements/__tests__/AnnouncementItem.spec.ts
+++ b/admin-frontend/src/components/announcements/__tests__/AnnouncementItem.spec.ts
@@ -36,6 +36,14 @@ vi.mock('../../../services/apiService', () => ({
     downloadFile: (...args) => mockDownloadFile(...args),
   },
 }));
+
+const pushNotificationErrorMock = vi.fn();
+vi.mock('../../../services/notificationService', () => ({
+  NotificationService: {
+    pushNotificationError: (...args) => pushNotificationErrorMock(...args),
+  },
+}));
+
 vi.mock('file-saver', () => ({
   saveAs: (...args) => mockSaveAs(...args),
 }));
@@ -100,6 +108,21 @@ describe('AnnouncementItem', () => {
         await wrapper.vm.downloadAnnouncementResource(mockAnnouncementResource);
         expect(mockDownloadFile).not.toHaveBeenCalled();
         expect(mockSaveAs).toHaveBeenCalled();
+      });
+    });
+
+    describe('when downloadFile fails', () => {
+      it('shows a snackbar error', async () => {
+        const mockAnnouncementResource = {
+          announcement_resource_id: '123',
+        };
+        mockDownloadFile.mockRejectedValueOnce(new Error('mock error'));
+        await wrapper.vm.downloadAnnouncementResource(mockAnnouncementResource);
+        expect(pushNotificationErrorMock).toHaveBeenCalledWith(
+          'There is a problem with this link/file, please try again later. If the problem persists please contact the Gender Equity Office; paytransparency@gov.bc.ca',
+          '',
+          30000,
+        );
       });
     });
   });

--- a/admin-frontend/src/components/announcements/__tests__/AnnouncementItem.spec.ts
+++ b/admin-frontend/src/components/announcements/__tests__/AnnouncementItem.spec.ts
@@ -80,6 +80,7 @@ describe('AnnouncementItem', () => {
 
   beforeEach(async () => {
     await initWrapper();
+    vi.clearAllMocks();
   });
 
   afterEach(() => {
@@ -119,7 +120,7 @@ describe('AnnouncementItem', () => {
         mockDownloadFile.mockRejectedValueOnce(new Error('mock error'));
         await wrapper.vm.downloadAnnouncementResource(mockAnnouncementResource);
         expect(pushNotificationErrorMock).toHaveBeenCalledWith(
-          'There is a problem with this link/file, please try again later. If the problem persists please contact the Gender Equity Office; paytransparency@gov.bc.ca',
+          'There is a problem with this link/file, please try again later or contact the helpdesk.',
           '',
           30000,
         );

--- a/frontend/src/components/announcements/AnnouncementItem.vue
+++ b/frontend/src/components/announcements/AnnouncementItem.vue
@@ -50,14 +50,26 @@ export default {
 import { Announcement, AnnouncementResource } from '../../types/announcements';
 import { sanitizeUrl } from '@braintree/sanitize-url';
 import ApiService from '../../common/apiService';
+import { NotificationService } from '../../common/notificationService';
 
-const props = defineProps<{
+defineProps<{
   announcement: Announcement;
 }>();
 
 async function downloadAnnouncementResource(
   announcementResource: AnnouncementResource,
 ) {
-  await ApiService.downloadFile(announcementResource.announcement_resource_id);
+  try {
+    await ApiService.downloadFile(
+      announcementResource.announcement_resource_id,
+    );
+  } catch (error) {
+    console.error(error);
+    NotificationService.pushNotificationError(
+      'There is a problem with this link/file, please try again later. If the problem persists please contact the Gender Equity Office; paytransparency@gov.bc.ca',
+      '',
+      30000,
+    );
+  }
 }
 </script>

--- a/frontend/src/components/announcements/__tests__/AnnouncementItem.spec.ts
+++ b/frontend/src/components/announcements/__tests__/AnnouncementItem.spec.ts
@@ -37,6 +37,13 @@ vi.mock('../../../common/apiService', () => ({
   },
 }));
 
+const pushNotificationErrorMock = vi.fn();
+vi.mock('../../../common/notificationService', () => ({
+  NotificationService: {
+    pushNotificationError: (...args) => pushNotificationErrorMock(...args),
+  },
+}));
+
 // Stub blobal objects needed for testing
 vi.stubGlobal('ResizeObserver', ResizeObserverMock);
 vi.stubGlobal('URL', { createObjectURL: vi.fn() });
@@ -87,6 +94,21 @@ describe('AnnouncementItem', () => {
         await wrapper.vm.downloadAnnouncementResource(mockAnnouncementResource);
         expect(mockDownloadFile).toHaveBeenCalled();
         expect(mockSaveAs).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('when downloadFile fails', () => {
+      it('shows a snackbar error', async () => {
+        const mockAnnouncementResource = {
+          announcement_resource_id: '123',
+        };
+        mockDownloadFile.mockRejectedValueOnce(new Error('mock error'));
+        await wrapper.vm.downloadAnnouncementResource(mockAnnouncementResource);
+        expect(pushNotificationErrorMock).toHaveBeenCalledWith(
+          'There is a problem with this link/file, please try again later. If the problem persists please contact the Gender Equity Office; paytransparency@gov.bc.ca',
+          '',
+          30000,
+        );
       });
     });
   });


### PR DESCRIPTION
# Description

Display error snack bar when download file fails

Fixes # ([issue](https://finrms.atlassian.net/browse/GEO-1088))

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)


## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have already been accepted and merged


## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://pay-transparency-pr-774-frontend.apps.silver.devops.gov.bc.ca)
- [Admin Frontend](https://pay-transparency-pr-774-admin-frontend.apps.silver.devops.gov.bc.ca)
- [Backend external API console](https://pay-transparency-pr-774-backend-external.apps.silver.devops.gov.bc.ca/api/V1/docs)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/fin-pay-transparency/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/fin-pay-transparency/actions/workflows/merge.yml)