### PR TITLE
chore: update Node version from 22 to 24

### DIFF
--- a/admin-frontend/Dockerfile
+++ b/admin-frontend/Dockerfile
@@ -1,5 +1,5 @@
 # Build static files
-FROM node:22-alpine AS build
+FROM node:24-alpine AS build
 WORKDIR /app
 COPY . .
 RUN npm ci --ignore-scripts && \

--- a/backend-external/Dockerfile
+++ b/backend-external/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22-bullseye-slim AS build
+FROM node:24-bullseye-slim AS build
 
 # Install packages, build and keep only prod packages
 WORKDIR /app
@@ -8,7 +8,7 @@ RUN npm ci --ignore-scripts && \
     npm run build
 
 
-FROM node:22-bullseye-slim AS dependencies
+FROM node:24-bullseye-slim AS dependencies
 
 # Install packages, build and keep only prod packages
 WORKDIR /app

--- a/backend-external/Dockerfile
+++ b/backend-external/Dockerfile
@@ -17,7 +17,7 @@ RUN npm ci --omit=dev --ignore-scripts
 
 
 # Deployment container
-FROM gcr.io/distroless/nodejs22-debian12:nonroot
+FROM gcr.io/distroless/nodejs24-debian12:nonroot
 ENV NODE_ENV=production
 # Copy over app.ts
 WORKDIR /app

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22-bullseye-slim AS build
+FROM node:24-bullseye-slim AS build
 
 # Install packages, build and keep only prod packages
 WORKDIR /app
@@ -9,7 +9,7 @@ RUN npm ci --ignore-scripts && \
 
 RUN mkdir -p /app/sessions
 
-FROM node:22-bullseye-slim AS dependencies
+FROM node:24-bullseye-slim AS dependencies
 
 # Install packages, build and keep only prod packages
 WORKDIR /app

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -18,7 +18,7 @@ RUN npm ci --omit=dev --ignore-scripts
 
 
 # Deployment container
-FROM gcr.io/distroless/nodejs22-debian12:nonroot
+FROM gcr.io/distroless/nodejs24-debian12:nonroot
 ENV NODE_ENV=production
 # Copy over app.ts
 WORKDIR /app

--- a/clamav-service/Dockerfile
+++ b/clamav-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22-bullseye-slim AS build
+FROM node:24-bullseye-slim AS build
 
 # Install packages, build and keep only prod packages
 WORKDIR /app
@@ -8,7 +8,7 @@ RUN npm ci --ignore-scripts && \
     npm run build
 
 
-FROM node:22-bullseye-slim AS dependencies
+FROM node:24-bullseye-slim AS dependencies
 
 # Install packages, build and keep only prod packages
 WORKDIR /app

--- a/clamav-service/Dockerfile
+++ b/clamav-service/Dockerfile
@@ -17,7 +17,7 @@ RUN npm ci --omit=dev --ignore-scripts
 
 
 # Deployment container
-FROM gcr.io/distroless/nodejs22-debian12:nonroot
+FROM gcr.io/distroless/nodejs24-debian12:nonroot
 ENV NODE_ENV=production
 # Copy over app.ts
 WORKDIR /app

--- a/doc-gen-service/Dockerfile
+++ b/doc-gen-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22-slim
+FROM node:24-slim
 
 WORKDIR /app
 

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,5 +1,5 @@
 # Build static files
-FROM node:22-alpine AS build
+FROM node:24-alpine AS build
 WORKDIR /app
 COPY . .
 RUN npm ci --ignore-scripts && \


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description
Bump NodeJS version for all services from 22 to 24 

Fixes # (issue)
https://fincsp.atlassian.net/browse/GEO-1369

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://pay-transparency-pr-1122-frontend.apps.silver.devops.gov.bc.ca)
- [Admin Frontend](https://pay-transparency-pr-1122-admin-frontend.apps.silver.devops.gov.bc.ca)
- [Backend external API console](https://pay-transparency-pr-1122-backend-external.apps.silver.devops.gov.bc.ca/api/V1/docs)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/fin-pay-transparency/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/fin-pay-transparency/actions/workflows/merge.yml)