### PR TITLE
fix(resources): Increment PVC size for crunchy instances

### DIFF
--- a/charts/fin-pay-transparency/values-prod.yaml
+++ b/charts/fin-pay-transparency/values-prod.yaml
@@ -182,7 +182,7 @@ crunchy:
         prometheus.io/port: "9187"
     replicas: 3
     dataVolumeClaimSpec:
-      storage: 600Mi
+      storage: 700Mi
       storageClassName: netapp-block-standard
     requests:
       cpu: 150m


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description
PVC size for PostgreSQL crunchy cluster has been increased for production environment. PVC was filled up causing one of the cluster member to fail.

## Type of change
Resource increment for crunchy cluster.

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc


---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://pay-transparency-pr-891-frontend.apps.silver.devops.gov.bc.ca)
- [Admin Frontend](https://pay-transparency-pr-891-admin-frontend.apps.silver.devops.gov.bc.ca)
- [Backend external API console](https://pay-transparency-pr-891-backend-external.apps.silver.devops.gov.bc.ca/api/V1/docs)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/fin-pay-transparency/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/fin-pay-transparency/actions/workflows/merge.yml)