### PR TITLE
chore: add auto approval flag

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -138,9 +138,11 @@ jobs:
       backend-external-url: https://pay-transparency-dev-backend-external.apps.silver.devops.gov.bc.ca/api
 
   get-last-deployed-and-check-human:
+    if: vars.PR_AUTO_APPROVAL_ENABLED == 'true'
     name: Get Last Deployed Version & Check Human Changes
     needs: [semantic-version, deploys]
     runs-on: ubuntu-24.04
+    environment: prod
     permissions:
       actions: read
     outputs:
@@ -162,7 +164,7 @@ jobs:
         with:
           oc_namespace: db4642-prod
           oc_server: ${{ vars.oc_server }}
-          oc_token: ${{ secrets.oc_token }} 
+          oc_token: ${{ secrets.OC_TOKEN }}
           commands: | 
              oc project db4642-prod
 
@@ -221,7 +223,8 @@ jobs:
     name: Trigger Test Deployment
     if:  >
       ( github.actor == 'dependabot[bot]' || github.actor == 'renovate[bot]' ) &&
-      ( needs.get-last-deployed-and-check-human.outputs.human_changes_exist == 'false' )
+      ( needs.get-last-deployed-and-check-human.outputs.human_changes_exist == 'false' ) &&
+      ( vars.PR_AUTO_APPROVAL_ENABLED == 'true')
     needs: [deploys,test-integration,semantic-version,get-last-deployed-and-check-human]
     uses: ./.github/workflows/cd-to-test-on-workflow-dispatch.yml
     secrets: inherit
@@ -232,7 +235,8 @@ jobs:
     name: Trigger Prod Deployment
     if:  >
       ( github.actor == 'dependabot[bot]' || github.actor == 'renovate[bot]' ) &&
-      ( needs.get-last-deployed-and-check-human.outputs.human_changes_exist == 'false' )
+      ( needs.get-last-deployed-and-check-human.outputs.human_changes_exist == 'false' ) &&
+      ( vars.PR_AUTO_APPROVAL_ENABLED == 'true')
     needs: [deploys,test-integration,semantic-version,trigger-test-deployment,get-last-deployed-and-check-human]
     uses: ./.github/workflows/cd-to-prod-on-workflow-dispatch.yml
     secrets: inherit


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description

This would allow all Renovate and Dependabot PRs to be merged automatically if CI check gates pass. The changes would be deployed to TEST and PROD environments automatically

## Type of change
- [x] CI/CD changes

# Jira Ticket:
https://fincsp.atlassian.net/browse/GEO-1350

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://pay-transparency-pr-1081-frontend.apps.silver.devops.gov.bc.ca)
- [Admin Frontend](https://pay-transparency-pr-1081-admin-frontend.apps.silver.devops.gov.bc.ca)
- [Backend external API console](https://pay-transparency-pr-1081-backend-external.apps.silver.devops.gov.bc.ca/api/V1/docs)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/fin-pay-transparency/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/fin-pay-transparency/actions/workflows/merge.yml)