### PR TITLE
fix: GEO-1186 Store file with a uuid to prevent overwriting

### DIFF
--- a/backend/src/v1/middlewares/storage/upload.ts
+++ b/backend/src/v1/middlewares/storage/upload.ts
@@ -24,7 +24,7 @@ export const useUpload = (options: Options) => {
     logger.log('info', 'Uploading file to S3');
 
     const { path, name, type, size } = file;
-    const lastDotIndex = name.lastIndexOf('.');
+    const lastDotIndex = name?.lastIndexOf('.') ?? -1;
     const ext = lastDotIndex !== -1 ? name.substring(lastDotIndex + 1) : '';
 
     if (!path.startsWith(os.tmpdir())) {

--- a/backend/src/v1/middlewares/storage/upload.ts
+++ b/backend/src/v1/middlewares/storage/upload.ts
@@ -9,6 +9,7 @@ import os from 'os';
 import retry from 'async-retry';
 import { S3_BUCKET, S3_OPTIONS } from '../../../constants/admin';
 import PATH from 'path';
+import { v4 as uuidv4 } from 'uuid';
 
 interface Options {
   folder: string;
@@ -23,6 +24,8 @@ export const useUpload = (options: Options) => {
     logger.log('info', 'Uploading file to S3');
 
     const { path, name, type, size } = file;
+    const lastDotIndex = name.lastIndexOf('.');
+    const ext = lastDotIndex !== -1 ? name.substring(lastDotIndex + 1) : '';
 
     if (!path.startsWith(os.tmpdir())) {
       logger.error('File not uploaded to temp directory');
@@ -41,7 +44,7 @@ export const useUpload = (options: Options) => {
       const stream = fs.createReadStream(path);
       const uploadParams: PutObjectCommandInput = {
         Bucket: S3_BUCKET,
-        Key: `${options.folder}/${data.attachmentId}/${name}`,
+        Key: `${options.folder}/${data.attachmentId}/${uuidv4()}.${ext}`,
         Body: stream,
         ContentType: type,
         ContentLength: size,


### PR DESCRIPTION
I only changed the name of the file that gets uploaded, nothing else.

Testing steps:
1. Create new announcement from the Admin Portal and upload a file: https://pay-transparency-pr-812-admin-frontend.apps.silver.devops.gov.bc.ca/announcements
2. View the announcement form the Frontend: https://pay-transparency-pr-812-frontend.apps.silver.devops.gov.bc.ca/dashboard
3. Click on the attachment link. It downloads as the link name, and it doesn't download as the filename which was stored.

Note that the announcement preview in the Admin Portal behaves differently that the actual announcement in the frontend.

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://pay-transparency-pr-812-frontend.apps.silver.devops.gov.bc.ca)
- [Admin Frontend](https://pay-transparency-pr-812-admin-frontend.apps.silver.devops.gov.bc.ca)
- [Backend external API console](https://pay-transparency-pr-812-backend-external.apps.silver.devops.gov.bc.ca/api/V1/docs)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/fin-pay-transparency/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/fin-pay-transparency/actions/workflows/merge.yml)