### PR TITLE
chore(ci): Add environment to check human changes job

### DIFF
--- a/.github/workflows/auto-approve-deps-update.yaml
+++ b/.github/workflows/auto-approve-deps-update.yaml
@@ -1,4 +1,4 @@
-name: Auto-approve Renovate PRs
+name: Auto-approve Renovate and Dependabot PRs
 
 on:
   workflow_run:
@@ -9,7 +9,7 @@ on:
 
 jobs:
   auto-approve:
-    if: github.actor == 'renovate[bot]' || github.event_name == 'workflow_dispatch'
+    if: (github.actor == 'renovate[bot]' || github.event_name == 'workflow_dispatch') && vars.PR_AUTO_APPROVAL_ENABLED == 'true'
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
@@ -22,16 +22,25 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            const prNumber = context.payload.pull_request.number;
+            const prs = context.payload.workflow_run.pull_requests;
+            if (!prs || prs.length === 0) {
+              core.setOutput("approved", "false");
+              return;
+            }
+            
+            const prNumber = prs[0].number;
             const { data: files } = await github.rest.pulls.listFiles({
             owner: context.repo.owner,
             repo: context.repo.repo,
             pull_number: prNumber
             });
+
             const allowedPaths = [
               /^backend\/package(-lock)?\.json$/,
               /^backend-external\/package(-lock)?\.json$/,
               /^doc-gen-service\/package(-lock)?\.json$/,
+              /^admin-frontend\/package(-lock)?\.json$/,
+              /^frontend\/package(-lock)?\.json$/,
             ];
 
             const unapprovedFiles = files.filter(file =>
@@ -60,3 +69,10 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           labels: auto-approved
           number: ${{ steps.file-check.outputs.prNumber }}
+
+      - name: Enable auto-merge
+        if: steps.file-check.outputs.approved == 'true' && ( github.actor == 'dependabot[bot]' || github.actor == 'renovate[bot]' )
+        uses: peter-evans/enable-pull-request-automerge@v3
+        with:
+          pull-request-number: ${{ steps.file-check.outputs.prNumber }}
+          merge-method: squash

--- a/.github/workflows/auto-approve-deps-update.yaml
+++ b/.github/workflows/auto-approve-deps-update.yaml
@@ -5,11 +5,10 @@ on:
     workflows: ["Build And Deploy to Sandbox in Dev namespace"]
     types:
       - completed
-  workflow_dispatch:
 
 jobs:
   auto-approve:
-    if: (github.actor == 'renovate[bot]' || github.event_name == 'workflow_dispatch') && vars.PR_AUTO_APPROVAL_ENABLED == 'true'
+    if: (github.actor == 'renovate[bot]' || github.actor == 'dependabot[bot]' || github.event_name == 'workflow_dispatch') && vars.PR_AUTO_APPROVAL_ENABLED == 'true'
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write

--- a/.github/workflows/cd-to-prod-on-workflow-dispatch.yml
+++ b/.github/workflows/cd-to-prod-on-workflow-dispatch.yml
@@ -12,6 +12,12 @@ on:
         required: false
         default: false
         type: boolean
+  workflow_call:
+    inputs:
+      tag: 
+        description: "The Docker Tag to deploy, it would be the latest tagged version that you want to deploy to PROD."
+        required: true
+        type: string
 concurrency:
   group: ${{ github.workflow }}
   cancel-in-progress: true

--- a/.github/workflows/cd-to-test-on-workflow-dispatch.yml
+++ b/.github/workflows/cd-to-test-on-workflow-dispatch.yml
@@ -13,6 +13,12 @@ on:
         required: false
         default: false
         type: boolean
+  workflow_call:
+    inputs:
+      tag:
+        description: "The Docker Tag to deploy, it would be the latest tagged version that you want to deploy from dev to TEST."
+        required: true
+        type: string      
 concurrency:
   group: ${{ github.workflow }}
   cancel-in-progress: true

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -138,9 +138,11 @@ jobs:
       backend-external-url: https://pay-transparency-dev-backend-external.apps.silver.devops.gov.bc.ca/api
 
   get-last-deployed-and-check-human:
+    if: vars.PR_AUTO_APPROVAL_ENABLED == 'true'
     name: Get Last Deployed Version & Check Human Changes
     needs: [semantic-version, deploys]
     runs-on: ubuntu-24.04
+    environment: prod
     permissions:
       actions: read
     outputs:
@@ -162,7 +164,7 @@ jobs:
         with:
           oc_namespace: db4642-prod
           oc_server: ${{ vars.oc_server }}
-          oc_token: ${{ secrets.oc_token }} 
+          oc_token: ${{ secrets.OC_TOKEN }} 
           commands: | 
              oc project db4642-prod
 
@@ -221,7 +223,8 @@ jobs:
     name: Trigger Test Deployment
     if:  >
       ( github.actor == 'dependabot[bot]' || github.actor == 'renovate[bot]' ) &&
-      ( needs.get-last-deployed-and-check-human.outputs.human_changes_exist == 'false' )
+      ( needs.get-last-deployed-and-check-human.outputs.human_changes_exist == 'false' ) &&
+      ( vars.PR_AUTO_APPROVAL_ENABLED == 'true' )
     needs: [deploys,test-integration,semantic-version,get-last-deployed-and-check-human]
     uses: ./.github/workflows/cd-to-test-on-workflow-dispatch.yml
     secrets: inherit
@@ -232,7 +235,8 @@ jobs:
     name: Trigger Prod Deployment
     if:  >
       ( github.actor == 'dependabot[bot]' || github.actor == 'renovate[bot]' ) &&
-      ( needs.get-last-deployed-and-check-human.outputs.human_changes_exist == 'false' )
+      ( needs.get-last-deployed-and-check-human.outputs.human_changes_exist == 'false' ) &&
+      ( vars.PR_AUTO_APPROVAL_ENABLED == 'true' )
     needs: [deploys,test-integration,semantic-version,trigger-test-deployment,get-last-deployed-and-check-human]
     uses: ./.github/workflows/cd-to-prod-on-workflow-dispatch.yml
     secrets: inherit

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -138,17 +138,11 @@ jobs:
       backend-external-url: https://pay-transparency-dev-backend-external.apps.silver.devops.gov.bc.ca/api
 
   get-last-deployed-and-check-human:
-<<<<<<< HEAD
     if: vars.PR_AUTO_APPROVAL_ENABLED == 'true'
     name: Get Last Deployed Version & Check Human Changes
     needs: [semantic-version, deploys]
     runs-on: ubuntu-24.04
     environment: prod
-=======
-    name: Get Last Deployed Version & Check Human Changes
-    needs: [semantic-version, deploys]
-    runs-on: ubuntu-24.04
->>>>>>> 8404608 (chore: auto deployment for renovate/dependabot PRs (#1065))
     permissions:
       actions: read
     outputs:
@@ -170,11 +164,7 @@ jobs:
         with:
           oc_namespace: db4642-prod
           oc_server: ${{ vars.oc_server }}
-<<<<<<< HEAD
           oc_token: ${{ secrets.OC_TOKEN }} 
-=======
-          oc_token: ${{ secrets.oc_token }} 
->>>>>>> 8404608 (chore: auto deployment for renovate/dependabot PRs (#1065))
           commands: | 
              oc project db4642-prod
 

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -83,6 +83,13 @@ jobs:
           skip-commit: "true"
           skip-on-empty: "false"
           git-push: "true"
+      - name: Validate semantic version
+        run: |
+          if [ -z "${{ steps.changelog.outputs.version }}" ]; then
+            echo "Missing semantic version"
+            exit 1
+          fi
+          
   retag-images:
     needs: [vars, semantic-version]
     runs-on: ubuntu-24.04
@@ -131,11 +138,17 @@ jobs:
       backend-external-url: https://pay-transparency-dev-backend-external.apps.silver.devops.gov.bc.ca/api
 
   get-last-deployed-and-check-human:
+<<<<<<< HEAD
     if: vars.PR_AUTO_APPROVAL_ENABLED == 'true'
     name: Get Last Deployed Version & Check Human Changes
     needs: [semantic-version, deploys]
     runs-on: ubuntu-24.04
     environment: prod
+=======
+    name: Get Last Deployed Version & Check Human Changes
+    needs: [semantic-version, deploys]
+    runs-on: ubuntu-24.04
+>>>>>>> 8404608 (chore: auto deployment for renovate/dependabot PRs (#1065))
     permissions:
       actions: read
     outputs:
@@ -157,7 +170,11 @@ jobs:
         with:
           oc_namespace: db4642-prod
           oc_server: ${{ vars.oc_server }}
+<<<<<<< HEAD
           oc_token: ${{ secrets.OC_TOKEN }} 
+=======
+          oc_token: ${{ secrets.oc_token }} 
+>>>>>>> 8404608 (chore: auto deployment for renovate/dependabot PRs (#1065))
           commands: | 
              oc project db4642-prod
 

--- a/renovate.json
+++ b/renovate.json
@@ -23,20 +23,31 @@
     ":semanticCommitScope(deps)"
   ],
   "automerge": false,
+  "platformAutomerge": true,
+  "automergeType": "pr",
   "prConcurrentLimit": 2,
   "dependencyDashboard": true,
   "packageRules": [
     {
+      "description": "Always update vulnerable npm packages immediately",
+      "matchDatasources": ["npm"],
+      "vulnerabilityAlerts": true,
+      "minimumReleaseAge": "5 days",
+      "groupName": null,
+      "prPriority": 100,
+      "labels": ["vulnerability"],
+      "separateMinorPatch": true,
+      "automerge": true,
+      "platformAutomerge": true
+    },
+    {
       "description": "One week stability period for npm packages",
-      "matchDatasources": [
-        "npm"
-      ],
+      "matchDatasources": ["npm"],
       "minimumReleaseAge": "5 days"
     },
     {
-      "matchManagers": [
-        "github-actions"
-      ],
+      "description": "Grouped GitHub Actions updates",
+      "matchManagers": ["github-actions"],
       "groupName": "github actions all dependencies",
       "groupSlug": "github actions all",
       "minimumReleaseAge": "3 days"
@@ -62,67 +73,28 @@
     {
       "description": "JS - puppeteer",
       "groupName": "puppeteer",
-      "matchPackageNames": [
-        "/puppeteer/"
-      ]
+      "matchPackageNames": ["/puppeteer/"]
     },
     {
       "description": "JS - group microsoft",
       "groupName": "microsoft",
-      "matchPackageNames": [
-        "/msal-node/"
-      ]
+      "matchPackageNames": ["/msal-node/"]
     },
     {
-      "description": "Automerge npm updates for backend",
-      "matchManagers": [
-        "npm"
-      ],
+      "description": "Automerge npm updates",
+      "matchManagers": ["npm"],
       "matchFileNames": [
-        "backend/**"
-      ],
-      "automerge": true,
-      "automergeType": "pr",
-      "labels": [
-        "automerge",
-        "npm-updates",
-        "backend"
-      ],
-      "minimumReleaseAge": "7 days"
-    },
-    {
-      "description": "Automerge npm updates for backend-external",
-      "matchManagers": [
-        "npm"
-      ],
-      "matchFileNames": [
-        "backend-external/**"
-      ],
-      "automerge": true,
-      "automergeType": "pr",
-      "labels": [
-        "automerge",
-        "npm-updates",
-        "backend-external"
-      ],
-      "minimumReleaseAge": "7 days"
-    },
-    {
-      "description": "Automerge npm updates for doc-gen-service",
-      "matchManagers": [
-        "npm"
-      ],
-      "matchFileNames": [
+        "backend/**",
+        "backend-external/**",
+        "frontend/**",
+        "admin-frontend/**",
         "doc-gen-service/**"
       ],
       "automerge": true,
+      "platformAutomerge": true,
       "automergeType": "pr",
-      "labels": [
-        "automerge",
-        "npm-updates",
-        "doc-gen-service"
-      ],
-      "minimumReleaseAge": "7 days"
+      "labels": ["automerge", "npm-updates"],
+      "minimumReleaseAge": "7 days"     
     }
   ],
   "lockFileMaintenance": {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description

This would allow all Renovate and Dependabot PRs to be merged automatically if CI check gates pass. The changes would be deployed to TEST and PROD environments automatically

## Type of change

Please delete options that are not relevant.

- [x] CI/CD changes

## Jira Ticket:
https://fincsp.atlassian.net/browse/GEO-1350

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://pay-transparency-pr-1082-frontend.apps.silver.devops.gov.bc.ca)
- [Admin Frontend](https://pay-transparency-pr-1082-admin-frontend.apps.silver.devops.gov.bc.ca)
- [Backend external API console](https://pay-transparency-pr-1082-backend-external.apps.silver.devops.gov.bc.ca/api/V1/docs)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/fin-pay-transparency/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/fin-pay-transparency/actions/workflows/merge.yml)