### PR TITLE
fix: GEO-1262 - save announcements in which plain text description length <= 2000 chars, but rich text is > 2000 chars.

### DIFF
--- a/backend/src/v1/routes/announcement-routes.spec.ts
+++ b/backend/src/v1/routes/announcement-routes.spec.ts
@@ -425,13 +425,16 @@ describe('announcement-routes', () => {
         mockCreateAnnouncement.mockResolvedValue({
           message: 'Announcement created',
         });
-        const response = await request(app).post('/').send({
-          title: 'Test',
-          description: 'Test',
-          expires_on: faker.date.recent(),
-          active_on: faker.date.future(),
-          status: 'DRAFT',
-        });
+        const response = await request(app)
+          .post('/')
+          .send({
+            title: 'Test',
+            //long description.  this would be rejected by the frontend, but should be allowed by the backend
+            description: '0'.repeat(2001),
+            expires_on: faker.date.recent(),
+            active_on: faker.date.future(),
+            status: 'DRAFT',
+          });
         expect(response.status).toBe(201);
         expect(response.body).toEqual({ message: 'Announcement created' });
       });

--- a/backend/src/v1/routes/announcement-routes.spec.ts
+++ b/backend/src/v1/routes/announcement-routes.spec.ts
@@ -429,7 +429,10 @@ describe('announcement-routes', () => {
           .post('/')
           .send({
             title: 'Test',
-            //long description.  this would be rejected by the frontend, but should be allowed by the backend
+            //long description.  this would be rejected by the frontend,
+            //but should be allowed by the backend (because the backend expects
+            //some of the characters may be rich text markup, which the system doesn't
+            //put a limit on
             description: '0'.repeat(2001),
             expires_on: faker.date.recent(),
             active_on: faker.date.future(),

--- a/backend/src/v1/types/announcements.ts
+++ b/backend/src/v1/types/announcements.ts
@@ -145,7 +145,7 @@ export type PatchAnnouncementsType = z.infer<typeof PatchAnnouncementsSchema>;
 export const AnnouncementDataSchema = z
   .object({
     title: z.string().min(1).max(100),
-    description: z.string().min(1).max(2000),
+    description: z.string().min(1),
     active_on: z.string().optional(),
     expires_on: z.string().optional(),
     status: z.enum(['PUBLISHED', 'DRAFT']),


### PR DESCRIPTION
# Description

Fixes # [GEO-1262](https://finrms.atlassian.net/browse/GEO-1262)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Updated an existing unit test

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have already been accepted and merged

[GEO-1262]: https://finrms.atlassian.net/browse/GEO-1262?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://pay-transparency-pr-872-frontend.apps.silver.devops.gov.bc.ca)
- [Admin Frontend](https://pay-transparency-pr-872-admin-frontend.apps.silver.devops.gov.bc.ca)
- [Backend external API console](https://pay-transparency-pr-872-backend-external.apps.silver.devops.gov.bc.ca/api/V1/docs)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/fin-pay-transparency/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/fin-pay-transparency/actions/workflows/merge.yml)