### PR TITLE
fix: GEO-1129 adjust vue-datepicker style to match other vuetify components

### DIFF
--- a/admin-frontend/src/App.vue
+++ b/admin-frontend/src/App.vue
@@ -318,6 +318,7 @@ input.dp__input {
     0px 1px 5px 0px var(--v-shadow-key-ambient-opacity, rgba(0, 0, 0, 0.12));
   padding-top: 7px !important;
   padding-bottom: 7px !important;
+  border: none;
 }
 
 .dp__input_invalid {

--- a/admin-frontend/src/components/announcements/AnnouncementForm.vue
+++ b/admin-frontend/src/components/announcements/AnnouncementForm.vue
@@ -963,4 +963,11 @@ const handleSave = handleSubmit(async (values) => {
   align-items: center;
   justify-content: space-between;
 }
+
+/* Override styles of the Vue3DatePicker so it looks similar other inputs 
+in this component */
+:deep(.dp__input) {
+  box-shadow: none !important;
+  border: 1px solid #aaaaaa;
+}
 </style>


### PR DESCRIPTION
# Description

Adjusted the style of the vue-datepicker components in the admin tool.  It now matches the style of other vuetify components around it.

Fixes # [GEO-1129](https://finrms.atlassian.net/browse/GEO-1129)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- visual inspection

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have already been accepted and merged

[GEO-1129]: https://finrms.atlassian.net/browse/GEO-1129?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://pay-transparency-pr-870-frontend.apps.silver.devops.gov.bc.ca)
- [Admin Frontend](https://pay-transparency-pr-870-admin-frontend.apps.silver.devops.gov.bc.ca)
- [Backend external API console](https://pay-transparency-pr-870-backend-external.apps.silver.devops.gov.bc.ca/api/V1/docs)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/fin-pay-transparency/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/fin-pay-transparency/actions/workflows/merge.yml)