### PR TITLE
fix(ci): update concurrency group

### DIFF
--- a/.github/workflows/.e2e-admin.yml
+++ b/.github/workflows/.e2e-admin.yml
@@ -73,9 +73,8 @@ jobs:
         run: |
           npm ci
 
-      - name: Update apt packages and install Playwright
+      - name: Install Playwright
         run: |
-          sudo apt-get update
           npx --no-install playwright install --with-deps
 
       - name: Run Tests

--- a/.github/workflows/.e2e-admin.yml
+++ b/.github/workflows/.e2e-admin.yml
@@ -22,7 +22,7 @@ on:
         type: string
       timeout-minutes:
         description: "Timeout minutes"
-        default: 8
+        default: 12
         required: false
         type: number
   workflow_call:

--- a/.github/workflows/.e2e-visual.yml
+++ b/.github/workflows/.e2e-visual.yml
@@ -71,9 +71,8 @@ jobs:
         run: |
           npm ci
 
-      - name: Update apt packages and install Playwright
+      - name: Install Playwright
         run: |
-          sudo apt-get update
           npx --no-install playwright install --with-deps          
 
       - name: Create blob reports directory

--- a/.github/workflows/.e2e.yml
+++ b/.github/workflows/.e2e.yml
@@ -71,9 +71,8 @@ jobs:
         run: |
           npm ci
 
-      - name: Update apt packages and install Playwright
+      - name: Install Playwright
         run: |
-          sudo apt-get update
           npx --no-install playwright install --with-deps
 
       - name: Create blob reports directory

--- a/.github/workflows/ci_cd_on_pr_dev_sandbox.yml
+++ b/.github/workflows/ci_cd_on_pr_dev_sandbox.yml
@@ -18,8 +18,8 @@ on:
 
 concurrency:
   # PR open and close use the same group, allowing only one at a time
-  group: pr-${{ github.workflow }}-${{ github.event.number }}
-  cancel-in-progress: true
+  group: pr-${{ github.event.number }}
+  cancel-in-progress: false
 
 jobs:
   builds:

--- a/.github/workflows/ci_cd_on_pr_hotfix.yml
+++ b/.github/workflows/ci_cd_on_pr_hotfix.yml
@@ -19,7 +19,7 @@ on:
 concurrency:
   # PR open and close use the same group, allowing only one at a time
   group: pr-${{ github.event.number }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 jobs:
   validate:
     if:  startsWith(github.head_ref, 'hotfix/') && (!github.event.pull_request.head.repo.fork)

--- a/.github/workflows/ci_cd_on_pr_hotfix.yml
+++ b/.github/workflows/ci_cd_on_pr_hotfix.yml
@@ -18,7 +18,7 @@ on:
 
 concurrency:
   # PR open and close use the same group, allowing only one at a time
-  group: pr-${{ github.workflow }}-${{ github.event.number }}
+  group: pr-${{ github.event.number }}
   cancel-in-progress: true
 jobs:
   validate:

--- a/.github/workflows/cleanup-on-pr-close.yml
+++ b/.github/workflows/cleanup-on-pr-close.yml
@@ -21,8 +21,8 @@ on:
 
 concurrency:
   # PR open and close use the same group, allowing only one at a time
-  group: pr-${{ github.workflow }}-${{ github.event.number }}
-  cancel-in-progress: true
+  group: pr-${{ github.event.number }}
+  cancel-in-progress: false
 
 jobs:
   # Clean up OpenShift when PR closed, no conditions

--- a/.github/workflows/cleanup_tag_hotfix-pr-close.yml
+++ b/.github/workflows/cleanup_tag_hotfix-pr-close.yml
@@ -22,7 +22,7 @@ on:
 concurrency:
   # PR open and close use the same group, allowing only one at a time
   group: pr-${{ github.event.number }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   # Clean up OpenShift when PR closed, no conditions

--- a/.github/workflows/cleanup_tag_hotfix-pr-close.yml
+++ b/.github/workflows/cleanup_tag_hotfix-pr-close.yml
@@ -21,7 +21,7 @@ on:
 
 concurrency:
   # PR open and close use the same group, allowing only one at a time
-  group: pr-${{ github.workflow }}-${{ github.event.number }}
+  group: pr-${{ github.event.number }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description
Closing a PR sometimes leaves the Helm chart still installed

Fixes # (issue)
https://fincsp.atlassian.net/browse/GEO-1353 
## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
This will be tested by creating a PR and then closing the PR before the deployment for the PR has completed in sandboxed DEV environment.

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://pay-transparency-pr-1111-frontend.apps.silver.devops.gov.bc.ca)
- [Admin Frontend](https://pay-transparency-pr-1111-admin-frontend.apps.silver.devops.gov.bc.ca)
- [Backend external API console](https://pay-transparency-pr-1111-backend-external.apps.silver.devops.gov.bc.ca/api/V1/docs)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/fin-pay-transparency/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/fin-pay-transparency/actions/workflows/merge.yml)