### PR TITLE
fix: GEO-1007 s3 now reports deleted objects

### DIFF
--- a/backend/src/external/services/s3-api.ts
+++ b/backend/src/external/services/s3-api.ts
@@ -124,7 +124,7 @@ export const deleteFiles = async (ids: string[]): Promise<Set<string>> => {
   try {
     // Get all the files stored under each id
     const filesPerId = await Promise.all(
-      ids.map((id) => getFileList(s3Client, id)), //TODO: try deleting the folders instead of each individual file. https://stackoverflow.com/a/73367823
+      ids.map((id) => getFileList(s3Client, id)),
     );
     const idsWithNoFiles = ids.filter(
       (id, index) => filesPerId[index].length === 0,
@@ -150,7 +150,7 @@ export const deleteFiles = async (ids: string[]): Promise<Set<string>> => {
 
     // report any errors
     responsePerGroup.forEach((r) =>
-      r.Errors.forEach((e) => {
+      r.Errors?.forEach((e) => {
         if (e.Code == 'NoSuchKey') idsWithNoFiles.push(getIdFromKey(e.Key));
         logger.error(e.Message);
       }),
@@ -158,7 +158,7 @@ export const deleteFiles = async (ids: string[]): Promise<Set<string>> => {
 
     // Return the id of all successful deleted
     const successfulIds = responsePerGroup.flatMap((r) =>
-      r.Deleted.reduce((acc, x) => {
+      r.Deleted?.reduce((acc, x) => {
         acc.push(getIdFromKey(x.Key));
         return acc;
       }, [] as string[]),


### PR DESCRIPTION
https://finrms.atlassian.net/browse/GEO-1007
Fixed a crash in the schedule that happens when there are no errors, and the code tries to loop through the errors anyways r.Errors.forEach() resulting in a crash.

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://pay-transparency-pr-841-frontend.apps.silver.devops.gov.bc.ca)
- [Admin Frontend](https://pay-transparency-pr-841-admin-frontend.apps.silver.devops.gov.bc.ca)
- [Backend external API console](https://pay-transparency-pr-841-backend-external.apps.silver.devops.gov.bc.ca/api/V1/docs)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/fin-pay-transparency/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/fin-pay-transparency/actions/workflows/merge.yml)