### PR TITLE
fix: trim announcement text fields

### DIFF
--- a/admin-frontend/src/services/__tests__/apiService.spec.ts
+++ b/admin-frontend/src/services/__tests__/apiService.spec.ts
@@ -455,7 +455,7 @@ describe('ApiService', () => {
       it('returns a promise that eventually resolves', async () => {
         const payload: any = {
           title: 'test',
-          describe: 'test',
+          description: 'test',
           status: 'PUBLISHED',
           expires_on: '2021-12-31',
           active_on: '2021-12-31',
@@ -498,7 +498,7 @@ describe('ApiService', () => {
   describe('updateAnnouncements', () => {
     describe('when the API request to the backend is successful', () => {
       it('returns a promise that eventually resolves', async () => {
-        const payload: any = { title: 'test' };
+        const payload: any = { title: 'test', description: 'test' };
         const mockResponse = {
           data: {},
           status: 201,

--- a/admin-frontend/src/services/apiService.ts
+++ b/admin-frontend/src/services/apiService.ts
@@ -519,8 +519,8 @@ export default {
 
 const buildFormData = (data: AnnouncementFormValue) => {
   const formData = new FormData();
-  formData.append('title', data.title);
-  formData.append('description', data.description);
+  formData.append('title', data.title.trim());
+  formData.append('description', data.description.trim());
   formData.append('status', data.status);
   if (data.active_on) {
     formData.append('active_on', data.active_on);
@@ -529,7 +529,7 @@ const buildFormData = (data: AnnouncementFormValue) => {
     formData.append('expires_on', data.expires_on);
   }
   if (data.linkUrl && data.linkDisplayName) {
-    formData.append('linkUrl', data.linkUrl);
+    formData.append('linkUrl', data.linkUrl.trim());
     formData.append('linkDisplayName', data.linkDisplayName);
   }
 
@@ -538,7 +538,7 @@ const buildFormData = (data: AnnouncementFormValue) => {
   }
 
   if (data.fileDisplayName) {
-    formData.append('fileDisplayName', data.fileDisplayName);
+    formData.append('fileDisplayName', data.fileDisplayName.trim());
   }
 
   if (data.attachmentId) {


### PR DESCRIPTION
#Description

Trim announcement text fields

Fixes # ([issue](https://finrms.atlassian.net/browse/GEO-1158))

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)


## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have already been accepted and merged


## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://pay-transparency-pr-779-frontend.apps.silver.devops.gov.bc.ca)
- [Admin Frontend](https://pay-transparency-pr-779-admin-frontend.apps.silver.devops.gov.bc.ca)
- [Backend external API console](https://pay-transparency-pr-779-backend-external.apps.silver.devops.gov.bc.ca/api/V1/docs)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/fin-pay-transparency/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/fin-pay-transparency/actions/workflows/merge.yml)