### PR TITLE
fix: GEO-1190 and GEO-1191 - admin report search and dashboard page fixes

### DIFF
--- a/admin-frontend/src/components/ReportSearchFilters.vue
+++ b/admin-frontend/src/components/ReportSearchFilters.vue
@@ -288,7 +288,7 @@ function getReportSearchFilters(): ReportFilterType {
   }
   if (submissionDateRange.value) {
     filters.push({
-      key: 'update_date',
+      key: 'create_date',
       operation: 'between',
       value: submissionDateRange.value.map((d, i) => {
         const jodaZonedDateTime = ZonedDateTime.from(

--- a/admin-frontend/src/components/__tests__/ReportsSearchFilters.spec.ts
+++ b/admin-frontend/src/components/__tests__/ReportsSearchFilters.spec.ts
@@ -84,7 +84,7 @@ describe('ReportSearchFilters', () => {
         wrapper.vm.submissionDateRange = dateRange;
         const filters = wrapper.vm.getReportSearchFilters();
         const submissonDateFilters = filters.filter(
-          (d) => d.key == 'update_date',
+          (d) => d.key == 'create_date',
         );
         expect(submissonDateFilters.length).toBe(1);
         expect(submissonDateFilters[0].operation).toBe('between');

--- a/admin-frontend/src/components/dashboard/RecentlySubmittedReports.vue
+++ b/admin-frontend/src/components/dashboard/RecentlySubmittedReports.vue
@@ -47,13 +47,13 @@ const headers = [
   {
     title: 'Submission Date',
     align: 'start',
-    sortable: true,
+    sortable: false,
     key: 'update_date',
   },
   {
     title: 'Employer Name',
     align: 'start',
-    sortable: true,
+    sortable: false,
     key: 'pay_transparency_company.company_name',
   },
   {

--- a/admin-frontend/src/components/dashboard/RecentlyViewedReports.vue
+++ b/admin-frontend/src/components/dashboard/RecentlyViewedReports.vue
@@ -45,13 +45,13 @@ const headers = [
   {
     title: 'Viewed On',
     align: 'start',
-    sortable: true,
+    sortable: false,
     key: 'admin_last_access_date',
   },
   {
     title: 'Employer Name',
     align: 'start',
-    sortable: true,
+    sortable: false,
     key: 'pay_transparency_company.company_name',
   },
   {

--- a/admin-frontend/src/store/modules/reportSearchStore.ts
+++ b/admin-frontend/src/store/modules/reportSearchStore.ts
@@ -14,11 +14,11 @@ export const DEFAULT_SEARCH_PARAMS: IReportSearchParams = {
   page: 1,
   itemsPerPage: 20,
   filter: undefined,
-  sort: [{ update_date: 'desc' }],
+  sort: [{ create_date: 'desc' }],
 };
 export const DEFAULT_DOWNLOAD_CSV_PARAMS: IReportSearchParams = {
   filter: undefined,
-  sort: [{ update_date: 'desc' }],
+  sort: [{ create_date: 'desc' }],
 };
 
 /*

--- a/admin-frontend/src/types/reports.ts
+++ b/admin-frontend/src/types/reports.ts
@@ -46,6 +46,7 @@ export enum ReportKeys {
 }
 export enum BackendReportSortKeys {
   COMPANY_NAME = 'company_name',
+  CREATE_DATE = 'create_date',
   UPDATE_DATE = 'update_date',
   NAICS_CODE = 'naics_code',
   EMPLOYEE_COUNT = 'employee_count_range_id',
@@ -55,13 +56,14 @@ export enum BackendReportSortKeys {
 //key expected by the backend when sorting
 export const SORT_KEY_MAPPING = {};
 SORT_KEY_MAPPING[ReportKeys.COMPANY_NAME] = BackendReportSortKeys.COMPANY_NAME;
+SORT_KEY_MAPPING[ReportKeys.CREATE_DATE] = BackendReportSortKeys.CREATE_DATE;
 SORT_KEY_MAPPING[ReportKeys.UPDATE_DATE] = BackendReportSortKeys.UPDATE_DATE;
 SORT_KEY_MAPPING[ReportKeys.NAICS_CODE] = BackendReportSortKeys.NAICS_CODE;
 SORT_KEY_MAPPING[ReportKeys.EMPLOYEE_COUNT] =
   BackendReportSortKeys.EMPLOYEE_COUNT;
 
 export type SubmissonDateFilter = {
-  key: 'update_date';
+  key: 'create_date';
   operation: 'between';
   value: string[];
 };

--- a/backend/src/v1/types/report-search.ts
+++ b/backend/src/v1/types/report-search.ts
@@ -3,6 +3,7 @@ import * as z from 'zod';
 export type FilterValueType = string[] | null | undefined | boolean;
 
 export type FilterKeyType =
+  | 'create_date'
   | 'update_date'
   | 'naics_code'
   | 'reporting_year'
@@ -12,6 +13,12 @@ export type FilterKeyType =
   | 'admin_last_access_date';
 
 export type SubmissonDateFilter = {
+  key: 'create_date';
+  operation: 'between';
+  value: string[];
+};
+
+export type UpdateDateFilter = {
   key: 'update_date';
   operation: 'between';
   value: string[];
@@ -57,6 +64,7 @@ export type AdminLastAccessDateFilter = {
 
 export type ReportFilterType = (
   | SubmissonDateFilter
+  | UpdateDateFilter
   | NaicsCodeFilter
   | ReportingYearFilter
   | IsUnlockedFilter
@@ -66,6 +74,7 @@ export type ReportFilterType = (
 )[];
 
 export type SortFieldType =
+  | 'create_date'
   | 'update_date'
   | 'naics_code'
   | 'employee_count_range_id'
@@ -75,6 +84,9 @@ export type SortFieldType =
 type SortDirection = 'asc' | 'desc';
 
 export type SubmissionDateSort = {
+  create_date: SortDirection;
+};
+export type UpdateDateSort = {
   update_date: SortDirection;
 };
 export type NaicsCodeSort = {
@@ -93,6 +105,7 @@ export type CompanySort = {
 
 export type ReportSortType = (
   | SubmissionDateSort
+  | UpdateDateSort
   | NaicsCodeSort
   | EmployeeCountRangeSort
   | CompanySort
@@ -108,6 +121,9 @@ export const RELATION_MAPPER: {
 const FILTER_OPERATION_SCHEMA: {
   [key in FilterKeyType]: z.ZodString | z.ZodEnum<any>;
 } = {
+  create_date: z.enum(['between'], {
+    message: 'Only "between" operation is allowed',
+  }),
   update_date: z.enum(['between'], {
     message: 'Only "between" operation is allowed',
   }),
@@ -131,6 +147,7 @@ const FILTER_OPERATION_SCHEMA: {
 };
 
 const FILTER_VALUE_SCHEMA: { [key in FilterKeyType]: any } = {
+  create_date: z.array(z.string()).optional(),
   update_date: z.array(z.string()).optional(),
   naics_code: z.array(z.string()).optional(),
   employee_count_range_id: z.array(z.string()).optional(),
@@ -145,6 +162,7 @@ export const FilterValidationSchema = z.array(
     .object({
       key: z.enum(
         [
+          'create_date',
           'update_date',
           'naics_code',
           'reporting_year',
@@ -156,7 +174,7 @@ export const FilterValidationSchema = z.array(
         {
           required_error: 'Missing or invalid filter key',
           message:
-            'key must be one of the following values: update_date, naics_code, reporting_year, is_unlocked, employee_count_range_id',
+            'key must be one of the following values: create_date, update_date, naics_code, reporting_year, is_unlocked, employee_count_range_id',
         },
       ),
       operation: z.string({


### PR DESCRIPTION
# Description

Admin portal changes:
- Dashboard page: removed the 'sort arrows' from the column header in both tables ("recently submitted" and "recently viewed")
- Report Search page: Updated the "submission date" filter to map to the "create_date" column (instead of the update_date column).  This makes it consistent with how the term "submission date" is used elsewhere on the page and in the app.

Fixes # [GEO-1190](https://finrms.atlassian.net/browse/GEO-1190) and [GEO-1191](https://finrms.atlassian.net/browse/GEO-1191)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

New unit tests.  Updated existing unit tests.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have already been accepted and merged

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://pay-transparency-pr-819-frontend.apps.silver.devops.gov.bc.ca)
- [Admin Frontend](https://pay-transparency-pr-819-admin-frontend.apps.silver.devops.gov.bc.ca)
- [Backend external API console](https://pay-transparency-pr-819-backend-external.apps.silver.devops.gov.bc.ca/api/V1/docs)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/fin-pay-transparency/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/fin-pay-transparency/actions/workflows/merge.yml)