### PR TITLE
chore(fix): Add openshift security context flag

### DIFF
--- a/charts/fin-pay-transparency/charts/crunchy-postgres/templates/PostgresCluster.yaml
+++ b/charts/fin-pay-transparency/charts/crunchy-postgres/templates/PostgresCluster.yaml
@@ -35,6 +35,9 @@ spec:
   {{- end}}
   {{ if .Values.pgmonitor.enabled }}
 
+  # Added to ensure openshift security context compatibility
+  openshift: true
+
   monitoring:
     pgmonitor:
       # this stuff is for the "exporter" container in the "postgres-cluster-ha" set of pods


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description

A recent OpenShift platform change caused crunchy cluster to fail because of OpenShift security context compatibility.

Fixes # (issue)
https://finrms.atlassian.net/browse/GEO-1279 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
Changes have been tested as crunchy cluster is functional after making the changes which was non-functional before the changes.


## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://pay-transparency-pr-929-frontend.apps.silver.devops.gov.bc.ca)
- [Admin Frontend](https://pay-transparency-pr-929-admin-frontend.apps.silver.devops.gov.bc.ca)
- [Backend external API console](https://pay-transparency-pr-929-backend-external.apps.silver.devops.gov.bc.ca/api/V1/docs)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/fin-pay-transparency/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/fin-pay-transparency/actions/workflows/merge.yml)