### PR TITLE
chore: remove pr auto merge

### DIFF
--- a/.github/workflows/auto-approve-deps-update.yaml
+++ b/.github/workflows/auto-approve-deps-update.yaml
@@ -68,10 +68,3 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           labels: auto-approved
           number: ${{ steps.file-check.outputs.prNumber }}
-
-      - name: Enable auto-merge
-        if: steps.file-check.outputs.approved == 'true' && ( github.actor == 'dependabot[bot]' || github.actor == 'renovate[bot]' )
-        uses: peter-evans/enable-pull-request-automerge@v3
-        with:
-          pull-request-number: ${{ steps.file-check.outputs.prNumber }}
-          merge-method: squash

--- a/.github/workflows/auto-approve-deps-update.yaml
+++ b/.github/workflows/auto-approve-deps-update.yaml
@@ -9,7 +9,7 @@ on:
 jobs:
   auto-approve:
     if: >
-      (github.actor == 'renovate[bot]' || github.actor == 'dependabot[bot]' || github.event_name == 'workflow_dispatch') &&
+      (github.actor == 'renovate[bot]' || github.actor == 'dependabot[bot]') &&
       github.event.workflow_run.conclusion == 'success' &&
       vars.PR_AUTO_APPROVAL_ENABLED == 'true'
     runs-on: ubuntu-latest

--- a/.github/workflows/auto-approve-deps-update.yaml
+++ b/.github/workflows/auto-approve-deps-update.yaml
@@ -8,7 +8,10 @@ on:
 
 jobs:
   auto-approve:
-    if: (github.actor == 'renovate[bot]' || github.actor == 'dependabot[bot]' || github.event_name == 'workflow_dispatch') && vars.PR_AUTO_APPROVAL_ENABLED == 'true'
+    if: >
+      (github.actor == 'renovate[bot]' || github.actor == 'dependabot[bot]' || github.event_name == 'workflow_dispatch') &&
+      github.event.workflow_run.conclusion == 'success' &&
+      vars.PR_AUTO_APPROVAL_ENABLED == 'true'
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -90,7 +90,7 @@
         "typescript": "5.9.3",
         "typescript-eslint": "^8.56.1",
         "vitest": "^4.0.18",
-        "vitest-mock-extended": "^3.1.0"
+        "vitest-mock-extended": "^4.0.0"
       }
     },
     "node_modules/@aws-crypto/crc32": {
@@ -10694,17 +10694,17 @@
       }
     },
     "node_modules/vitest-mock-extended": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/vitest-mock-extended/-/vitest-mock-extended-3.1.0.tgz",
-      "integrity": "sha512-vCM0VkuocOUBwwqwV7JB7YStw07pqeKvEIrZnR8l3PtwYi6rAAJAyJACeC1UYNfbQWi85nz7EdiXWBFI5hll2g==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/vitest-mock-extended/-/vitest-mock-extended-4.0.0.tgz",
+      "integrity": "sha512-m2FmH8JYfxzZoLsHuhXRY+Pv++a3zd91HYpSz81tpRLEHbtFkEL2QcWvJowucWuNTirzQURKfWbJJSXbYqkTsA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "ts-essentials": ">=10.0.0"
       },
       "peerDependencies": {
-        "typescript": "3.x || 4.x || 5.x",
-        "vitest": ">=3.0.0"
+        "typescript": "3.x || 4.x || 5.x || 6.x",
+        "vitest": ">=4.0.0"
       }
     },
     "node_modules/vitest/node_modules/es-module-lexer": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -86,7 +86,7 @@
     "typescript": "5.9.3",
     "typescript-eslint": "^8.56.1",
     "vitest": "^4.0.18",
-    "vitest-mock-extended": "^3.1.0"
+    "vitest-mock-extended": "^4.0.0"
   },
   "overrides": {
     "@prisma/dev": {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description
Dependency update automation for Renovate and Dependabot PRs

## Type of change
- [x] CI/CD automation

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://pay-transparency-pr-1085-frontend.apps.silver.devops.gov.bc.ca)
- [Admin Frontend](https://pay-transparency-pr-1085-admin-frontend.apps.silver.devops.gov.bc.ca)
- [Backend external API console](https://pay-transparency-pr-1085-backend-external.apps.silver.devops.gov.bc.ca/api/V1/docs)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/fin-pay-transparency/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/fin-pay-transparency/actions/workflows/merge.yml)