### PR TITLE
fix: update validation error messages

### DIFF
--- a/backend/src/v1/services/error-service.spec.ts
+++ b/backend/src/v1/services/error-service.spec.ts
@@ -38,8 +38,8 @@ const mockValidationError = new ValidationError(
   //rowErrors
   [
     new RowError(13, [
-      'Hours Worked must not contain data when Special Salary contains data.',
-      'Ordinary Pay must not be blank or 0 when Hours Worked contains data.',
+      'Ordinary Pay and Hours Worked must contain data.',
+      'Special Salary must not contain data when Hours Worked or Ordinary Pay contains data.',
     ]),
     new RowError(1142, [
       "Invalid Gender Code 'D' (expected one of: M, W, F, X, U).",
@@ -52,8 +52,8 @@ const mockValidationError = new ValidationError(
 const mockArray = [
   'Minimum allowed start date is 2024.',
   'Start date and end date must always be 12 months apart.',
-  'Hours Worked must not contain data when Special Salary contains data.',
-  'Ordinary Pay must not be blank or 0 when Hours Worked contains data.',
+  'Ordinary Pay and Hours Worked must contain data.',
+  'Special Salary must not contain data when Hours Worked or Ordinary Pay contains data.',
   "Invalid Gender Code 'D' (expected one of: M, W, F, X, U).",
   'Something went wrong.',
 ];

--- a/backend/src/v1/services/validate-service.spec.ts
+++ b/backend/src/v1/services/validate-service.spec.ts
@@ -505,6 +505,59 @@ describe('validate-service', () => {
       });
     });
 
+    describe(`given an record that specifies ${SUBMISSION_ROW_COLUMNS.HOURS_WORKED} and ${SUBMISSION_ROW_COLUMNS.SPECIAL_SALARY} but not ${SUBMISSION_ROW_COLUMNS.ORDINARY_PAY}`, () => {
+      it('returns a RowError', () => {
+        const overrides = {};
+        overrides[SUBMISSION_ROW_COLUMNS.HOURS_WORKED] = VALID_HOUR_AMOUNTS[0];
+        overrides[SUBMISSION_ROW_COLUMNS.SPECIAL_SALARY] =
+          VALID_DOLLAR_AMOUNTS[0];
+        overrides[SUBMISSION_ROW_COLUMNS.ORDINARY_PAY] = NO_DATA_VALUES[0];
+        const invalidRecord = createSampleRecord(overrides);
+
+        const recordNum = 1;
+        const result: RowError | null = validateService.validateRecord(
+          recordNum,
+          invalidRecord,
+        );
+
+        expect(result).not.toBeNull();
+        console.log(result);
+        expect(
+          doesAnyRowErrorContainAll(result, [
+            SUBMISSION_ROW_COLUMNS.HOURS_WORKED,
+            SUBMISSION_ROW_COLUMNS.ORDINARY_PAY,
+            SUBMISSION_ROW_COLUMNS.SPECIAL_SALARY,
+          ]),
+        ).toBeTruthy();
+      });
+    });
+
+    describe(`given an record that specifies both ${SUBMISSION_ROW_COLUMNS.ORDINARY_PAY} and ${SUBMISSION_ROW_COLUMNS.SPECIAL_SALARY}`, () => {
+      it('returns a RowError', () => {
+        const overrides = {};
+        overrides[SUBMISSION_ROW_COLUMNS.ORDINARY_PAY] =
+          VALID_DOLLAR_AMOUNTS[0];
+        overrides[SUBMISSION_ROW_COLUMNS.SPECIAL_SALARY] =
+          VALID_DOLLAR_AMOUNTS[0];
+        const invalidRecord = createSampleRecord(overrides);
+
+        const recordNum = 1;
+        const result: RowError | null = validateService.validateRecord(
+          recordNum,
+          invalidRecord,
+        );
+
+        //expect one line error that mentions both SUBMISSION_ROW_COLUMNS.ORDINARY_PAY and SUBMISSION_ROW_COLUMNS.SPECIAL_SALARY
+        expect(result).not.toBeNull();
+        expect(
+          doesAnyRowErrorContainAll(result, [
+            SUBMISSION_ROW_COLUMNS.ORDINARY_PAY,
+            SUBMISSION_ROW_COLUMNS.SPECIAL_SALARY,
+          ]),
+        ).toBeTruthy();
+      });
+    });
+
     describe(`given an record that specifies ${SUBMISSION_ROW_COLUMNS.HOURS_WORKED} but not ${SUBMISSION_ROW_COLUMNS.ORDINARY_PAY}`, () => {
       it('returns a RowError', () => {
         const overrides = {};
@@ -533,8 +586,86 @@ describe('validate-service', () => {
       it('returns a RowError', () => {
         const overrides = {};
         overrides[SUBMISSION_ROW_COLUMNS.HOURS_WORKED] = NO_DATA_VALUES[0];
-        overrides[SUBMISSION_ROW_COLUMNS.ORDINARY_PAY] = 35;
+        overrides[SUBMISSION_ROW_COLUMNS.ORDINARY_PAY] =
+          VALID_DOLLAR_AMOUNTS[0];
         overrides[SUBMISSION_ROW_COLUMNS.SPECIAL_SALARY] = NO_DATA_VALUES[0];
+        const invalidRecord = createSampleRecord(overrides);
+
+        const recordNum = 1;
+        const result: RowError | null = validateService.validateRecord(
+          recordNum,
+          invalidRecord,
+        );
+
+        //expect one line error that mentions both SUBMISSION_ROW_COLUMNS.HOURS_WORKED and SUBMISSION_ROW_COLUMNS.ORDINARY_PAY
+        expect(result).not.toBeNull();
+        expect(
+          doesAnyRowErrorContainAll(result, [
+            SUBMISSION_ROW_COLUMNS.HOURS_WORKED,
+            SUBMISSION_ROW_COLUMNS.ORDINARY_PAY,
+          ]),
+        ).toBeTruthy();
+      });
+    });
+
+    describe(`given an record that specifies ${SUBMISSION_ROW_COLUMNS.ORDINARY_PAY} and ${SUBMISSION_ROW_COLUMNS.SPECIAL_SALARY} but not ${SUBMISSION_ROW_COLUMNS.HOURS_WORKED}`, () => {
+      it('returns a RowError', () => {
+        const overrides = {};
+        overrides[SUBMISSION_ROW_COLUMNS.HOURS_WORKED] = NO_DATA_VALUES[0];
+        overrides[SUBMISSION_ROW_COLUMNS.ORDINARY_PAY] = 35;
+        overrides[SUBMISSION_ROW_COLUMNS.SPECIAL_SALARY] =
+          VALID_DOLLAR_AMOUNTS[0];
+        const invalidRecord = createSampleRecord(overrides);
+
+        const recordNum = 1;
+        const result: RowError | null = validateService.validateRecord(
+          recordNum,
+          invalidRecord,
+        );
+
+        expect(result).not.toBeNull();
+        expect(
+          doesAnyRowErrorContainAll(result, [
+            SUBMISSION_ROW_COLUMNS.HOURS_WORKED,
+            SUBMISSION_ROW_COLUMNS.SPECIAL_SALARY,
+            SUBMISSION_ROW_COLUMNS.ORDINARY_PAY,
+          ]),
+        ).toBeTruthy();
+      });
+    });
+
+    describe(`given an record that specifies ${SUBMISSION_ROW_COLUMNS.HOURS_WORKED} but not ${SUBMISSION_ROW_COLUMNS.ORDINARY_PAY} and ${SUBMISSION_ROW_COLUMNS.SPECIAL_SALARY}`, () => {
+      it('returns a RowError', () => {
+        const overrides = {};
+        overrides[SUBMISSION_ROW_COLUMNS.HOURS_WORKED] = 20;
+        overrides[SUBMISSION_ROW_COLUMNS.ORDINARY_PAY] = NO_DATA_VALUES[0];
+        overrides[SUBMISSION_ROW_COLUMNS.SPECIAL_SALARY] = NO_DATA_VALUES[0];
+        const invalidRecord = createSampleRecord(overrides);
+
+        const recordNum = 1;
+        const result: RowError | null = validateService.validateRecord(
+          recordNum,
+          invalidRecord,
+        );
+
+        //expect one line error that mentions both SUBMISSION_ROW_COLUMNS.HOURS_WORKED and SUBMISSION_ROW_COLUMNS.ORDINARY_PAY
+        expect(
+          doesAnyRowErrorContainAll(result, [
+            SUBMISSION_ROW_COLUMNS.HOURS_WORKED,
+            SUBMISSION_ROW_COLUMNS.ORDINARY_PAY,
+          ]),
+        ).toBeTruthy();
+      });
+    });
+
+    describe(`given an record that specifies ${SUBMISSION_ROW_COLUMNS.HOURS_WORKED}, ${SUBMISSION_ROW_COLUMNS.ORDINARY_PAY} and ${SUBMISSION_ROW_COLUMNS.SPECIAL_SALARY}`, () => {
+      it('returns a RowError', () => {
+        const overrides = {};
+        overrides[SUBMISSION_ROW_COLUMNS.HOURS_WORKED] = 20;
+        overrides[SUBMISSION_ROW_COLUMNS.ORDINARY_PAY] =
+          VALID_DOLLAR_AMOUNTS[0];
+        overrides[SUBMISSION_ROW_COLUMNS.SPECIAL_SALARY] =
+          VALID_DOLLAR_AMOUNTS[0];
         const invalidRecord = createSampleRecord(overrides);
 
         const recordNum = 1;
@@ -574,7 +705,6 @@ describe('validate-service', () => {
           doesAnyRowErrorContainAll(result, [
             SUBMISSION_ROW_COLUMNS.HOURS_WORKED,
             SUBMISSION_ROW_COLUMNS.ORDINARY_PAY,
-            SUBMISSION_ROW_COLUMNS.SPECIAL_SALARY,
           ]),
         ).toBeTruthy();
       });

--- a/backend/src/v1/services/validate-service.ts
+++ b/backend/src/v1/services/validate-service.ts
@@ -270,19 +270,11 @@ const validateService = {
       );
     }
     if (
-      !this.isZeroSynonym(hoursWorked) &&
-      !this.isZeroSynonym(specialSalary)
+      !this.isZeroSynonym(specialSalary) &&
+      (!this.isZeroSynonym(hoursWorked) || !this.isZeroSynonym(ordinaryPay))
     ) {
       errorMessages.push(
-        `${SUBMISSION_ROW_COLUMNS.HOURS_WORKED} must not contain data when ${SUBMISSION_ROW_COLUMNS.SPECIAL_SALARY} contains data.`,
-      );
-    }
-    if (
-      !this.isZeroSynonym(ordinaryPay) &&
-      !this.isZeroSynonym(specialSalary)
-    ) {
-      errorMessages.push(
-        `${SUBMISSION_ROW_COLUMNS.ORDINARY_PAY} must not contain data when ${SUBMISSION_ROW_COLUMNS.SPECIAL_SALARY} contains data.`,
+        `${SUBMISSION_ROW_COLUMNS.SPECIAL_SALARY} must not contain data when ${SUBMISSION_ROW_COLUMNS.HOURS_WORKED} or ${SUBMISSION_ROW_COLUMNS.ORDINARY_PAY} contains data.`,
       );
     }
     if (
@@ -291,7 +283,7 @@ const validateService = {
       this.isZeroSynonym(specialSalary)
     ) {
       errorMessages.push(
-        `${SUBMISSION_ROW_COLUMNS.SPECIAL_SALARY} must contain data when ${SUBMISSION_ROW_COLUMNS.HOURS_WORKED} and ${SUBMISSION_ROW_COLUMNS.ORDINARY_PAY} do not contain data.`,
+        `${SUBMISSION_ROW_COLUMNS.ORDINARY_PAY} and ${SUBMISSION_ROW_COLUMNS.HOURS_WORKED} must contain data.`,
       );
     }
     if (this.isZeroSynonym(hoursWorked) && !this.isZeroSynonym(ordinaryPay)) {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description
## Update error messages from backend validation service:
**Current error message**: Special Salary must contain data when Hours Worked and Ordinary Pay do not contain data.
**Replace with**: Ordinary Pay and Hours Worked must contain data.

**Current error message**: Hours Worked must not contain data when Special Salary contains data. Ordinary Pay must not contain data when Special Salary contains data.
**Replace with**: Special Salary must not contain data when Hours Worked or Ordinary Pay contains data.

Fixes # (issue)
https://fincsp.atlassian.net/browse/GEO-1363

# How Has This Been Tested?
Unit testing changes for Backend validation service

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://pay-transparency-pr-1109-frontend.apps.silver.devops.gov.bc.ca)
- [Admin Frontend](https://pay-transparency-pr-1109-admin-frontend.apps.silver.devops.gov.bc.ca)
- [Backend external API console](https://pay-transparency-pr-1109-backend-external.apps.silver.devops.gov.bc.ca/api/V1/docs)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/fin-pay-transparency/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/fin-pay-transparency/actions/workflows/merge.yml)