### PR TITLE
fix: GEO-1239 - edit expired announcement now has default 'save as' status of 'DRAFT'

### DIFF
--- a/admin-frontend/src/components/announcements/AnnouncementForm.vue
+++ b/admin-frontend/src/components/announcements/AnnouncementForm.vue
@@ -398,6 +398,11 @@ import AnnouncementStatusChip from './AnnouncementStatusChip.vue';
 import type { VTextField } from 'vuetify/components';
 import RichTextArea from '../RichTextArea.vue';
 
+const announcementStatusOptions = [
+  AnnouncementStatus.Draft,
+  AnnouncementStatus.Published,
+];
+
 // References to component's exported properties
 const announcementTitleRef = ref<VTextField | null>(null);
 const linkUrlRef = ref<VTextField | null>(null);
@@ -480,7 +485,11 @@ const { handleSubmit, setErrors, errors, meta, values } = useForm({
     linkDisplayName: announcement?.linkDisplayName || '',
     fileDisplayName: announcement?.fileDisplayName || '',
     attachmentId: announcement?.attachmentId || v4(),
-    status: announcement?.status || 'DRAFT',
+    status:
+      announcement?.status &&
+      announcementStatusOptions.indexOf(announcement.status as any) >= 0
+        ? announcement.status
+        : AnnouncementStatus.Draft,
     attachment: undefined,
   },
   validationSchema: {


### PR DESCRIPTION
# Description

This fix prevents users from receiving a not-very-descriptive error messages if they edit and try saving an expired announcement without first choosing a status of 'DRAFT' or 'PUBLISHED'.

Fixes # [GEO-1239](https://finrms.atlassian.net/browse/GEO-1239)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- New unit test

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have already been accepted and merged

[GEO-1239]: https://finrms.atlassian.net/browse/GEO-1239?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://pay-transparency-pr-861-frontend.apps.silver.devops.gov.bc.ca)
- [Admin Frontend](https://pay-transparency-pr-861-admin-frontend.apps.silver.devops.gov.bc.ca)
- [Backend external API console](https://pay-transparency-pr-861-backend-external.apps.silver.devops.gov.bc.ca/api/V1/docs)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/fin-pay-transparency/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/fin-pay-transparency/actions/workflows/merge.yml)