### PR TITLE
fix: GEO-1280 Lock status missing in history

### DIFF
--- a/backend/src/v1/services/admin-report-service.spec.ts
+++ b/backend/src/v1/services/admin-report-service.spec.ts
@@ -973,7 +973,7 @@ describe('admin-report-service', () => {
         });
       });
 
-      it('handles unknown action when no changes detected', async () => {
+      it('assumes locked status action when no changes detected', async () => {
         const mockReportId = '4492feff-99d7-4b2b-8896-12a59a75d4e1';
         const mockReport = {
           report_id: mockReportId,
@@ -1007,7 +1007,7 @@ describe('admin-report-service', () => {
         expect(reportAdminActionHistory).toHaveLength(2);
         expect(reportAdminActionHistory[1]).toEqual({
           report_history_id: 'hist-1',
-          action: 'Unknown',
+          action: 'Unlocked',
           admin_modified_date: mockHistoryRecords[0].admin_modified_date,
           admin_user_display_name: 'History Admin 1',
         });

--- a/backend/src/v1/services/admin-report-service.ts
+++ b/backend/src/v1/services/admin-report-service.ts
@@ -237,14 +237,6 @@ const adminReportService = {
         // Don't keep this if it wasn't an admin action
         if (item.admin_modified_date < item.update_date) return acc;
 
-        // Determine the action based on what changed
-        const ret: ReportAdminActionHistory = {
-          report_history_id: item.report_history_id,
-          action: 'Unknown',
-          admin_modified_date: item.admin_modified_date,
-          admin_user_display_name: item.admin_user.display_name,
-        };
-
         let previousItem;
         if (index < allHistory.length - 1) {
           // Next item in descending order is the previous action
@@ -258,12 +250,19 @@ const adminReportService = {
           previousItem = { report_status: 'Published', is_unlocked: true };
         }
 
-        // Compare with previous action to see what changed
+        // prepare the return object
+        const ret: ReportAdminActionHistory = {
+          report_history_id: item.report_history_id,
+          action: item.is_unlocked ? 'Unlocked' : 'Locked', //assume the action was locking/unlocking
+          admin_modified_date: item.admin_modified_date,
+          admin_user_display_name: item.admin_user.display_name,
+        };
+
+        // If the report status changed, update the action accordingly
         if (item.report_status !== previousItem.report_status) {
           ret.action = item.report_status as 'Withdrawn' | 'Published';
-        } else if (item.is_unlocked !== previousItem.is_unlocked) {
-          ret.action = item.is_unlocked ? 'Unlocked' : 'Locked';
         }
+
         acc.push(ret);
         return acc;
       },


### PR DESCRIPTION


---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://pay-transparency-pr-962-frontend.apps.silver.devops.gov.bc.ca)
- [Admin Frontend](https://pay-transparency-pr-962-admin-frontend.apps.silver.devops.gov.bc.ca)
- [Backend external API console](https://pay-transparency-pr-962-backend-external.apps.silver.devops.gov.bc.ca/api/V1/docs)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/fin-pay-transparency/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/fin-pay-transparency/actions/workflows/merge.yml)