### PR TITLE
fix(workflows): install oc CLI before usage

### DIFF
--- a/.github/workflows/build-deploy-clamav-to-tools.yml
+++ b/.github/workflows/build-deploy-clamav-to-tools.yml
@@ -41,6 +41,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         name: checkout
+      - name: Install OpenShift CLI
+        run: |
+          curl -LO https://mirror.openshift.com/pub/openshift-v4/clients/oc/latest/linux/oc.tar.gz
+          tar -xzf oc.tar.gz
+          sudo mv oc /usr/local/bin/
       - name: Login to OpenShift
         shell: bash
         run: |

--- a/.github/workflows/cleanup-on-pr-close.yml
+++ b/.github/workflows/cleanup-on-pr-close.yml
@@ -33,6 +33,11 @@ jobs:
       release: pay-transparency-pr-${{ github.event.number }}
     runs-on: ubuntu-24.04
     steps:
+      - name: Install OpenShift CLI
+        run: |
+          curl -LO https://mirror.openshift.com/pub/openshift-v4/clients/oc/latest/linux/oc.tar.gz
+          tar -xzf oc.tar.gz
+          sudo mv oc /usr/local/bin/
       - name: Remove OpenShift artifacts
         run: |
           oc login --token=${{ secrets.OC_TOKEN }} --server=${{ vars.OC_SERVER }}

--- a/.github/workflows/cleanup_tag_hotfix-pr-close.yml
+++ b/.github/workflows/cleanup_tag_hotfix-pr-close.yml
@@ -33,6 +33,11 @@ jobs:
       release: pay-transparency-pr-${{ github.event.number }}
     runs-on: ubuntu-24.04
     steps:
+      - name: Install OpenShift CLI
+        run: |
+          curl -LO https://mirror.openshift.com/pub/openshift-v4/clients/oc/latest/linux/oc.tar.gz
+          tar -xzf oc.tar.gz
+          sudo mv oc /usr/local/bin/
       - name: Remove OpenShift artifacts
         run: |
           oc login --token=${{ secrets.OC_TOKEN }} --server=${{ vars.OC_SERVER }}

--- a/.github/workflows/maintenance.yml
+++ b/.github/workflows/maintenance.yml
@@ -27,7 +27,12 @@ jobs:
       runs-on: ubuntu-24.04
       environment: ${{ github.event.inputs.environment }}
       if: ${{ github.event.inputs.action == 'true' }}
-      steps:
+      steps:        
+        - name: Install OpenShift CLI
+          run: |
+            curl -LO https://mirror.openshift.com/pub/openshift-v4/clients/oc/latest/linux/oc.tar.gz
+            tar -xzf oc.tar.gz
+            sudo mv oc /usr/local/bin/
         - name: Login to OpenShift
           shell: bash
           run: |
@@ -54,6 +59,11 @@ jobs:
         environment: ${{ github.event.inputs.environment }}
         if: ${{ github.event.inputs.action == 'false' }}
         steps:
+            - name: Install OpenShift CLI
+              run: |
+                curl -LO https://mirror.openshift.com/pub/openshift-v4/clients/oc/latest/linux/oc.tar.gz
+                tar -xzf oc.tar.gz
+                sudo mv oc /usr/local/bin/
             - name: Login to OpenShift
               shell: bash
               run: |

--- a/.github/workflows/sysdig.yml
+++ b/.github/workflows/sysdig.yml
@@ -12,6 +12,11 @@ jobs:
       environment: tools
       steps:
       - uses: actions/checkout@v4
+      - name: Install OpenShift CLI
+        run: |
+          curl -LO https://mirror.openshift.com/pub/openshift-v4/clients/oc/latest/linux/oc.tar.gz
+          tar -xzf oc.tar.gz
+          sudo mv oc /usr/local/bin/
       - name: Add Sysdig Team
         run: |
           oc login --token=${{ secrets.oc_token }} --server=${{ vars.oc_server }}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description
oc CLI installation step added in workflows before using oc CLI in GitHub workflow jobs

Fixes # (issue)
Breaking GitHub workflow(s) introduced by https://github.com/bcgov/fin-pay-transparency/pull/855 

## Type of change
Please delete options that are not relevant.
- [x] GitHub workflow(s) fix to ensure GitHub workflows are working as expected

# How Has This Been Tested?
- [x] GitHub workflow files have been executed to test the changes

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] Any dependent changes have already been accepted and merged