### PR TITLE
fix: update file checking

### DIFF
--- a/.github/workflows/auto-approve-renovate.yaml
+++ b/.github/workflows/auto-approve-renovate.yaml
@@ -73,6 +73,6 @@ jobs:
           labels: auto-approved
           number: ${{ steps.file-check.outputs.prNumber }}
       
-      - name: Log approval
+      - name: Log PR approval
         if: steps.file-check.outputs.approved == 'true'
         run: echo "Auto-approved PR #${{ steps.file-check.outputs.prNumber }}"


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description
File checking logic has been updated to ensure workflow doesn't show status as failed when no files are found for approval in backend, backend-external and doc-gen-service

## Type of change
- [x] Fixes current logic of file checking in required components

# How Has This Been Tested?
- This would be tested when a new PR is generated by renovate bot for dependency update in any/all of backend, backend-external and doc-gen-service


## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://pay-transparency-pr-978-frontend.apps.silver.devops.gov.bc.ca)
- [Admin Frontend](https://pay-transparency-pr-978-admin-frontend.apps.silver.devops.gov.bc.ca)
- [Backend external API console](https://pay-transparency-pr-978-backend-external.apps.silver.devops.gov.bc.ca/api/V1/docs)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/fin-pay-transparency/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/fin-pay-transparency/actions/workflows/merge.yml)