### PR TITLE
test: fix broken test due to the new year

### DIFF
--- a/.vscode/fin-pay-transparency.code-workspace
+++ b/.vscode/fin-pay-transparency.code-workspace
@@ -25,20 +25,25 @@
   ],
   "settings": {
     "jest.disabledWorkspaceFolders": [
-      "fin-pay-transparency",
+      // jest doesn't know which multi-root projects contain jest tests or not,
+      // so we have to specify which ones don't.
+      "infrastructure",
       "frontend",
-      "admin-frontend"
+      "admin-frontend",
+      "clamav-service"
     ],
     "editor.defaultFormatter": "esbenp.prettier-vscode",
     "editor.formatOnSave": true,
     "editor.formatOnPaste": true,
     "files.exclude": {
+      // exclude these files from the main workspace,
+      // otherwise they will show up twice, which is confusing.
       "backend": true,
       "frontend": true,
       "admin-frontend": true,
       "doc-gen-service": true,
       "backend-external": true,
-      "clamav-service": true,
+      "clamav-service": true
     }
   }
 }

--- a/backend-external/.gitignore
+++ b/backend-external/.gitignore
@@ -1,3 +1,4 @@
 node_modules
+coverage
 # Keep environment variables out of version control
 .env

--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -1,3 +1,4 @@
 node_modules
+coverage
 # Keep environment variables out of version control
 .env

--- a/doc-gen-service/.gitignore
+++ b/doc-gen-service/.gitignore
@@ -1,3 +1,4 @@
 node_modules
+coverage
 # Keep environment variables out of version control
 .env

--- a/frontend/src/components/__tests__/InputForm.spec.ts
+++ b/frontend/src/components/__tests__/InputForm.spec.ts
@@ -52,7 +52,7 @@ const mockReport = {
 const mockConfig = {
   maxUploadFileSize: 8388608, //bytes
   reportEditDurationInDays: 30,
-  reportingYearOptions: [2023, 2024],
+  reportingYearOptions: [LocalDate.now().year() - 1, LocalDate.now().year()],
 };
 
 describe('InputForm', () => {


### PR DESCRIPTION
With the new year, one of the tests started failing because it had hard-coded last year (2024) into it's test. Updated the test to dynamically load the current year which aligns with the tests that use the current year.

Also, update .gitignore so that when searching in vscode multi-root projects, the 'coverage' directory is properly ignored.

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://pay-transparency-pr-888-frontend.apps.silver.devops.gov.bc.ca)
- [Admin Frontend](https://pay-transparency-pr-888-admin-frontend.apps.silver.devops.gov.bc.ca)
- [Backend external API console](https://pay-transparency-pr-888-backend-external.apps.silver.devops.gov.bc.ca/api/V1/docs)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/fin-pay-transparency/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/fin-pay-transparency/actions/workflows/merge.yml)