### PR TITLE
fix: GEO-1213 - admin tool - submission date in search reports csv now corresponds to 'create_date'

### DIFF
--- a/backend/src/v1/services/admin-report-service.spec.ts
+++ b/backend/src/v1/services/admin-report-service.spec.ts
@@ -600,7 +600,7 @@ describe('admin-report-service', () => {
       });
     });
   });
-  /*
+
   describe('toHumanFriendlyReport', () => {
     describe('given a report of the form returned by searchReport', () => {
       it('returns a flattened and simplified report', () => {
@@ -640,24 +640,24 @@ describe('admin-report-service', () => {
             company_name: 'BC Crown Corp',
           },
         };
+
         const result = adminReportService.toHumanFriendlyReport(mockReport);
-        expect(result['Submission date']).toBe(mockReport.update_date);
-        expect(result['Company name']).toBe(
+        expect(result['Submission Date']).toBe(mockReport.create_date);
+        expect(result['Employer Name']).toBe(
           mockReport.pay_transparency_company.company_name,
         );
-        expect(result['Reporting year']).toBe(mockReport.reporting_year);
-        expect(result['NAICS code']).toBe(mockReport.naics_code);
-        expect(result['Employee count']).toBe(
+        expect(result['Reporting Year']).toBe(mockReport.reporting_year);
+        expect(result['NAICS Code']).toBe(mockReport.naics_code);
+        expect(result['Employee Count']).toBe(
           mockReport.employee_count_range.employee_count_range,
         );
-        expect(result['Is unlocked?']).toBe(
+        expect(result['Is Unlocked']).toBe(
           mockReport.is_unlocked ? 'Yes' : 'No',
         );
-        expect(Object.keys(result).length).toBe(6);
+        expect(Object.keys(result)).toHaveLength(6);
       });
     });
   });
-  */
 
   describe('changeReportLockStatus', () => {
     it('should throw error if report does not exist', async () => {

--- a/backend/src/v1/services/admin-report-service.ts
+++ b/backend/src/v1/services/admin-report-service.ts
@@ -107,9 +107,8 @@ const adminReportService = {
 
     // Convert the boolean "true" and "false" values into "Yes" and "No"
     flattened['is_unlocked'] = flattened['is_unlocked'] ? 'Yes' : 'No';
-
     const attrsToRename = {
-      update_date: 'Submission Date',
+      create_date: 'Submission Date',
       company_name: 'Employer Name',
       naics_code: 'NAICS Code',
       employee_count_range: 'Employee Count',


### PR DESCRIPTION
# Description

Fixes # [GEO-1213](https://finrms.atlassian.net/browse/GEO-1213)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

New unit test

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have already been accepted and merged



---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://pay-transparency-pr-843-frontend.apps.silver.devops.gov.bc.ca)
- [Admin Frontend](https://pay-transparency-pr-843-admin-frontend.apps.silver.devops.gov.bc.ca)
- [Backend external API console](https://pay-transparency-pr-843-backend-external.apps.silver.devops.gov.bc.ca/api/V1/docs)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/fin-pay-transparency/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/fin-pay-transparency/actions/workflows/merge.yml)