### PR TITLE
fix: geo 1158 fix textarea to correctly count characters

### DIFF
--- a/admin-frontend/src/components/announcements/AnnouncementForm.vue
+++ b/admin-frontend/src/components/announcements/AnnouncementForm.vue
@@ -94,7 +94,15 @@
                 counter
                 rows="3"
                 :error-messages="errors.description"
-              ></v-textarea>
+              >
+                <template #counter="{ max }">
+                  <span>
+                    {{ getDescriptionLength(announcementDescription) }}/{{
+                      max
+                    }}
+                  </span>
+                </template>
+              </v-textarea>
             </v-col>
             <v-col cols="12" md="12" sm="12">
               <h5 class="mb-2">Time settings</h5>
@@ -463,7 +471,7 @@ const { handleSubmit, setErrors, errors, meta, values } = useForm({
     description(value) {
       if (!value) return 'Description is required.';
 
-      if (value.length > 2000)
+      if (getDescriptionLength(value) > 2000)
         return 'Description should have a maximum of 2000 characters.';
 
       return true;
@@ -526,7 +534,7 @@ const { handleSubmit, setErrors, errors, meta, values } = useForm({
 
 const { value: announcementTitle } = useField('title');
 const { value: status } = useField<string>('status');
-const { value: announcementDescription } = useField('description');
+const { value: announcementDescription } = useField<string>('description');
 const { value: activeOn } = useField('active_on') as any;
 const { value: expiresOn } = useField('expires_on') as any;
 const { value: noExpiry } = useField('no_expiry') as any;
@@ -534,6 +542,10 @@ const { value: linkUrl } = useField('linkUrl') as any;
 const { value: linkDisplayName } = useField('linkDisplayName') as any;
 const { value: fileDisplayName } = useField('fileDisplayName') as any;
 const { value: attachment } = useField('attachment') as any;
+
+const getDescriptionLength = (value: string) => {
+  return value.replace(/(\r\n|\n|\r)/g, '  ').length;
+};
 
 watch(noExpiry, () => {
   if (noExpiry.value) {


### PR DESCRIPTION
# Description

Fix textarea to include new line in characters count

Fixes # ([issue](https://finrms.atlassian.net/browse/GEO-1158))

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)


## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have already been accepted and merged


## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://pay-transparency-pr-781-frontend.apps.silver.devops.gov.bc.ca)
- [Admin Frontend](https://pay-transparency-pr-781-admin-frontend.apps.silver.devops.gov.bc.ca)
- [Backend external API console](https://pay-transparency-pr-781-backend-external.apps.silver.devops.gov.bc.ca/api/V1/docs)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/fin-pay-transparency/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/fin-pay-transparency/actions/workflows/merge.yml)