### PR TITLE
feat: GEO-579 - admin dashboard tweaks

### DIFF
--- a/admin-frontend/src/components/dashboard/NumSubmissionsInYear.vue
+++ b/admin-frontend/src/components/dashboard/NumSubmissionsInYear.vue
@@ -2,9 +2,10 @@
   <v-card class="ptap-widget">
     <v-card-text class="h-100 d-flex flex-column">
       <div class="widget-header flex-grow-0 flex-shrink-0">
-        Number of reports submitted for the current reporting year ({{
-          currentReportingYear
-        }})
+        Number of reports submitted for the current reporting year
+        <span v-if="!isLoading && currentReportingYear"
+          >({{ currentReportingYear }})</span
+        >
       </div>
       <div
         class="d-flex flex-column justify-center align-center text-primary flex-grow-1 flex-shrink-0"

--- a/admin-frontend/src/components/dashboard/RecentlySubmittedReports.vue
+++ b/admin-frontend/src/components/dashboard/RecentlySubmittedReports.vue
@@ -6,7 +6,12 @@
     :get-reports="getRecentlySubmittedReports"
   >
     <template #item.update_date="{ item }">
-      {{ formatIsoDateTimeAsLocalDate(item.update_date) }}
+      <span class="date-column">
+        <div>{{ formatIsoDateTimeAsLocalDate(item.update_date) }}</div>
+        <small class="text-grey-darken-3">{{
+          formatIsoDateTimeAsLocalTime(item.update_date)
+        }}</small>
+      </span>
     </template>
   </ReportsWidget>
 </template>
@@ -25,7 +30,10 @@ import {
 } from '../../types/reports';
 import ReportsWidget from './ReportsWidget.vue';
 import ApiService from '../../services/apiService';
-import { formatIsoDateTimeAsLocalDate } from '../../utils/date';
+import {
+  formatIsoDateTimeAsLocalDate,
+  formatIsoDateTimeAsLocalTime,
+} from '../../utils/date';
 import { ref } from 'vue';
 
 const pageSize = 5;
@@ -50,7 +58,7 @@ const headers = [
   },
   {
     title: 'Actions',
-    align: 'start',
+    align: 'center',
     sortable: false,
     key: 'actions',
   },

--- a/admin-frontend/src/components/dashboard/RecentlyViewedReports.vue
+++ b/admin-frontend/src/components/dashboard/RecentlyViewedReports.vue
@@ -6,7 +6,14 @@
     :get-reports="getRecentlyViewedReports"
   >
     <template #item.admin_last_access_date="{ item }">
-      {{ formatIsoDateTimeAsLocalDate(item.admin_last_access_date) }}
+      <span class="date-column">
+        <div>
+          {{ formatIsoDateTimeAsLocalDate(item.admin_last_access_date) }}
+        </div>
+        <small class="text-grey-darken-3">{{
+          formatIsoDateTimeAsLocalTime(item.admin_last_access_date)
+        }}</small>
+      </span>
     </template>
   </ReportsWidget>
 </template>
@@ -25,7 +32,10 @@ import {
 } from '../../types/reports';
 import ReportsWidget from './ReportsWidget.vue';
 import ApiService from '../../services/apiService';
-import { formatIsoDateTimeAsLocalDate } from '../../utils/date';
+import {
+  formatIsoDateTimeAsLocalDate,
+  formatIsoDateTimeAsLocalTime,
+} from '../../utils/date';
 import { ref } from 'vue';
 
 const pageSize = 5;
@@ -46,7 +56,7 @@ const headers = [
   },
   {
     title: 'Actions',
-    align: 'start',
+    align: 'center',
     sortable: false,
     key: 'actions',
   },

--- a/admin-frontend/src/components/dashboard/ReportsWidget.vue
+++ b/admin-frontend/src/components/dashboard/ReportsWidget.vue
@@ -20,7 +20,9 @@
         </template>
 
         <template #item.actions="{ item }">
-          <ReportActions :report="item"></ReportActions>
+          <div class="actions-column">
+            <ReportActions :report="item"></ReportActions>
+          </div>
         </template>
       </v-data-table-server>
     </v-card-text>
@@ -105,5 +107,16 @@ defineExpose({
 <style>
 .ptap-widget thead {
   background-color: #eeeeee;
+}
+</style>
+
+<style>
+tr > td:has(> .date-column) {
+  width: 25%;
+  min-width: 180px;
+}
+tr > td:has(> .actions-column) {
+  width: 20%;
+  min-width: 140px;
 }
 </style>


### PR DESCRIPTION
# Description

Minor tweaks to the admin dashboard:

- the 'recently viewed' and 'recently submitted' tables now show times (not just dates)
- column widths in the 'recently viewed' and 'recently submitted' tables are consistent
- the 'number of reports submitted in the current reporting year' widget doesn't shown the current reporting year while loading

Fixes # [GEO-579](https://finrms.atlassian.net/browse/GEO-579)

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Visual inspection.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have already been accepted and merged


---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://pay-transparency-pr-792-frontend.apps.silver.devops.gov.bc.ca)
- [Admin Frontend](https://pay-transparency-pr-792-admin-frontend.apps.silver.devops.gov.bc.ca)
- [Backend external API console](https://pay-transparency-pr-792-backend-external.apps.silver.devops.gov.bc.ca/api/V1/docs)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/fin-pay-transparency/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/fin-pay-transparency/actions/workflows/merge.yml)