### PR TITLE
refactor(ci): enable automerge for backend and backend-external npm p…

### DIFF
--- a/.github/workflows/auto-approve-renovate.yaml
+++ b/.github/workflows/auto-approve-renovate.yaml
@@ -1,0 +1,60 @@
+name: Auto-approve Renovate PRs (backend and backend-external only)
+
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+
+jobs:
+  auto-approve:
+    if: github.actor == 'renovate[bot]'
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: read
+
+    steps:
+      - name: Get list of changed files
+        id: file-check
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const prNumber = context.payload.pull_request.number;
+            const { data: files } = await github.rest.pulls.listFiles({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: prNumber
+            });
+
+            const allowedPaths = [
+              /^backend\/package(-lock)?\.json$/,
+              /^backend-external\/package(-lock)?\.json$/
+            ];
+
+            for (const file of files) {
+              if (!allowedPaths.some(regex => regex.test(file.filename))) {
+                core.setFailed(`Unapproved file changed: ${file.filename}`);
+                return;
+              }
+            }
+
+            core.setOutput("approved", "true");
+            core.setOutput("prNumber", prNumber);
+
+       - name: Auto approve PR
+        if: steps.file-check.outputs.approved == 'true'
+        uses: hmarr/auto-approve-action@v3
+        with:
+          pull-request-number: ${{ steps.file-check.outputs.prNumber }}  
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Add auto-approved label
+        if: steps.file-check.outputs.approved == 'true'
+        uses: actions-ecosystem/action-add-labels@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          labels: auto-approved
+          number: ${{ steps.file-check.outputs.prNumber }}

--- a/renovate.json
+++ b/renovate.json
@@ -72,6 +72,24 @@
       "matchPackageNames": [
         "/msal-node/"
       ]
+    },
+    {
+      "description": "Automerge npm updates for backend",
+      "matchManagers": ["npm"],
+      "matchPaths": ["backend/**"],
+      "automerge": true,
+      "automergeType": "pr",
+      "labels": ["automerge", "npm-updates", "backend"],
+      "minimumReleaseAge": "7 days"
+    },
+    {
+      "description": "Automerge npm updates for backend-external",
+      "matchManagers": ["npm"],
+      "matchPaths": ["backend-external/**"],
+      "automerge": true,
+      "automergeType": "pr",
+      "labels": ["automerge", "npm-updates", "backend-external"],
+      "minimumReleaseAge": "7 days"
     }
   ],
   "lockFileMaintenance": {


### PR DESCRIPTION

<!-- Provide a general summary of your changes in the Title above -->

# Description
The configuration changes would enable renovate to auto-merge backend and backend-external npm packages when all check gates pass.

Task #
https://finrms.atlassian.net/browse/GEO-1306 

## Type of change
- [x] CI change for backend and backend-external renovate PRs

# How Has This Been Tested?

- New GitHub action workflow for auto-approval would be tested when a PR is created for backend and backend-external npm package updates by renovate[not]


## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc