### PR TITLE
feat: GEO-1189 - removed flags allowing dashboard and analytics pages to be disabled

### DIFF
--- a/admin-frontend/Caddyfile
+++ b/admin-frontend/Caddyfile
@@ -19,8 +19,6 @@
       Content-Type text/javascript
     }
     respond `window.config = {
-      "IS_ADMIN_DASHBOARD_AVAILABLE":"{$IS_ADMIN_DASHBOARD_AVAILABLE}",
-      "IS_ADMIN_ANALYTICS_AVAILABLE":"{$IS_ADMIN_ANALYTICS_AVAILABLE}",
       "SNOWPLOW_URL":"{$SNOWPLOW_URL}"
     };`
   }

--- a/admin-frontend/src/components/AnalyticsPage.vue
+++ b/admin-frontend/src/components/AnalyticsPage.vue
@@ -10,7 +10,7 @@
     >Web Traffic Analytics</v-btn
   >
 
-  <div v-if="isAnalyticsAvailable" class="w-100 overflow-x-auto">
+  <div class="w-100 overflow-x-auto">
     <div
       v-for="[name, details] in powerBiDetailsPerResource"
       :key="name"
@@ -47,16 +47,11 @@ type PowerBiDetails = {
 
 const snowplowUrl = (window as any).config?.SNOWPLOW_URL;
 
-const isAnalyticsAvailable =
-  (window as any).config?.IS_ADMIN_ANALYTICS_AVAILABLE?.toUpperCase() == 'TRUE';
-
 const powerBiDetailsPerResource = createDefaultPowerBiDetailsMap([
   POWERBI_RESOURCE.ANALYTICS,
 ]);
 
-if (isAnalyticsAvailable) {
-  getPowerBiAccessToken(powerBiDetailsPerResource);
-}
+getPowerBiAccessToken(powerBiDetailsPerResource);
 
 /** Create a Map containing the details of the resources. */
 function createDefaultPowerBiDetailsMap(

--- a/admin-frontend/src/components/DashboardPage.vue
+++ b/admin-frontend/src/components/DashboardPage.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-row v-if="isDashboardAvailable" :dense="true" class="w-100">
+  <v-row :dense="true" class="w-100">
     <v-col sm="12" md="12" lg="7" xl="6" class="mb-4">
       <h4 class="mb-4">
         <v-icon icon="mdi-clipboard-text-outline"></v-icon>
@@ -85,8 +85,6 @@ import ToolTip from './ToolTip.vue';
 import { ref, onMounted } from 'vue';
 
 const refreshIntervalMinutes: number = 5;
-const isDashboardAvailable =
-  (window as any).config?.IS_ADMIN_DASHBOARD_AVAILABLE?.toUpperCase() == 'TRUE';
 
 const recentlySubmittedReports = ref<typeof RecentlySubmittedReports>();
 const recentlyViewedReports = ref<typeof RecentlyViewedReports>();


### PR DESCRIPTION
# Description

Fixes # [GEO-1189](https://finrms.atlassian.net/browse/GEO-1189)

[GEO-1189]: https://finrms.atlassian.net/browse/GEO-1189?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://pay-transparency-pr-857-frontend.apps.silver.devops.gov.bc.ca)
- [Admin Frontend](https://pay-transparency-pr-857-admin-frontend.apps.silver.devops.gov.bc.ca)
- [Backend external API console](https://pay-transparency-pr-857-backend-external.apps.silver.devops.gov.bc.ca/api/V1/docs)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/fin-pay-transparency/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/fin-pay-transparency/actions/workflows/merge.yml)