### PR TITLE
fix: GEO-1198 report and announcement searches convert filter dates into UTC timezone

### DIFF
--- a/admin-frontend/src/components/ReportSearchFilters.vue
+++ b/admin-frontend/src/components/ReportSearchFilters.vue
@@ -303,7 +303,7 @@ function getReportSearchFilters(): ReportFilterType {
                 .withMinute(59)
                 .withSecond(59)
                 .withNano(999);
-        console.log(`--> ${DateTimeFormatter.ISO_DATE_TIME.format(adjusted)}`);
+
         return DateTimeFormatter.ISO_DATE_TIME.format(adjusted);
       }),
     });

--- a/admin-frontend/src/components/ReportSearchFilters.vue
+++ b/admin-frontend/src/components/ReportSearchFilters.vue
@@ -291,9 +291,7 @@ function getReportSearchFilters(): ReportFilterType {
       key: 'create_date',
       operation: 'between',
       value: submissionDateRange.value.map((d, i) => {
-        const jodaZonedDateTime = ZonedDateTime.from(
-          nativeJs(d),
-        ).withZoneSameLocal(ZoneId.of('UTC'));
+        const jodaZonedDateTime = ZonedDateTime.from(nativeJs(d));
         const adjusted =
           i == 0
             ? jodaZonedDateTime //start of day
@@ -306,6 +304,7 @@ function getReportSearchFilters(): ReportFilterType {
                 .withMinute(59)
                 .withSecond(59)
                 .withNano(999);
+        console.log(`--> ${DateTimeFormatter.ISO_DATE_TIME.format(adjusted)}`);
         return DateTimeFormatter.ISO_DATE_TIME.format(adjusted);
       }),
     });

--- a/admin-frontend/src/components/ReportSearchFilters.vue
+++ b/admin-frontend/src/components/ReportSearchFilters.vue
@@ -244,7 +244,6 @@ import {
   ZonedDateTime,
   nativeJs,
   DateTimeFormatter,
-  ZoneId,
   LocalDate,
 } from '@js-joda/core';
 import { Locale } from '@js-joda/locale_en';

--- a/backend/src/v1/services/admin-report-service.spec.ts
+++ b/backend/src/v1/services/admin-report-service.spec.ts
@@ -180,6 +180,21 @@ describe('admin-report-service', () => {
     });
 
     describe('filtering', () => {
+      describe('when there are dates in the filter', () => {
+        it('dates in the filters are converted to UTC', async () => {
+          await adminReportService.searchReport(
+            0,
+            10,
+            '[]',
+            '[{"key": "create_date", "operation": "between", "value": ["2024-10-02T00:00:00-07:00", "2024-10-02T23:59:59-07:00"] }]',
+          );
+          const { where } = mockFindMany.mock.calls[0][0];
+          expect(where.create_date).toEqual({
+            gte: '2024-10-02T07:00:00Z',
+            lt: '2024-10-03T06:59:59Z',
+          });
+        });
+      });
       describe('when filter is valid', () => {
         describe('reporting year', () => {
           it('eq', async () => {

--- a/backend/src/v1/services/admin-report-service.ts
+++ b/backend/src/v1/services/admin-report-service.ts
@@ -12,6 +12,7 @@ import {
 } from '../types/report-search';
 import { PayTransparencyUserError } from './file-upload-service';
 import { reportService } from './report-service';
+import { utils } from './utils-service';
 
 interface IGetReportMetricsInput {
   reportingYear: number;
@@ -34,7 +35,7 @@ const adminReportService = {
   ): Promise<any> {
     offset = offset || 0;
     let sortObj: ReportSortType = [];
-    let filterObj: ReportFilterType[] = [];
+    let filters: ReportFilterType[] = [];
     if (limit < 0) {
       throw new PayTransparencyUserError('Invalid limit');
     }
@@ -43,14 +44,16 @@ const adminReportService = {
     }
     try {
       sortObj = JSON.parse(sort);
-      filterObj = JSON.parse(filter);
+      filters = JSON.parse(filter);
     } catch (e) {
       throw new PayTransparencyUserError('Invalid query parameters');
     }
 
-    await FilterValidationSchema.parseAsync(filterObj);
+    await FilterValidationSchema.parseAsync(filters);
 
-    const where = this.convertFiltersToPrismaFormat(filterObj);
+    filters = utils.convertIsoDateStringsToUtc(filters, 'value');
+
+    const where = this.convertFiltersToPrismaFormat(filters);
 
     const orderBy =
       adminReportServicePrivate.convertSortToPrismaFormat(sortObj);

--- a/backend/src/v1/services/announcements-service.ts
+++ b/backend/src/v1/services/announcements-service.ts
@@ -5,6 +5,7 @@ import {
   ZonedDateTime,
   ZoneId,
 } from '@js-joda/core';
+import '@js-joda/timezone';
 import {
   announcement,
   announcement_resource,
@@ -13,6 +14,7 @@ import {
 } from '@prisma/client';
 import { DefaultArgs } from '@prisma/client/runtime/library';
 import isEmpty from 'lodash/isEmpty';
+import { config } from '../../config';
 import { logger } from '../../logger';
 import prisma from '../prisma/prisma-client';
 import { PaginatedResult } from '../types';
@@ -24,8 +26,6 @@ import {
 } from '../types/announcements';
 import { UserInputError } from '../types/errors';
 import { utils } from './utils-service';
-import { config } from '../../config';
-import '@js-joda/timezone';
 
 const saveHistory = async (
   tx: Omit<
@@ -132,6 +132,8 @@ export const announcementService = {
   async getAnnouncements(
     query: AnnouncementQueryType = {},
   ): Promise<PaginatedResult<announcement>> {
+    query.filters = utils.convertIsoDateStringsToUtc(query.filters, 'value');
+
     const where = buildAnnouncementWhereInput(query);
     const orderBy = buildAnnouncementSortInput(query);
     const items = await prisma.announcement.findMany({

--- a/backend/src/v1/services/utils-service.spec.ts
+++ b/backend/src/v1/services/utils-service.spec.ts
@@ -80,7 +80,7 @@ describe('utils-service', () => {
           throw new Error('test');
         });
 
-        expect(utils.parseJwt('test')).toBe(null);
+        expect(utils.parseJwt('test')).toBeNull();
       });
     });
 
@@ -158,7 +158,7 @@ describe('utils-service', () => {
       });
     });
     describe('when typeHints are provided', () => {
-      it('the executed SQL includes casts to te specified hints', () => {
+      it('the executed SQL includes casts to te specified hints', async () => {
         const mockTx = {
           $executeRawUnsafe: jest.fn(),
         };
@@ -169,7 +169,7 @@ describe('utils-service', () => {
         const mockTableName = 'mock_table';
         const primaryKeyCol = 'mock_table_id';
 
-        utils.updateManyUnsafe(
+        await utils.updateManyUnsafe(
           mockTx,
           updates,
           typeHints,
@@ -196,6 +196,33 @@ describe('utils-service', () => {
         expect(executedSql).toContain(
           `'${updates[0].third_col}'::${typeHints.third_col}`,
         );
+      });
+    });
+  });
+
+  describe('convertIsoDateStringsToUtc', () => {
+    describe('given an array of objects with the wrong form', () => {
+      it('throws an error', () => {
+        const items = [{}];
+        expect(() =>
+          utils.convertIsoDateStringsToUtc(items, 'some_attribute'),
+        ).toThrow(
+          "All objects in the given array are expected to have a property called 'some_attribute'",
+        );
+      });
+    });
+    describe('given an array of objects, some of which have dates, and some which do not', () => {
+      it('returns a copy of the array, with modified copies of those items that have dates, and unmodified copies of the other items', () => {
+        const items = [
+          { value: '2024-10-02T00:00:00-07:00' },
+          { value: 'not a date' },
+        ];
+        const modifiedCopies = utils.convertIsoDateStringsToUtc(items, 'value');
+        const expected = [
+          { value: '2024-10-02T07:00:00Z' }, //date string converted to UTC
+          { value: 'not a date' }, //not modified
+        ];
+        expect(modifiedCopies).toStrictEqual(expected);
       });
     });
   });


### PR DESCRIPTION
# Description

Fixes # [GEO-1198](https://finrms.atlassian.net/browse/GEO-1198)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

New unit tests

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have already been accepted and merged

[GEO-1198]: https://finrms.atlassian.net/browse/GEO-1198?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://pay-transparency-pr-822-frontend.apps.silver.devops.gov.bc.ca)
- [Admin Frontend](https://pay-transparency-pr-822-admin-frontend.apps.silver.devops.gov.bc.ca)
- [Backend external API console](https://pay-transparency-pr-822-backend-external.apps.silver.devops.gov.bc.ca/api/V1/docs)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/fin-pay-transparency/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/fin-pay-transparency/actions/workflows/merge.yml)