### PR TITLE
fix: GEO-1194 - admin tool - lock/unlock no longer clobbers calculated data 

### DIFF
--- a/backend/src/v1/services/admin-report-service.spec.ts
+++ b/backend/src/v1/services/admin-report-service.spec.ts
@@ -664,7 +664,7 @@ describe('admin-report-service', () => {
       expect(report.is_unlocked).toBeTruthy();
       expect(report.admin_modified_date).toBe(report.report_unlock_date);
       expect(report.admin_user_id).toBe('1234');
-      expect(reportService.movePublishedReportToHistory).toHaveBeenCalled();
+      expect(reportService.copyPublishedReportToHistory).toHaveBeenCalled();
     });
     it('should change report is_unlocked to false', async () => {
       const report = await adminReportService.changeReportLockStatus(

--- a/backend/src/v1/services/admin-report-service.ts
+++ b/backend/src/v1/services/admin-report-service.ts
@@ -148,7 +148,7 @@ const adminReportService = {
 
       const currentDateUtc = convert(ZonedDateTime.now(ZoneId.UTC)).toDate();
 
-      await reportService.movePublishedReportToHistory(tx, existingReport);
+      await reportService.copyPublishedReportToHistory(tx, existingReport);
 
       await prisma.pay_transparency_report.update({
         where: { report_id: reportId },


### PR DESCRIPTION
# Description

Fixes # [GEO-1194](https://finrms.atlassian.net/browse/GEO-1194)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Updated existing unit tests

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have already been accepted and merged

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://pay-transparency-pr-821-frontend.apps.silver.devops.gov.bc.ca)
- [Admin Frontend](https://pay-transparency-pr-821-admin-frontend.apps.silver.devops.gov.bc.ca)
- [Backend external API console](https://pay-transparency-pr-821-backend-external.apps.silver.devops.gov.bc.ca/api/V1/docs)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/fin-pay-transparency/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/fin-pay-transparency/actions/workflows/merge.yml)